### PR TITLE
Fix type errors from backend and prisma

### DIFF
--- a/apps/ow-api/package.json
+++ b/apps/ow-api/package.json
@@ -11,6 +11,7 @@
     "seed": "node --loader ts-node/esm --experimental-specifier-resolution=node src/database/seed.ts",
     "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint --fix .",
+    "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage"

--- a/apps/ow-api/package.json
+++ b/apps/ow-api/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "build:prod": "tsup src --dts",
+    "build:prod": "tsup src",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage"

--- a/apps/ow-api/package.json
+++ b/apps/ow-api/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
+    "build:prod": "tsup src --dts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage"
@@ -39,6 +40,7 @@
     "@vitest/ui": "^0.23.4",
     "eslint": "^8.26.0",
     "express": "^4.18.1",
+    "tsup": "^6.4.0",
     "tsx": "^3.11.0",
     "vite-tsconfig-paths": "^3.5.2",
     "vitest": "^0.23.4"

--- a/apps/ow-api/src/context.ts
+++ b/apps/ow-api/src/context.ts
@@ -1,24 +1,21 @@
-import { PrismaClient } from "@dotkomonline/db"
-import { type Session } from "next-auth"
+import { prisma } from "@dotkomonline/db"
 
-import { type inferAsyncReturnType } from "@trpc/server"
+import type { inferAsyncReturnType } from "@trpc/server"
+import * as trpcExpress from "@trpc/server/adapters/express"
 
 import { initUserRepository } from "./modules/auth/user-repository"
 import { initUserService } from "./modules/auth/user-service"
 import { initEventRepository } from "./modules/event/event-repository"
 import { initEventService } from "./modules/event/event-service"
 
-type CreateContextOptions = {
-  session: Session | null
-}
-
 /** Use this helper for:
  * - testing, so we dont have to mock Next.js' req/res
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://beta.create.t3.gg/en/usage/trpc#-servertrpccontextts
  **/
