### PR TITLE
fix: re-export cockroach dialect and adapter separately from migrator

### DIFF
--- a/packages/ow-db/src/cockroach.ts
+++ b/packages/ow-db/src/cockroach.ts
@@ -1,4 +1,4 @@
-import { PostgresAdapter, PostgresDialect } from "kysely";
+import { PostgresAdapter, PostgresDialect } from "kysely"
 
 export class CockroachAdapter extends PostgresAdapter {
   override acquireMigrationLock(): Promise<void> {

--- a/packages/ow-db/src/cockroach.ts
+++ b/packages/ow-db/src/cockroach.ts
@@ -1,0 +1,13 @@
+import { PostgresAdapter, PostgresDialect } from "kysely";
+
+export class CockroachAdapter extends PostgresAdapter {
+  override acquireMigrationLock(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+export class CockroachDialect extends PostgresDialect {
+  override createAdapter(): CockroachAdapter {
+    return new CockroachAdapter()
+  }
+}

--- a/packages/ow-db/src/index.ts
+++ b/packages/ow-db/src/index.ts
@@ -1,8 +1,9 @@
 import { Kysely, PostgresDialect, CamelCasePlugin } from "kysely"
-import { Pool } from "pg"
+import pg from "pg"
 import { Database } from "./types"
 
 export * from "./types"
+export { CockroachDialect } from "./cockroach"
 
 declare global {
   // allow global `var` declarations
@@ -14,7 +15,7 @@ export const kysely =
   global.kysely ||
   new Kysely<Database>({
     dialect: new PostgresDialect({
-      pool: new Pool({
+      pool: new pg.Pool({
         connectionString: process.env.DATABASE_URL as string,
       }),
     }),

--- a/packages/ow-db/src/migrator.ts
+++ b/packages/ow-db/src/migrator.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "fs"
-import { FileMigrationProvider, Kysely, Migrator, PostgresAdapter, PostgresDialect } from "kysely"
+import { FileMigrationProvider, Kysely, Migrator } from "kysely"
 import * as path from "path"
 
 import { Database } from "./types"

--- a/packages/ow-db/src/migrator.ts
+++ b/packages/ow-db/src/migrator.ts
@@ -4,24 +4,12 @@ import * as path from "path"
 
 import { Database } from "./types"
 
-export class CockroachAdapter extends PostgresAdapter {
-  override acquireMigrationLock(): Promise<void> {
-    return Promise.resolve()
-  }
-}
-
-export class CockroachDialect extends PostgresDialect {
-  override createAdapter(): CockroachAdapter {
-    return new CockroachAdapter()
-  }
-}
-
 export const createMigrator = (db: Kysely<Database>) =>
   new Migrator({
     db: db,
     provider: new FileMigrationProvider({
       fs,
       path,
-      migrationFolder: new URL("../src/migrations", import.meta.url).pathname,
+      migrationFolder: new URL("migrations", import.meta.url).pathname,
     }),
   })


### PR DESCRIPTION
Addresses a problem where the migrator wouldn't run because the adapter wasn't exported, while still making it possible for nextjs to run without having to resolve the new URL in createMigrator
