### PR TITLE
Make it possible to publish packages under dotkomonline on NPM

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "scripts": {
     "dev": "vite",
     "build:prod": "tsc && vite build",

--- a/apps/ow-api/.eslintrc
+++ b/apps/ow-api/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "@dotkom/eslint-config-ow"
+  "extends": "@dotkomonline/eslint-config-ow"
 }

--- a/apps/ow-api/package.json
+++ b/apps/ow-api/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "exports": "./dist/index.js",
   "type": "module",
+  "private": true,
   "scripts": {
     "dev": "NODE_ENV=development run -T nodemon --watch './src/**.{ts}' --watch './config/**.{ts,json}' --exec 'node --loader ts-node/esm --experimental-specifier-resolution=node src/index.ts'",
     "watch": "tsc-watch --project tsconfig.json --onSuccess \"yarn dev\"",

--- a/apps/ow-api/package.json
+++ b/apps/ow-api/package.json
@@ -15,8 +15,8 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@dotkom/db": "workspace:^",
-    "@dotkom/logger": "workspace:^",
+    "@dotkomonline/db": "workspace:^",
+    "@dotkomonline/logger": "workspace:^",
     "@trpc/server": "^10.0.0-alpha.48",
     "@types/aws-lambda": "^8.10.101",
     "config": "^3.3.7",
@@ -25,7 +25,7 @@
     "zod": "^3.17.10"
   },
   "devDependencies": {
-    "@dotkom/eslint-config-ow": "workspace:*",
+    "@dotkomonline/eslint-config-ow": "workspace:*",
     "@types/config": "^3.3.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.14",

--- a/apps/ow-api/src/index.ts
+++ b/apps/ow-api/src/index.ts
@@ -1,5 +1,5 @@
-import { getLogger } from "@dotkom/logger"
-import { PrismaClient } from "@dotkom/db"
+import { getLogger } from "@dotkomonline/logger"
+import { PrismaClient } from "@dotkomonline/db"
 import { initUserRepository } from "./modules/auth/user-repository.js"
 import { initUserService } from "./modules/auth/user-service.js"
 import { createServer } from "./server.js"

--- a/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
+++ b/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
@@ -3,7 +3,7 @@ import { initUserService } from "../user-service"
 import { v4 as uuidv4 } from "uuid"
 import { initUserRepository } from "../user-repository"
 import { NotFoundError } from "../../../errors/errors"
-import { PrismaClient } from "@dotkom/db"
+import { PrismaClient } from "@dotkomonline/db"
 
 describe("UserService", () => {
   const prisma = vi.mocked(PrismaClient.prototype, true)

--- a/apps/ow-api/src/modules/auth/user-repository.ts
+++ b/apps/ow-api/src/modules/auth/user-repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@dotkom/db"
+import { PrismaClient } from "@dotkomonline/db"
 import { InsertUser, mapToUser, User } from "./user"
 
 export interface UserRepository {

--- a/apps/ow-api/src/modules/auth/user.ts
+++ b/apps/ow-api/src/modules/auth/user.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { User as PrismaUser } from "@dotkom/db"
+import { User as PrismaUser } from "@dotkomonline/db"
 
 const userSchema = z.object({
   id: z.string().uuid(),

--- a/apps/ow-api/src/modules/company/__test__/company-service.spec.ts
+++ b/apps/ow-api/src/modules/company/__test__/company-service.spec.ts
@@ -3,7 +3,7 @@ import { initCompanyService } from "../company-service"
 import { v4 as uuidv4 } from "uuid"
 import { initCompanyRepository } from "../company-repository"
 import { NotFoundError } from "../../../errors/errors"
-import { PrismaClient } from "@dotkom/db"
+import { PrismaClient } from "@dotkomonline/db"
 
 describe("CompanyService", () => {
   const prisma = vi.mocked(PrismaClient.prototype, true)

--- a/apps/ow-api/src/modules/company/company-repository.ts
+++ b/apps/ow-api/src/modules/company/company-repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@dotkom/db"
+import { PrismaClient } from "@dotkomonline/db"
 import { InsertCompany, mapToCompany, Company } from "./company"
 
 export interface CompanyRepository {

--- a/apps/ow-api/src/modules/company/company.ts
+++ b/apps/ow-api/src/modules/company/company.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { Company as PrismaCompany } from "@dotkom/db"
+import { Company as PrismaCompany } from "@dotkomonline/db"
 
 const companySchema = z.object({
   id: z.string().uuid(),

--- a/apps/web/.eslintrc
+++ b/apps/web/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["@dotkom/eslint-config-ow", "next/core-web-vitals"],
+  "extends": ["@dotkomonline/eslint-config-ow", "next/core-web-vitals"],
   "settings": {
     "react": {
       "version": "detect"

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const withTM = require("next-transpile-modules")(["@dotkom/ui"])
+const withTM = require("next-transpile-modules")(["@dotkomonline/ui"])
 
 /**
  * @type {import('next').NextConfig}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@dotkom/ui": "workspace:^",
+    "@dotkomonline/ui": "workspace:^",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-avatar": "^1.0.0",
     "@radix-ui/react-checkbox": "^1.0.0",
@@ -39,7 +39,7 @@
     "swr": "^1.3.0"
   },
   "devDependencies": {
-    "@dotkom/eslint-config-ow": "workspace:*",
+    "@dotkomonline/eslint-config-ow": "workspace:*",
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-essentials": "^6.5.9",
     "@storybook/addon-knobs": "^6.4.0",

--- a/apps/web/src/components/atoms/Circle/Circle.tsx
+++ b/apps/web/src/components/atoms/Circle/Circle.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@components/primitives"
-import { CSS } from "@dotkom/ui"
+import { CSS } from "@dotkomonline/ui"
 
 const circleStyle: CSS = {
   color: "$white",

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 import { FC, PropsWithChildren } from "react"
 import Navbar from "../organisms/Navbar"
 

--- a/apps/web/src/components/molecules/ComingEvent/ComingEvent.tsx
+++ b/apps/web/src/components/molecules/ComingEvent/ComingEvent.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Badge, Text } from "@dotkom/ui"
+import { Badge, Text } from "@dotkomonline/ui"
 import { css } from "@stitches/react"
 import Image from "next/image"
 

--- a/apps/web/src/components/molecules/CompanyAdListItem/CompanyAdListItem.tsx
+++ b/apps/web/src/components/molecules/CompanyAdListItem/CompanyAdListItem.tsx
@@ -3,7 +3,7 @@ import { CSS } from "@dotkom/ui"
 import { DateTime } from "luxon"
 import { FC } from "react"
 import Image from "next/image"
-import { Badge, Text } from "@dotkom/ui"
+import { Badge, Text } from "@dotkomonline/ui"
 
 interface CompanyAdListItemProps {
   name: string

--- a/apps/web/src/components/molecules/CompanyAdListItem/CompanyAdListItem.tsx
+++ b/apps/web/src/components/molecules/CompanyAdListItem/CompanyAdListItem.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@components/primitives"
-import { CSS } from "@dotkom/ui"
+import { CSS } from "@dotkomonline/ui"
 import { DateTime } from "luxon"
 import { FC } from "react"
 import Image from "next/image"

--- a/apps/web/src/components/molecules/ConnectedCircles.tsx
+++ b/apps/web/src/components/molecules/ConnectedCircles.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@components/primitives"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 import { Circle } from "../atoms/Circle/Circle"
 import { DottedLine } from "../atoms/DottedCurve"
 

--- a/apps/web/src/components/molecules/EventCard/EventCard.tsx
+++ b/apps/web/src/components/molecules/EventCard/EventCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from "@dotkom/ui"
+import { Card, Text } from "@dotkomonline/ui"
 import { FC } from "react"
 import Image from "next/image"
 import { CSS, css, styled } from "@dotkom/ui"

--- a/apps/web/src/components/molecules/EventCard/EventCard.tsx
+++ b/apps/web/src/components/molecules/EventCard/EventCard.tsx
@@ -1,7 +1,7 @@
 import { Card, Text } from "@dotkomonline/ui"
 import { FC } from "react"
 import Image from "next/image"
-import { CSS, css, styled } from "@dotkom/ui"
+import { CSS, css, styled } from "@dotkomonline/ui"
 import { Box, Flex } from "@components/primitives"
 import { DateTime } from "luxon"
 import { FiUsers, FiMapPin, FiClock } from "react-icons/fi"

--- a/apps/web/src/components/molecules/PortableText.tsx
+++ b/apps/web/src/components/molecules/PortableText.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable*/
 import BlockContent, { BlockContentProps } from "@sanity/block-content-to-react"
 import { FC } from "react"
-import { Text } from "@dotkom/ui"
+import { Text } from "@dotkomonline/ui"
 
 interface PortableTextProps {
   blocks: BlockContentProps["blocks"]

--- a/apps/web/src/components/organisms/Navbar/MobileDropdown.tsx
+++ b/apps/web/src/components/organisms/Navbar/MobileDropdown.tsx
@@ -3,7 +3,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import NavbarLogo from "./components/logo"
 import Content from "./components/mobile/Content"
 import ContentTrigger from "./components/mobile/ContentTrigger"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 

--- a/apps/web/src/components/organisms/Navbar/Navbar.tsx
+++ b/apps/web/src/components/organisms/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import DesktopNavigation from "@components/organisms/Navbar/DesktopNavigation"
 import MobileDropdown from "./MobileDropdown"
-import { styled, css } from "@dotkom/ui"
+import { styled, css } from "@dotkomonline/ui"
 import useWindow from "./useWindow"
 
 const Navbar = () => {

--- a/apps/web/src/components/organisms/Navbar/components/desktop/Content.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/desktop/Content.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@dotkom/ui"
+import { styled } from "@dotkomonline/ui"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { enterFromLeft, enterFromRight, exitToLeft, exitToRight } from "../../keyframes/keyframes"
 

--- a/apps/web/src/components/organisms/Navbar/components/desktop/ContentList.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/desktop/ContentList.tsx
@@ -1,4 +1,4 @@
-import { css, styled } from "@dotkom/ui"
+import { css, styled } from "@dotkomonline/ui"
 
 const styles = css({
   display: "grid",

--- a/apps/web/src/components/organisms/Navbar/components/desktop/ContentListItem.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/desktop/ContentListItem.tsx
@@ -1,5 +1,5 @@
 import { mauve, violet } from "@radix-ui/colors"
-import { css, styled } from "@dotkom/ui"
+import { css, styled } from "@dotkomonline/ui"
 import { FC } from "react"
 import { NavigationMenuLink } from "."
 import { DesktopProps } from "./DesktopProps"

--- a/apps/web/src/components/organisms/Navbar/components/desktop/DebugLink.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/desktop/DebugLink.tsx
@@ -1,5 +1,5 @@
 import { mauve } from "@radix-ui/colors"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 import { FiAlertTriangle } from "react-icons/fi"
 import { NavigationMenuLink } from "."
 import { LinkText, LinkTitle } from "./ContentListItem"

--- a/apps/web/src/components/organisms/Navbar/components/desktop/NavigationMenuViewport.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/desktop/NavigationMenuViewport.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@stitches/react"
 import { scaleIn, scaleOut } from "../../keyframes/keyframes"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const NavigationMenuViewport = () => (
   <div className={styles.wrapper()}>

--- a/apps/web/src/components/organisms/Navbar/components/logo/index.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/logo/index.tsx
@@ -1,5 +1,5 @@
 import OnlineIcon from "@components/atoms/OnlineIcon"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 import Link from "next/link"
 
 const NavbarLogo = () => {

--- a/apps/web/src/components/organisms/Navbar/components/mobile/Content.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/mobile/Content.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@stitches/react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { slideDownAndFade, slideLeftAndFade, slideRightAndFade, slideUpAndFade } from "../../keyframes/keyframes"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const Content = () => {
   return (

--- a/apps/web/src/components/organisms/Navbar/components/mobile/ContentTrigger.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/mobile/ContentTrigger.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { FiMenu } from "react-icons/fi"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const ContentTrigger = () => {
   return (

--- a/apps/web/src/components/organisms/Navbar/components/profile/AvatarImage.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/profile/AvatarImage.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@stitches/react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const AvatarImage = () => (
   <Avatar>

--- a/apps/web/src/components/organisms/Navbar/components/profile/DropdownItemContainer.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/profile/DropdownItemContainer.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@stitches/react"
 import { slideDownAndFade, slideLeftAndFade, slideRightAndFade, slideUpAndFade } from "../../keyframes/keyframes"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 const styles = {
   content: css({

--- a/apps/web/src/components/organisms/Navbar/components/profile/ProfileTrigger.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/profile/ProfileTrigger.tsx
@@ -1,6 +1,6 @@
 import AvatarImage from "./AvatarImage"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 

--- a/apps/web/src/components/organisms/Navbar/components/profile/index.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/profile/index.tsx
@@ -3,7 +3,7 @@ import { styled } from "@stitches/react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import DropdownItemsContainer from "./DropdownItemContainer"
 import ProfileTrigger from "./ProfileTrigger"
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 
 export const Profile = () => {
   return (

--- a/apps/web/src/components/primitives.ts
+++ b/apps/web/src/components/primitives.ts
@@ -1,4 +1,4 @@
-import { styled } from "@dotkom/ui"
+import { styled } from "@dotkomonline/ui"
 
 export const Box = styled("div")
 export const Flex = styled(Box, { display: "flex" })

--- a/apps/web/src/components/views/ArticleView.tsx
+++ b/apps/web/src/components/views/ArticleView.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex } from "../primitives"
 import { FC } from "react"
 import { Article } from "src/api/get-article"
-import { CSS, css, styled } from "@dotkom/ui"
+import { CSS, css, styled } from "@dotkomonline/ui"
 import PortableText from "@components/molecules/PortableText"
 import Image from "next/image"
 import { DateTime } from "luxon"

--- a/apps/web/src/components/views/ArticleView.tsx
+++ b/apps/web/src/components/views/ArticleView.tsx
@@ -5,7 +5,7 @@ import { CSS, css, styled } from "@dotkom/ui"
 import PortableText from "@components/molecules/PortableText"
 import Image from "next/image"
 import { DateTime } from "luxon"
-import { Badge, Text } from "@dotkom/ui"
+import { Badge, Text } from "@dotkomonline/ui"
 
 interface ArticleViewProps {
   article: Article

--- a/apps/web/src/components/views/CompanyView/CompanyInterestProcess.tsx
+++ b/apps/web/src/components/views/CompanyView/CompanyInterestProcess.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react"
 import Circle from "@components/atoms/Circle"
-import type { CSS } from "@dotkom/ui"
+import type { CSS } from "@dotkomonline/ui"
 import { Box } from "@components/primitives"
 interface CompanyInterestProcessProps {
   steps: string[]

--- a/apps/web/src/components/views/CompanyView/OurProducts.tsx
+++ b/apps/web/src/components/views/CompanyView/OurProducts.tsx
@@ -1,4 +1,4 @@
-import { css } from "@dotkom/ui"
+import { css } from "@dotkomonline/ui"
 import { Flex } from "@components/primitives"
 import BedpressIcon from "@components/icons/BedpressIcon"
 import ItexIcon from "@components/icons/ItexIcon"

--- a/apps/web/src/components/views/CompanyView/OurProducts.tsx
+++ b/apps/web/src/components/views/CompanyView/OurProducts.tsx
@@ -5,7 +5,7 @@ import ItexIcon from "@components/icons/ItexIcon"
 import OfflineIcon from "@components/icons/OfflineIcon"
 import UtlysningIcon from "@components/icons/UtlysningIcon"
 import TechtalksIcon from "@components/icons/TechtalksIcon"
-import { Text } from "@dotkom/ui"
+import { Text } from "@dotkomonline/ui"
 
 const OurProducts = () => {
   return (

--- a/apps/web/src/components/views/CompanyView/index.tsx
+++ b/apps/web/src/components/views/CompanyView/index.tsx
@@ -5,7 +5,7 @@ import { CSS, css, styled } from "@dotkom/ui"
 import { FC } from "react"
 import CompanyInterestProcess from "./CompanyInterestProcess"
 import OurProducts from "./OurProducts"
-import { Button } from "@dotkom/ui"
+import { Button } from "@dotkomonline/ui"
 
 export type Content = BlockContentProps["blocks"]
 

--- a/apps/web/src/components/views/CompanyView/index.tsx
+++ b/apps/web/src/components/views/CompanyView/index.tsx
@@ -1,7 +1,7 @@
 import PortableText from "@components/molecules/PortableText"
 import { Box } from "@components/primitives"
 import { BlockContentProps } from "@sanity/block-content-to-react"
-import { CSS, css, styled } from "@dotkom/ui"
+import { CSS, css, styled } from "@dotkomonline/ui"
 import { FC } from "react"
 import CompanyInterestProcess from "./CompanyInterestProcess"
 import OurProducts from "./OurProducts"

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { getCssText } from "@dotkom/ui"
+import { getCssText } from "@dotkomonline/ui"
 import NextDocument, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from "next/document"
 
 export default class Document extends NextDocument {

--- a/apps/web/src/pages/auth/login.tsx
+++ b/apps/web/src/pages/auth/login.tsx
@@ -1,5 +1,5 @@
 import OnlineIcon from "@/components/atoms/OnlineIcon"
-import { Button, css, Text, TextInput } from "@dotkom/ui"
+import { Button, css, Text, TextInput } from "@dotkomonline/ui"
 import { NextPageWithLayout } from "../_app"
 
 const Login: NextPageWithLayout = () => {

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button } from "@dotkom/ui"
+import { Button } from "@dotkomonline/ui"
 
 import { useSession, signIn, signOut } from "next-auth/react"
 

--- a/apps/web/src/theme/global-style.ts
+++ b/apps/web/src/theme/global-style.ts
@@ -1,4 +1,4 @@
-import { globalCss } from "@dotkom/ui"
+import { globalCss } from "@dotkomonline/ui"
 
 export const globalStyles = globalCss({
   html: {

--- a/apps/web/src/theme/stitches.config.ts
+++ b/apps/web/src/theme/stitches.config.ts
@@ -1,2 +1,2 @@
-import { createTheme } from "@dotkom/ui"
+import { createTheme } from "@dotkomonline/ui"
 export const onlineTheme = createTheme({})

--- a/packages/eslint-config-ow/package.json
+++ b/packages/eslint-config-ow/package.json
@@ -3,6 +3,7 @@
   "packageManager": "yarn@3.2.0",
   "version": "1.0.0",
   "main": "index.js",
+  "private": true,
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/packages/eslint-config-ow/package.json
+++ b/packages/eslint-config-ow/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dotkom/eslint-config-ow",
+  "name": "@dotkomonline/eslint-config-ow",
   "packageManager": "yarn@3.2.0",
   "version": "1.0.0",
   "main": "index.js",

--- a/packages/ow-db/package.json
+++ b/packages/ow-db/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "private": true,
   "scripts": {
     "build": "run generate && tsup src/index.ts --format esm --dts --clean --sourcemap",
     "migrate": "prisma migrate dev",

--- a/packages/ow-db/package.json
+++ b/packages/ow-db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dotkom/db",
+  "name": "@dotkomonline/db",
   "packageManager": "yarn@3.2.0",
   "version": "1.0.0",
   "type": "module",

--- a/packages/ow-logger/package.json
+++ b/packages/ow-logger/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dotkom/logger",
+  "name": "@dotkomonline/logger",
   "packageManager": "yarn@3.2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ow-logger/package.json
+++ b/packages/ow-logger/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "private": true,
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean --sourcemap",
     "lint": "run -T eslint --max-warnings 0 .",

--- a/packages/ow-ui/.npmignore
+++ b/packages/ow-ui/.npmignore
@@ -1,0 +1,2 @@
+.turbo
+src

--- a/packages/ow-ui/package.json
+++ b/packages/ow-ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "private": false,
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --target es2020 --clean --dts",
     "lint": "run -T eslint --max-warnings 0 .",

--- a/packages/ow-ui/package.json
+++ b/packages/ow-ui/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@dotkom/ui",
+  "name": "@dotkomonline/ui",
+  "version": "0.1.0-beta.0",
   "packageManager": "yarn@3.2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ow-ui/package.json
+++ b/packages/ow-ui/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "private": false,
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --target es2020 --clean --dts",
     "lint": "run -T eslint --max-warnings 0 .",

--- a/packages/ow-ui/tsconfig.json
+++ b/packages/ow-ui/tsconfig.json
@@ -5,5 +5,5 @@
     "declaration": true,
     "jsx": "react-jsx"
   },
-  "exclude": ["./src/config/utils.ts"]
+  "exclude": ["./src/config/utils.ts", "dist", ".turbo"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,9 +2447,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dotkom/db@workspace:^, @dotkom/db@workspace:packages/ow-db":
+"@dotkomonline/db@workspace:^, @dotkomonline/db@workspace:packages/ow-db":
   version: 0.0.0-use.local
-  resolution: "@dotkom/db@workspace:packages/ow-db"
+  resolution: "@dotkomonline/db@workspace:packages/ow-db"
   dependencies:
     "@prisma/client": ^4.1.1
     "@types/chance": ^1.1.3
@@ -2460,9 +2460,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dotkom/eslint-config-ow@workspace:*, @dotkom/eslint-config-ow@workspace:packages/eslint-config-ow":
+"@dotkomonline/eslint-config-ow@workspace:*, @dotkomonline/eslint-config-ow@workspace:packages/eslint-config-ow":
   version: 0.0.0-use.local
-  resolution: "@dotkom/eslint-config-ow@workspace:packages/eslint-config-ow"
+  resolution: "@dotkomonline/eslint-config-ow@workspace:packages/eslint-config-ow"
   dependencies:
     "@typescript-eslint/eslint-plugin": ^5.32.0
     "@typescript-eslint/parser": ^5.32.0
@@ -2472,18 +2472,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dotkom/logger@workspace:^, @dotkom/logger@workspace:packages/ow-logger":
+"@dotkomonline/logger@workspace:^, @dotkomonline/logger@workspace:packages/ow-logger":
   version: 0.0.0-use.local
-  resolution: "@dotkom/logger@workspace:packages/ow-logger"
+  resolution: "@dotkomonline/logger@workspace:packages/ow-logger"
   dependencies:
     tsup: ^6.2.3
     winston: ^3.8.2
   languageName: unknown
   linkType: soft
 
-"@dotkom/ui@workspace:^, @dotkom/ui@workspace:packages/ow-ui":
+"@dotkomonline/ui@workspace:^, @dotkomonline/ui@workspace:packages/ow-ui":
   version: 0.0.0-use.local
-  resolution: "@dotkom/ui@workspace:packages/ow-ui"
+  resolution: "@dotkomonline/ui@workspace:packages/ow-ui"
   dependencies:
     "@radix-ui/colors": ^0.1.8
     "@radix-ui/react-alert-dialog": ^1.0.0
@@ -7087,9 +7087,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api@workspace:apps/ow-api"
   dependencies:
-    "@dotkom/db": "workspace:^"
-    "@dotkom/eslint-config-ow": "workspace:*"
-    "@dotkom/logger": "workspace:^"
+    "@dotkomonline/db": "workspace:^"
+    "@dotkomonline/eslint-config-ow": "workspace:*"
+    "@dotkomonline/logger": "workspace:^"
     "@trpc/server": ^10.0.0-alpha.48
     "@types/aws-lambda": ^8.10.101
     "@types/config": ^3.3.0
@@ -22733,8 +22733,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web@workspace:apps/web"
   dependencies:
-    "@dotkom/eslint-config-ow": "workspace:*"
-    "@dotkom/ui": "workspace:^"
+    "@dotkomonline/eslint-config-ow": "workspace:*"
+    "@dotkomonline/ui": "workspace:^"
     "@radix-ui/colors": ^0.1.8
     "@radix-ui/react-avatar": ^1.0.0
     "@radix-ui/react-checkbox": ^1.0.0


### PR DESCRIPTION
Renames the package.json organization names from `@dotkom` to `@dotkomonline` to match our organization on npm.

Also explicitly marks all packages as private or not to prevent accidental publishing of apps/other packages