-export const createContext = async (_opts: CreateContextOptions) => {
-  const client = new PrismaClient()
+export const createContext = async ({ req, res }: trpcExpress.CreateExpressContextOptions) => {
+  console.log({ req, res })
+  const client = prisma
 
   // Repositories
   const userRepository = initUserRepository(client)

--- a/apps/ow-api/src/context.ts
+++ b/apps/ow-api/src/context.ts
@@ -15,11 +15,9 @@ import { initEventService } from "./modules/event/event-service"
  **/
 export const createContext = async ({ req, res }: trpcExpress.CreateExpressContextOptions) => {
   console.log({ req, res })
-  const client = prisma
-
   // Repositories
-  const userRepository = initUserRepository(client)
-  const eventRepository = initEventRepository(client)
+  const userRepository = initUserRepository(prisma)
+  const eventRepository = initEventRepository(prisma)
 
   // Services
   const userService = initUserService(userRepository)

--- a/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
+++ b/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
@@ -2,7 +2,6 @@ import { PrismaClient } from "@dotkomonline/db"
 import { v4 as uuidv4 } from "uuid"
 
 import { NotFoundError } from "../../../errors/errors"
-import { InsertUser } from "../user"
 import { initUserRepository } from "../user-repository"
 import { initUserService } from "../user-service"
 
@@ -12,15 +11,16 @@ describe("UserService", () => {
   const userService = initUserService(userRepository)
 
   it("creates a new user", async () => {
-    const user: InsertUser = {
+    // TODO: change this when i finish the register function
+    const user = {
       firstName: "Monkey",
       lastName: "Markus",
       email: "monkey@markus.com",
       username: "monkey_markus",
     }
     const id = uuidv4()
-    vi.spyOn(userRepository, "createUser").mockResolvedValueOnce({ id, ...user })
-    await expect(userService.register(user)).resolves.toEqual({ id, ...user })
+    vi.spyOn(userRepository, "createUser").mockResolvedValueOnce({})
+    await expect(userService.register(user.email, "password")).resolves.toEqual({ id, ...user })
     expect(userRepository.createUser).toHaveBeenCalledWith(user)
   })
 

--- a/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
+++ b/apps/ow-api/src/modules/auth/__test__/user-service.spec.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "@dotkomonline/db"
 import { v4 as uuidv4 } from "uuid"
 
 import { NotFoundError } from "../../../errors/errors"
+import { User } from "../user"
 import { initUserRepository } from "../user-repository"
 import { initUserService } from "../user-service"
 
@@ -12,15 +13,17 @@ describe("UserService", () => {
 
   it("creates a new user", async () => {
     // TODO: change this when i finish the register function
-    const user = {
-      firstName: "Monkey",
-      lastName: "Markus",
-      email: "monkey@markus.com",
-      username: "monkey_markus",
-    }
     const id = uuidv4()
-    vi.spyOn(userRepository, "createUser").mockResolvedValueOnce({})
-    await expect(userService.register(user.email, "password")).resolves.toEqual({ id, ...user })
+    const user: User = {
+      name: "Markus",
+      email: "monkey@markus.com",
+      id,
+      image: "",
+      createdAt: new Date(2022, 5, 3),
+      password: "hunter2",
+    }
+    vi.spyOn(userRepository, "createUser").mockResolvedValueOnce(user)
+    await expect(userService.register("monkey@markus.com", "password")).resolves.toEqual(user)
     expect(userRepository.createUser).toHaveBeenCalledWith(user)
   })
 

--- a/apps/ow-api/src/modules/auth/user-service.ts
+++ b/apps/ow-api/src/modules/auth/user-service.ts
@@ -1,7 +1,7 @@
+import { NotFoundError } from "@/errors/errors"
 import { Configuration, V0alpha2Api } from "@ory/client"
 import bcrypt from "bcrypt"
 
-import { NotFoundError } from "../../errors/errors"
 import { User } from "./user"
 import { UserRepository } from "./user-repository"
 

--- a/apps/ow-api/src/modules/auth/user-service.ts
+++ b/apps/ow-api/src/modules/auth/user-service.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from "../../errors/errors"
 import { Configuration, V0alpha2Api } from "@ory/client"
 import bcrypt from "bcrypt"
 
+import { NotFoundError } from "../../errors/errors"
 import { User } from "./user"
 import { UserRepository } from "./user-repository"
 

--- a/apps/ow-api/src/modules/auth/user-service.ts
+++ b/apps/ow-api/src/modules/auth/user-service.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "@/errors/errors"
+import { NotFoundError } from "../../errors/errors"
 import { Configuration, V0alpha2Api } from "@ory/client"
 import bcrypt from "bcrypt"
 

--- a/apps/ow-api/src/modules/auth/user.ts
+++ b/apps/ow-api/src/modules/auth/user.ts
@@ -1,4 +1,4 @@
-import { User as PrismaUser } from "@dotkomonline/db"
+import type { Prisma } from "@dotkomonline/db"
 import { z } from "zod"
 
 const userSchema = z.object({
@@ -13,6 +13,6 @@ const userSchema = z.object({
 
 export type User = z.infer<typeof userSchema>
 
-export const mapToUser = (payload: PrismaUser): User => {
+export const mapToUser = (payload: Prisma.UserGetPayload<null>): User => {
   return userSchema.parse(payload)
 }

--- a/apps/ow-api/src/modules/company/company.ts
+++ b/apps/ow-api/src/modules/company/company.ts
@@ -1,4 +1,4 @@
-import { Company as PrismaCompany } from "@dotkomonline/db"
+import { Prisma } from "@dotkomonline/db"
 import { z } from "zod"
 
 const companySchema = z.object({
@@ -15,6 +15,6 @@ const companySchema = z.object({
 export type Company = z.infer<typeof companySchema>
 export type InsertCompany = Omit<Company, "id">
 
-export const mapToCompany = (payload: PrismaCompany): Company => {
+export const mapToCompany = (payload: Prisma.CompanyGetPayload<null>): Company => {
   return companySchema.parse(payload)
 }

--- a/apps/ow-api/src/modules/event/__test__/event-service.spec.ts
+++ b/apps/ow-api/src/modules/event/__test__/event-service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "@/errors/errors"
+import { NotFoundError } from "../../../errors/errors"
 import { PrismaClient } from "@dotkomonline/db"
 import { randomUUID } from "crypto"
 import { describe, vi } from "vitest"

--- a/apps/ow-api/src/modules/event/__test__/event-service.spec.ts
+++ b/apps/ow-api/src/modules/event/__test__/event-service.spec.ts
@@ -1,8 +1,8 @@
-import { NotFoundError } from "../../../errors/errors"
 import { PrismaClient } from "@dotkomonline/db"
 import { randomUUID } from "crypto"
 import { describe, vi } from "vitest"
 
+import { NotFoundError } from "../../../errors/errors"
 import { InsertEvent } from "../event"
 import { initEventRepository } from "../event-repository"
 import { initEventService } from "../event-service"

--- a/apps/ow-api/src/modules/event/event.ts
+++ b/apps/ow-api/src/modules/event/event.ts
@@ -1,4 +1,4 @@
-import { Event as PrismaEvent } from "@dotkomonline/db"
+import { Prisma } from "@dotkomonline/db"
 import { z } from "zod"
 
 export const eventSchema = z.object({
@@ -18,6 +18,6 @@ export const eventSchema = z.object({
 export type Event = z.infer<typeof eventSchema>
 export type InsertEvent = Omit<Event, "id">
 
-export const mapToEvent = (payload: PrismaEvent): Event => {
+export const mapToEvent = (payload: Prisma.EventGetPayload<null>): Event => {
   return eventSchema.parse(payload)
 }

--- a/apps/ow-api/src/server.ts
+++ b/apps/ow-api/src/server.ts
@@ -3,7 +3,7 @@ import express from "express"
 
 import { createExpressMiddleware } from "@trpc/server/adapters/express"
 
-import { createContext } from "./index.js"
+import { createContext } from "./context"
 import { appRouter } from "./router.js"
 
 export const createServer = () => {

--- a/packages/ow-db/src/index.ts
+++ b/packages/ow-db/src/index.ts
@@ -1,2 +1,20 @@
-export * from "@prisma/client"
-export * from ".prisma/client"
+import { Prisma, PrismaClient } from "@prisma/client"
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined
+}
+
+const prismaOptions: Prisma.PrismaClientOptions = {}
+if (!!process.env.NEXT_PUBLIC_DEBUG) prismaOptions.log = ["query", "error", "warn"]
+
+export const prisma = globalThis.prisma || new PrismaClient(prismaOptions)
+
+export const customPrisma = (options: Prisma.PrismaClientOptions) => new PrismaClient({ ...prismaOptions, ...options })
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prisma = prisma
+}
+
+export type { Prisma, PrismaClient }
+export default prisma

--- a/packages/ow-db/src/index.ts
+++ b/packages/ow-db/src/index.ts
@@ -17,4 +17,3 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export type { Prisma, PrismaClient }
-export default prisma

--- a/turbo.json
+++ b/turbo.json
@@ -28,5 +28,13 @@
       "cache": false
     }
   },
-  "globalDependencies": ["$NODE_ENV", "$API_PORT", "$DASHBOARD_PORT","$NEXTAUTH_CLIENT_ID", "$NEXTAUTH_URL", "$HYDRA_ADMIN_URL"]
+  "globalDependencies": [
+    "$NODE_ENV",
+    "$API_PORT",
+    "$DASHBOARD_PORT",
+    "$NEXTAUTH_CLIENT_ID",
+    "$NEXTAUTH_URL",
+    "$HYDRA_ADMIN_URL",
+    "$NEXT_PUBLIC_DEBUG"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,6 +8882,7 @@ __metadata:
     cors: ^2.8.5
     eslint: ^8.26.0
     express: ^4.18.1
+    tsup: ^6.4.0
     tsx: ^3.11.0
     uuid: ^8.3.2
     vite-tsconfig-paths: ^3.5.2
@@ -9948,6 +9949,17 @@ __metadata:
   peerDependencies:
     esbuild: ">=0.13"
   checksum: e433dd18ad2ccaf9d210040c5ce300a8c60f4caf0472856fd5162ec407f7b5b3e0559e540aa92b7381a18a6ff2b45bbe9270dc2fd7ace17e445e72a9cbc7fa95
+  languageName: node
+  linkType: hard
+
+"bundle-require@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "bundle-require@npm:3.1.2"
+  dependencies:
+    load-tsconfig: ^0.2.0
+  peerDependencies:
+    esbuild: ">=0.13"
+  checksum: 71f8cb81bcde97825317b0e516b7e479ec70bd2370f55a8f02795c0df6d541e6562c4b9ec0427cc7b5b835103a8dcf306da04e3846fa468146358471490fcf81
   languageName: node
   linkType: hard
 
@@ -21728,6 +21740,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "rollup@npm:3.2.5"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 1779b778fe4b14f80a995a641d3a89a76e3651170536192022dce1821f1241ee49496353655aa812dc8f8334c89a302ad957b757d4370cf57e41ca270bb394fd
+  languageName: node
+  linkType: hard
+
 "rollup@npm:~2.78.0":
   version: 2.78.1
   resolution: "rollup@npm:2.78.1"
@@ -23880,6 +23906,42 @@ __metadata:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
   checksum: f1cb8f4f83a4a304f61d57dc62fb7176d1fa8842485a7dec4c3fd7cb98e169dbdc4bf52c45ff8cede6843b791fe4a0f70579b34684f568af3c2c3cb2f8469af4
+  languageName: node
+  linkType: hard
+
+"tsup@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "tsup@npm:6.4.0"
+  dependencies:
+    bundle-require: ^3.1.2
+    cac: ^6.7.12
+    chokidar: ^3.5.1
+    debug: ^4.3.1
+    esbuild: ^0.15.1
+    execa: ^5.0.0
+    globby: ^11.0.3
+    joycon: ^3.0.1
+    postcss-load-config: ^3.0.1
+    resolve-from: ^5.0.0
+    rollup: ^3.2.5
+    source-map: 0.8.0-beta.0
+    sucrase: ^3.20.3
+    tree-kill: ^1.2.2
+  peerDependencies:
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ^4.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: a8bcb05265783c38e7c3a5c1d849736dda6122fc15ff78f4b76245cfe2bab93e0ddf74487cd5fe52e23d5fc7600dad154d0f5d1ed3dcc6b429b582d1dd4a49c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Change log
- export a global default Prisma
- instead of using models, we use the type `Prisma.___GetPayload<null>`. That way we can avoid conflicts between the typing of prisma and the normal types
- owdb is copied from cal.com