### PR TITLE
Convert PascalCase to snake_case for table names

### DIFF
--- a/apps/db-migrator/src/db.ts
+++ b/apps/db-migrator/src/db.ts
@@ -1,11 +1,11 @@
-import { Database } from "@dotkomonline/db"
-import { Kysely, PostgresDialect, CamelCasePlugin } from "kysely"
+import { CockroachDialect, Database } from "@dotkomonline/db"
+import { Kysely, CamelCasePlugin } from "kysely"
 import pg from "pg"
 
 import { env } from "./env"
 
 export const db = new Kysely<Database>({
-  dialect: new PostgresDialect({
+  dialect: new CockroachDialect({
     pool: new pg.Pool({
       connectionString: env.DATABASE_URL,
     }),

--- a/apps/db-migrator/src/index.ts
+++ b/apps/db-migrator/src/index.ts
@@ -36,8 +36,8 @@ program
         "Migrating...\n" +
           res.results.map((r, i) => `${i + 1}. ${r.direction} ${r.migrationName}: ${r.status}`).join("\n")
       )
-    } else if (res.error) {
-      logger.error(res.error)
+    } else {
+      logger.warn(res)
     }
 
     if (option.withSeed) {

--- a/apps/db-migrator/src/seed.ts
+++ b/apps/db-migrator/src/seed.ts
@@ -7,7 +7,7 @@ import { db } from "./db"
 
 faker.seed(69)
 
-const createRandomUser = (): Insertable<Database["User"]> => {
+const createRandomUser = (): Insertable<Database["owUser"]> => {
   return {
     id: faker.datatype.uuid(),
     name: faker.name.firstName(),
@@ -17,7 +17,7 @@ const createRandomUser = (): Insertable<Database["User"]> => {
   }
 }
 
-const createRandomEvent = (): Insertable<Database["Event"]> => {
+const createRandomEvent = (): Insertable<Database["event"]> => {
   const start = faker.date.future()
   return {
     id: faker.datatype.uuid(),
@@ -33,7 +33,7 @@ const createRandomEvent = (): Insertable<Database["Event"]> => {
   }
 }
 
-const createRandomAttendance = (eventIDs: string[]): Insertable<Database["Attendance"]> => {
+const createRandomAttendance = (eventIDs: string[]): Insertable<Database["attendance"]> => {
   return {
     id: faker.datatype.uuid(),
     eventID: faker.helpers.arrayElement(eventIDs),
@@ -52,7 +52,7 @@ export const seed = async () => {
   )
 
   await db
-    .insertInto("User")
+    .insertInto("owUser")
     .values(users)
     .returning("id")
     .onConflict((oc) =>
@@ -65,7 +65,7 @@ export const seed = async () => {
     .execute()
 
   await db
-    .insertInto("Event")
+    .insertInto("event")
     .values(event)
     .returning("id")
     .onConflict((oc) =>
@@ -83,7 +83,7 @@ export const seed = async () => {
     .execute()
 
   await db
-    .insertInto("Attendance")
+    .insertInto("attendance")
     .values(attendance)
     .returning("id")
     .onConflict((oc) =>

--- a/packages/api/src/modules/auth/user-repository.ts
+++ b/packages/api/src/modules/auth/user-repository.ts
@@ -2,7 +2,7 @@ import { Database } from "@dotkomonline/db"
 import { Kysely, Selectable } from "kysely"
 import { type User, UserSchema } from "@dotkomonline/types"
 
-export const mapToUser = (payload: Selectable<Database["User"]>): User => {
+export const mapToUser = (payload: Selectable<Database["owUser"]>): User => {
   return UserSchema.parse(payload)
 }
 
@@ -16,23 +16,23 @@ export interface UserRepository {
 export const initUserRepository = (db: Kysely<Database>): UserRepository => {
   const repo: UserRepository = {
     getUserByID: async (id) => {
-      const user = await db.selectFrom("User").selectAll().where("id", "=", id).executeTakeFirst()
+      const user = await db.selectFrom("owUser").selectAll().where("id", "=", id).executeTakeFirst()
       return user ? mapToUser(user) : undefined
     },
     getUserByEmail: async (email) => {
-      const user = await db.selectFrom("User").selectAll().where("email", "=", email).executeTakeFirst()
+      const user = await db.selectFrom("owUser").selectAll().where("email", "=", email).executeTakeFirst()
       return user ? mapToUser(user) : undefined
     },
     getUsers: async (limit: number) => {
-      const users = await db.selectFrom("User").selectAll().limit(limit).execute()
+      const users = await db.selectFrom("owUser").selectAll().limit(limit).execute()
       return users.map(mapToUser)
     },
     createUser: async (email, password) => {
-      const user = await db
-        .insertInto("User")
-        .values({ email: email, password: password })
-        .returningAll()
-        .executeTakeFirst()
+      console.log(db)
+      const res = db.insertInto("owUser").values({ email: email, password: password }).returningAll()
+      console.log(res.compile().sql)
+      const user = await res.executeTakeFirst()
+      console.log(user)
       return user ? mapToUser(user) : undefined
     },
   }

--- a/packages/api/src/modules/company/company-repository.ts
+++ b/packages/api/src/modules/company/company-repository.ts
@@ -2,7 +2,7 @@ import { Database } from "@dotkomonline/db"
 import { Company, CompanySchema, CompanyWrite } from "@dotkomonline/types"
 import { Kysely, Selectable } from "kysely"
 
-export const mapToCompany = (payload: Selectable<Database["Company"]>): Company => {
+export const mapToCompany = (payload: Selectable<Database["company"]>): Company => {
   return CompanySchema.parse(payload)
 }
 
@@ -15,16 +15,16 @@ export interface CompanyRepository {
 export const initCompanyRepository = (db: Kysely<Database>): CompanyRepository => {
   const repo: CompanyRepository = {
     getCompanyByID: async (id) => {
-      const company = await db.selectFrom("Company").selectAll().where("id", "=", id).executeTakeFirst()
+      const company = await db.selectFrom("company").selectAll().where("id", "=", id).executeTakeFirst()
       return company ? mapToCompany(company) : undefined
     },
     getCompanies: async (limit: number) => {
-      const companies = await db.selectFrom("Company").selectAll().limit(limit).execute()
+      const companies = await db.selectFrom("company").selectAll().limit(limit).execute()
       return companies.map(mapToCompany)
     },
     create: async (val) => {
       const company = await db
-        .insertInto("Company")
+        .insertInto("company")
         .values({
           name: val.name,
           description: val.description,

--- a/packages/api/src/modules/event/event-repository.ts
+++ b/packages/api/src/modules/event/event-repository.ts
@@ -2,37 +2,37 @@ import { Database } from "@dotkomonline/db"
 import { Attendance, Event, EventSchema } from "@dotkomonline/types"
 import { Insertable, Kysely, Selectable, sql } from "kysely"
 
-const mapToEvent = (data: Selectable<Database["Event"]>) => EventSchema.parse(data)
+const mapToEvent = (data: Selectable<Database["event"]>) => EventSchema.parse(data)
 
 export interface EventRepository {
-  createEvent: (data: Insertable<Database["Event"]>) => Promise<Event | undefined>
+  createEvent: (data: Insertable<Database["event"]>) => Promise<Event | undefined>
   getEvents: (limit: number, offset?: number) => Promise<Event[]>
   getEventByID: (id: string) => Promise<Event | undefined>
 }
 
 export const initEventRepository = (db: Kysely<Database>): EventRepository => ({
   createEvent: async (data) => {
-    const event = await db.insertInto("Event").values(data).returningAll().executeTakeFirst()
+    const event = await db.insertInto("event").values(data).returningAll().executeTakeFirst()
     return event ? mapToEvent(event) : undefined
   },
   getEvents: async (limit, offset = 0) => {
-    const events = await db.selectFrom("Event").selectAll().limit(limit).offset(offset).execute()
+    const events = await db.selectFrom("event").selectAll().limit(limit).offset(offset).execute()
     return events.map(mapToEvent)
   },
   getEventByID: async (id) => {
     // TODO: move the attendance query to a helper
 
     const event = await db
-      .selectFrom("Event")
+      .selectFrom("event")
       .where("id", "=", id)
-      .leftJoin("Attendance", "Attendance.eventID", "Event.id")
-      .selectAll("Event")
+      .leftJoin("attendance", "attendance.eventID", "event.id")
+      .selectAll("event")
       .select(
-        sql<Attendance[]>`COALESCE(json_agg(Attendance) FILTER (WHERE Attendance.id IS NOT NULL), '[]')`.as(
+        sql<Attendance[]>`COALESCE(json_agg(attendance) FILTER (WHERE attendance.id IS NOT NULL), '[]')`.as(
           "attendances"
         )
       )
-      .groupBy("Event.id")
+      .groupBy("event.id")
       .executeTakeFirst()
 
     return event ? mapToEvent(event) : undefined

--- a/packages/ow-db/src/index.ts
+++ b/packages/ow-db/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./types"
-export { createMigrator } from "./migrator"
+export { createMigrator, CockroachAdapter, CockroachDialect } from "./migrator"

--- a/packages/ow-db/src/migrations/0001_create_user_and_auth.ts
+++ b/packages/ow-db/src/migrations/0001_create_user_and_auth.ts
@@ -5,7 +5,7 @@ import { createTableWithDefaults } from "../utils"
 // Kysely reccomends using "any" in migrations
 
 export async function up(db: Kysely<any>): Promise<void> {
-  await createTableWithDefaults("User", { id: true, createdAt: true }, db.schema)
+  await createTableWithDefaults("ow_user", { id: true, createdAt: true }, db.schema)
     .addColumn("name", "varchar(255)")
     .addColumn("email", "varchar(255)", (col) => col.notNull().unique())
     .addColumn("email_verified", "timestamptz", (col) => col.notNull().defaultTo(sql`now()`))
@@ -13,26 +13,26 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn("image", "varchar(255)")
     .execute()
 
-  await createTableWithDefaults("Session", { id: true, createdAt: true }, db.schema)
+  await createTableWithDefaults("session", { id: true, createdAt: true }, db.schema)
     .addColumn("session_token", "text", (col) => col.notNull().unique())
     .addColumn("expires", "timestamptz", (col) => col.notNull())
-    .addColumn("user_id", "uuid", (col) => col.references("User.id").onDelete("cascade").notNull())
+    .addColumn("user_id", "uuid", (col) => col.references("ow_user.id").onDelete("cascade").notNull())
     .execute()
 
-  await createTableWithDefaults("VerificationToken", { id: true }, db.schema)
+  await createTableWithDefaults("verification_token", { id: true }, db.schema)
     .addColumn("identifier", "varchar(250)", (col) => col.notNull().unique())
     .addColumn("token", "varchar(250)", (col) => col.notNull())
     .addColumn("expires", "timestamptz", (col) => col.notNull())
     .execute()
 
   await db.schema
-    .createIndex("VerificationToken_identifier_token_unique_index")
-    .on("VerificationToken")
+    .createIndex("verification_token_identifier_token_unique_index")
+    .on("verification_token")
     .columns(["identifier", "token"])
     .unique()
     .execute()
 
-  await createTableWithDefaults("Account", { id: true, createdAt: true }, db.schema)
+  await createTableWithDefaults("account", { id: true, createdAt: true }, db.schema)
     .addColumn("type", "varchar(100)", (col) => col.notNull())
     .addColumn("provider", "varchar(100)", (col) => col.notNull())
     .addColumn("provider_account_id", "varchar(100)", (col) => col.notNull())
@@ -45,20 +45,20 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn("session_state", "varchar(100)")
     .addColumn("oauth_token_secret", "text")
     .addColumn("oauth_token", "text")
-    .addColumn("user_id", "uuid", (col) => col.notNull().references("User.id").onDelete("cascade"))
+    .addColumn("user_id", "uuid", (col) => col.notNull().references("ow_user.id").onDelete("cascade"))
     .execute()
 
   await db.schema
-    .createIndex("Account_provider_account_unique_index")
-    .on("Account")
+    .createIndex("account_provider_account_unique_index")
+    .on("account")
     .columns(["provider", "provider_account_id"])
     .unique()
     .execute()
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropTable("Account").execute()
-  await db.schema.dropTable("VerificationToken").execute()
-  await db.schema.dropTable("Session").execute()
-  await db.schema.dropTable("User").execute()
+  await db.schema.dropTable("account").execute()
+  await db.schema.dropTable("verification_token").execute()
+  await db.schema.dropTable("session").execute()
+  await db.schema.dropTable("ow_user").execute()
 }

--- a/packages/ow-db/src/migrations/0002_create_company.ts
+++ b/packages/ow-db/src/migrations/0002_create_company.ts
@@ -3,7 +3,7 @@ import { Kysely } from "kysely"
 import { createTableWithDefaults } from "../utils"
 
 export async function up(db: Kysely<any>) {
-  await createTableWithDefaults("Company", { id: true, createdAt: true }, db.schema)
+  await createTableWithDefaults("company", { id: true, createdAt: true }, db.schema)
     .addColumn("name", "varchar(100)", (col) => col.notNull())
     .addColumn("description", "text", (col) => col.notNull())
     .addColumn("phone", "varchar(69)")
@@ -14,12 +14,12 @@ export async function up(db: Kysely<any>) {
     .execute()
 
   // Create a table for committee based on the old migration
-  await createTableWithDefaults("Committee", { id: true, createdAt: true }, db.schema)
+  await createTableWithDefaults("committee", { id: true, createdAt: true }, db.schema)
     .addColumn("name", "varchar(100)", (col) => col.notNull())
     .execute()
 }
 
 export async function down(db: Kysely<any>) {
-  await db.schema.dropTable("Committee").execute()
-  await db.schema.dropTable("Company").execute()
+  await db.schema.dropTable("committee").execute()
+  await db.schema.dropTable("company").execute()
 }

--- a/packages/ow-db/src/migrations/0003_create-event.ts
+++ b/packages/ow-db/src/migrations/0003_create-event.ts
@@ -5,7 +5,7 @@ import { createTableWithDefaults } from "../utils"
 export async function up(db: Kysely<any>) {
   await db.schema.createType("event_status").asEnum(["TBA", "PUBLIC", "NO_LIMIT", "ATTENDANCE"]).execute()
 
-  await createTableWithDefaults("Event", { id: true, createdAt: true, updatedAt: true }, db.schema)
+  await createTableWithDefaults("event", { id: true, createdAt: true, updatedAt: true }, db.schema)
     .addColumn("title", "varchar(255)", (col) => col.notNull())
     .addColumn("start", "timestamptz", (col) => col.notNull())
     .addColumn("end", "timestamptz", (col) => col.notNull())
@@ -16,41 +16,41 @@ export async function up(db: Kysely<any>) {
     .addColumn("subtitle", "varchar(255)")
     .addColumn("image_url", "varchar(255)")
     .addColumn("location", "varchar(255)")
-    .addColumn("committee_id", "uuid", (col) => col.references("Committee.id").onDelete("set null"))
+    .addColumn("committee_id", "uuid", (col) => col.references("committee.id").onDelete("set null"))
     .execute()
 
-  await createTableWithDefaults("Attendance", { id: true, createdAt: true, updatedAt: true }, db.schema)
+  await createTableWithDefaults("ettendance", { id: true, createdAt: true, updatedAt: true }, db.schema)
     .addColumn("start", "timestamptz", (col) => col.notNull())
     .addColumn("end", "timestamptz", (col) => col.notNull())
     .addColumn("deregister_deadline", "timestamptz", (col) => col.notNull())
     .addColumn("limit", "integer", (col) => col.notNull())
-    .addColumn("event_id", "uuid", (col) => col.references("Event.id").onDelete("cascade"))
+    .addColumn("event_id", "uuid", (col) => col.references("event.id").onDelete("cascade"))
     .execute()
 
-  await createTableWithDefaults("Attendee", { id: true, createdAt: true, updatedAt: true }, db.schema)
-    .addColumn("user_id", "uuid", (col) => col.references("User.id").onDelete("cascade"))
-    .addColumn("attendance_id", "uuid", (col) => col.references("Attendance.id").onDelete("cascade"))
+  await createTableWithDefaults("attendee", { id: true, createdAt: true, updatedAt: true }, db.schema)
+    .addColumn("user_id", "uuid", (col) => col.references("user.id").onDelete("cascade"))
+    .addColumn("attendance_id", "uuid", (col) => col.references("attendance.id").onDelete("cascade"))
     .execute()
 
   await db.schema
-    .createIndex("Attendee_user_attendance_unique_index")
-    .on("Attendee")
+    .createIndex("attendee_user_attendance_unique_index")
+    .on("attendee")
     .columns(["user_id", "attendance_id"])
     .unique()
     .execute()
 
   await db.schema
-    .createTable("EventCompany")
+    .createTable("event_company")
     .addColumn("event_id", "uuid", (col) => col.references("event.id").onDelete("cascade"))
     .addColumn("company_id", "uuid", (col) => col.references("company.id").onDelete("cascade"))
-    .addPrimaryKeyConstraint("EventCompany_pk", ["event_id", "company_id"])
+    .addPrimaryKeyConstraint("event_company_pk", ["event_id", "company_id"])
     .execute()
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropTable("Attendee").execute()
-  await db.schema.dropTable("Attendance").execute()
-  await db.schema.dropTable("EventCompany").execute()
-  await db.schema.dropTable("Event").execute()
+  await db.schema.dropTable("attendee").execute()
+  await db.schema.dropTable("attendance").execute()
+  await db.schema.dropTable("event_company").execute()
+  await db.schema.dropTable("event").execute()
   await db.schema.dropType("event_status").execute()
 }

--- a/packages/ow-db/src/migrator.ts
+++ b/packages/ow-db/src/migrator.ts
@@ -1,8 +1,20 @@
 import { promises as fs } from "fs"
-import { FileMigrationProvider, Kysely, Migrator } from "kysely"
+import { FileMigrationProvider, Kysely, Migrator, PostgresAdapter, PostgresDialect } from "kysely"
 import * as path from "path"
 
 import { Database } from "./types"
+
+export class CockroachAdapter extends PostgresAdapter {
+  override acquireMigrationLock(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+export class CockroachDialect extends PostgresDialect {
+  override createAdapter(): CockroachAdapter {
+    return new CockroachAdapter()
+  }
+}
 
 export const createMigrator = (db: Kysely<Database>) =>
   new Migrator({

--- a/packages/ow-db/src/types/index.ts
+++ b/packages/ow-db/src/types/index.ts
@@ -3,7 +3,7 @@ import { EventTable, AttendanceTable, AttendeeTable, CommitteeTable } from "./ev
 import { UserTable, SessionTable, VerificationTokenTable, AccountTable } from "./user"
 
 export interface Database {
-  user: UserTable
+  owUser: UserTable
   company: CompanyTable
   session: SessionTable
   verificationToken: VerificationTokenTable

--- a/packages/ow-db/src/types/index.ts
+++ b/packages/ow-db/src/types/index.ts
@@ -3,14 +3,14 @@ import { EventTable, AttendanceTable, AttendeeTable, CommitteeTable } from "./ev
 import { UserTable, SessionTable, VerificationTokenTable, AccountTable } from "./user"
 
 export interface Database {
-  User: UserTable
-  Company: CompanyTable
-  Session: SessionTable
-  VerificationToken: VerificationTokenTable
-  Account: AccountTable
-  Event: EventTable
-  Attendance: AttendanceTable
-  Committee: CommitteeTable
-  Attendee: AttendeeTable
-  EventCompany: EventCompanyTable
+  user: UserTable
+  company: CompanyTable
+  session: SessionTable
+  verificationToken: VerificationTokenTable
+  account: AccountTable
+  event: EventTable
+  attendance: AttendanceTable
+  committee: CommitteeTable
+  attendee: AttendeeTable
+  eventCompany: EventCompanyTable
 }


### PR DESCRIPTION
# Changelog

- Converts table names to snake case
- This is due to capitlized letters not working correctly with the camelcase plugin, which is prefered in javascript