### PR TITLE
Add db fixtures and additional migrate options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,4 @@
   "editor.quickSuggestions": {
     "strings": true
   },
-  "tailwindCSS.rootFontSize": 14
 }

--- a/apps/db-migrator/package.json
+++ b/apps/db-migrator/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "dependencies": {
     "@dotkomonline/db": "*",
+    "@dotkomonline/types": "*",
     "chalk": "^5.1.2",
     "commander": "^9.4.1",
     "kysely": "^0.23.0",

--- a/apps/db-migrator/src/fixture.ts
+++ b/apps/db-migrator/src/fixture.ts
@@ -1,0 +1,134 @@
+import { attendances } from "./fixtures/attendance"
+import { attendees } from "./fixtures/attendee"
+import { committees } from "./fixtures/committee"
+import { companies } from "./fixtures/company"
+import { db } from "./db"
+import { eventCompany } from "./fixtures/event-company"
+import { events } from "./fixtures/event"
+import { marks } from "./fixtures/mark"
+import { users } from "./fixtures/user"
+
+export const runFixtures = async () => {
+  await db
+    .insertInto("owUser")
+    .values(users)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        name: (eb) => eb.ref("excluded.name"),
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        email: (eb) => eb.ref("excluded.email"),
+        emailVerified: (eb) => eb.ref("excluded.emailVerified"),
+        password: (eb) => eb.ref("excluded.password"),
+        image: (eb) => eb.ref("excluded.image"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("company")
+    .values(companies)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        name: (eb) => eb.ref("excluded.name"),
+        description: (eb) => eb.ref("excluded.description"),
+        phone: (eb) => eb.ref("excluded.phone"),
+        email: (eb) => eb.ref("excluded.email"),
+        website: (eb) => eb.ref("excluded.website"),
+        location: (eb) => eb.ref("excluded.location"),
+        type: (eb) => eb.ref("excluded.type"),
+        image: (eb) => eb.ref("excluded.image"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("committee")
+    .values(committees)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        name: (eb) => eb.ref("excluded.name"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("event")
+    .values(events)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
+        title: (eb) => eb.ref("excluded.title"),
+        start: (eb) => eb.ref("excluded.start"),
+        end: (eb) => eb.ref("excluded.end"),
+        status: (eb) => eb.ref("excluded.status"),
+        type: (eb) => eb.ref("excluded.type"),
+        public: (eb) => eb.ref("excluded.public"),
+        description: (eb) => eb.ref("excluded.description"),
+        subtitle: (eb) => eb.ref("excluded.subtitle"),
+        imageUrl: (eb) => eb.ref("excluded.imageUrl"),
+        location: (eb) => eb.ref("excluded.location"),
+        committeeId: (eb) => eb.ref("excluded.committeeId"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("eventCompany")
+    .values(eventCompany)
+    .onConflict((oc) => oc.columns(["eventId", "companyId"]).doNothing())
+    .execute()
+
+  await db
+    .insertInto("attendance")
+    .values(attendances)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
+        start: (eb) => eb.ref("excluded.start"),
+        end: (eb) => eb.ref("excluded.end"),
+        deregisterDeadline: (eb) => eb.ref("excluded.deregisterDeadline"),
+        limit: (eb) => eb.ref("excluded.limit"),
+        eventId: (eb) => eb.ref("excluded.eventId"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("attendee")
+    .values(attendees)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        createdAt: (eb) => eb.ref("excluded.createdAt"),
+        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
+        userId: (eb) => eb.ref("excluded.userId"),
+        attendanceId: (eb) => eb.ref("excluded.attendanceId"),
+      })
+    )
+    .execute()
+
+  await db
+    .insertInto("mark")
+    .values(marks)
+    .returning("id")
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
+        title: (eb) => eb.ref("excluded.title"),
+        givenAt: (eb) => eb.ref("excluded.givenAt"),
+        category: (eb) => eb.ref("excluded.category"),
+        details: (eb) => eb.ref("excluded.details"),
+        duration: (eb) => eb.ref("excluded.duration"),
+      })
+    )
+    .execute()
+}

--- a/apps/db-migrator/src/fixtures/attendance.ts
+++ b/apps/db-migrator/src/fixtures/attendance.ts
@@ -1,0 +1,35 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const attendances: Insertable<Database["attendance"]>[] = [
+  {
+    id: "09971e1c-d1ab-498d-89ca-f0b7645b74f7",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    start: new Date("2023-06-11 15:00:00+00"),
+    end: new Date("2023-06-12 15:00:00+00"),
+    deregisterDeadline: new Date("2023-06-13 15:00:00+00"),
+    limit: 20,
+    eventId: "abdcc9c3-6d6a-4767-8d8a-608d8c091eb1",
+  },
+  {
+    id: "5afcbebb-f96f-4c76-b1dc-917039be1749",
+    createdAt: new Date("2023-02-23 11:03:49.289+00"),
+    updatedAt: new Date("2023-02-23 11:03:49.289+00"),
+    start: new Date("2023-06-16 15:00:00+00"),
+    end: new Date("2023-06-17 15:00:00+00"),
+    deregisterDeadline: new Date("2023-06-18 15:00:00+00"),
+    limit: 5,
+    eventId: "abdcc9c3-6d6a-4767-8d8a-608d8c091eb1",
+  },
+  {
+    id: "a12f4850-a400-4dc8-916a-cd8239dca1e0",
+    createdAt: new Date("2023-02-25 11:03:49.289+00"),
+    updatedAt: new Date("2023-02-25 11:03:49.289+00"),
+    start: new Date("2023-06-18 15:00:00+00"),
+    end: new Date("2023-06-19 15:00:00+00"),
+    deregisterDeadline: new Date("2023-06-20 15:00:00+00"),
+    limit: 20,
+    eventId: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+  },
+]

--- a/apps/db-migrator/src/fixtures/attendee.ts
+++ b/apps/db-migrator/src/fixtures/attendee.ts
@@ -1,0 +1,26 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const attendees: Insertable<Database["attendee"]>[] = [
+  {
+    id: "a76532a6-0789-471b-af41-efe99c458f92",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: "71f83a49-4c5c-4249-b01a-59647711f5fb",
+    attendanceId: "09971e1c-d1ab-498d-89ca-f0b7645b74f7",
+  },
+  {
+    id: "e9874714-fd1c-4ad2-a768-51ca3d64959f",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: "0ee21040-e30e-4331-a912-05f66ac52eea",
+    attendanceId: "09971e1c-d1ab-498d-89ca-f0b7645b74f7",
+  },
+  {
+    id: "a12f4850-a400-4dc8-916a-cd8239dca1e0",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: "71f83a49-4c5c-4249-b01a-59647711f5fb",
+    attendanceId: "a12f4850-a400-4dc8-916a-cd8239dca1e0",
+  },
+]

--- a/apps/db-migrator/src/fixtures/committee.ts
+++ b/apps/db-migrator/src/fixtures/committee.ts
@@ -1,0 +1,25 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const committees: Insertable<Database["committee"]>[] = [
+  {
+    id: "060bc7ee-d9ac-43bb-bc97-178deceb42cc",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    name: "Dotkom",
+  },
+  {
+    id: "23361509-94d5-4123-81ca-fd2795223942",
+    createdAt: new Date("2023-02-23 11:03:49.289+00"),
+    name: "Bedkom",
+  },
+  {
+    id: "d19021fb-2f10-4b5c-92dd-098fe5cee4d7",
+    createdAt: new Date("2023-02-25 11:03:49.289+00"),
+    name: "Arrkom",
+  },
+  {
+    id: "97913415-399b-4ddc-9a1e-deedc886c1b4",
+    createdAt: new Date("2023-02-15 11:03:49.289+00"),
+    name: "Hovedstyret",
+  },
+]

--- a/apps/db-migrator/src/fixtures/company.ts
+++ b/apps/db-migrator/src/fixtures/company.ts
@@ -1,0 +1,31 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const companies: Insertable<Database["company"]>[] = [
+  {
+    id: "7c45f557-0ae2-4153-9934-375dc8c94f7b",
+    createdAt: new Date("2023-02-28 17:23:45.329666+00"),
+    name: "Bekk",
+    description: "Et konsulentselskap som forøvrig er hovedsponsor for Online Linjeforening",
+    phone: "+47 123 45 678",
+    email: "bekk@bekk.no",
+    website: "https://bekk.no",
+    location: "Oslo & Trondheim",
+    type: "Consulting",
+    image:
+      "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/md/6a826628-9ebf-426e-9966-625513779427.png",
+  },
+  {
+    id: "200fa69b-1037-471e-ad6e-7047444c7e35",
+    createdAt: new Date("2023-03-01 14:50:38.564678+00"),
+    name: "Junior Consulting",
+    description: "Et konsulentselskap drevet av erfaringssultne studenter",
+    phone: "+47 876 54 321",
+    email: "test@jrc.no",
+    website: "https://www.jrc.no/",
+    location: "Trondheim",
+    type: "Consulting",
+    image:
+      "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/md/8b65f23a-94a4-4b24-a997-bb051b9c831a.png",
+  },
+]

--- a/apps/db-migrator/src/fixtures/event-company.ts
+++ b/apps/db-migrator/src/fixtures/event-company.ts
@@ -1,0 +1,17 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const eventCompany: Insertable<Database["eventCompany"]>[] = [
+  {
+    eventId: "abdcc9c3-6d6a-4767-8d8a-608d8c091eb1",
+    companyId: "7c45f557-0ae2-4153-9934-375dc8c94f7b",
+  },
+  {
+    eventId: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+    companyId: "7c45f557-0ae2-4153-9934-375dc8c94f7b",
+  },
+  {
+    eventId: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+    companyId: "200fa69b-1037-471e-ad6e-7047444c7e35",
+  },
+]

--- a/apps/db-migrator/src/fixtures/event.ts
+++ b/apps/db-migrator/src/fixtures/event.ts
@@ -1,0 +1,39 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const events: Insertable<Database["event"]>[] = [
+  {
+    id: "abdcc9c3-6d6a-4767-8d8a-608d8c091eb1",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    title: "Kurs i å lage fixtures",
+    start: new Date("2023-02-17 00:00:00+00"),
+    end: new Date("2023-02-22 01:33:00+00"),
+    status: "PUBLIC",
+    type: "SOCIAL",
+    public: true,
+    description: "Dette er et kurs i å lage fixtures",
+    subtitle: "Kurs i fixtures",
+    imageUrl:
+      "https://online.ntnu.no/_next/image?url=https%3A%2F%2Fonlineweb4-prod.s3.eu-north-1.amazonaws.com%2Fmedia%2Fimages%2Fresponsive%2Flg%2Fdf32b932-f4c4-4a49-9129-a8ab528b1e33.jpeg&w=1200&q=75",
+    location: "Hovedbygget",
+    committeeId: null,
+  },
+  {
+    id: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+    createdAt: new Date("2023-02-23 11:03:49.289+00"),
+    updatedAt: new Date("2023-02-23 11:03:49.289+00"),
+    title: "Åre 2024",
+    start: new Date("2023-02-23 11:40:00+00"),
+    end: new Date("2023-02-23 11:03:38.63+00"),
+    status: "NO_LIMIT",
+    type: "SOCIAL",
+    public: false,
+    description: "Tur til åre",
+    subtitle: "Subtitle tur til åre",
+    imageUrl:
+      "https://online.ntnu.no/_next/image?url=https%3A%2F%2Fonlineweb4-prod.s3.eu-north-1.amazonaws.com%2Fmedia%2Fimages%2Fresponsive%2Flg%2Fdf32b932-f4c4-4a49-9129-a8ab528b1e33.jpeg&w=1200&q=75",
+    location: "Åre, Sverige",
+    committeeId: null,
+  },
+]

--- a/apps/db-migrator/src/fixtures/mark.ts
+++ b/apps/db-migrator/src/fixtures/mark.ts
@@ -1,0 +1,23 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const marks: Insertable<Database["mark"]>[] = [
+  {
+    id: "778bba47-e8fa-49b2-bef4-9afa1aa81693",
+    updatedAt: new Date("2023-01-25 19:58:43.138389+00"),
+    title: "a",
+    givenAt: new Date("2023-01-25 19:58:43.138389+00"),
+    category: "a",
+    details: "a",
+    duration: 20,
+  },
+  {
+    id: "139b386f-8b04-4401-ac45-e16c190d12d0",
+    updatedAt: new Date("2023-01-25 20:05:31.034217+00"),
+    title: "a",
+    givenAt: new Date("2023-01-25 20:05:31.034217+00"),
+    category: "a",
+    details: "a",
+    duration: 20,
+  },
+]

--- a/apps/db-migrator/src/fixtures/user.ts
+++ b/apps/db-migrator/src/fixtures/user.ts
@@ -1,0 +1,23 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const users: Insertable<Database["owUser"]>[] = [
+  {
+    id: "71f83a49-4c5c-4249-b01a-59647711f5fb",
+    createdAt: new Date("2023-01-03 02:12:54.374715+00"),
+    name: "Anhkha Vo",
+    email: "dev@akvo.no",
+    emailVerified: null,
+    password: "doesntmatter",
+    image: null,
+  },
+  {
+    id: "0ee21040-e30e-4331-a912-05f66ac52eea",
+    createdAt: new Date("2023-01-18 19:22:17.627253+00"),
+    name: "Julian Grande",
+    email: "juliangrande@gmx.com",
+    emailVerified: null,
+    password: "doesntmatter",
+    image: null,
+  },
+]

--- a/apps/db-migrator/src/index.ts
+++ b/apps/db-migrator/src/index.ts
@@ -1,9 +1,9 @@
-import { createMigrator } from "@dotkomonline/db/src/migrator"
-import { getLogger } from "@dotkomonline/logger"
-import { program, Argument } from "commander"
-import { MigrationResultSet } from "kysely"
+import { Argument, program } from "commander"
 
+import { MigrationResultSet } from "kysely"
+import { createMigrator } from "@dotkomonline/db/src/migrator"
 import { db } from "./db"
+import { getLogger } from "@dotkomonline/logger"
 
 export const logger = getLogger("migrator")
 
@@ -11,12 +11,18 @@ program
   .name("migrator")
   .description("CLI to migrate OW database")
   .addArgument(
-    new Argument("<action>", "Up, down or latest").choices(["up", "down", "latest"]).default("latest").argOptional()
+    new Argument("<action>", "Up, down or latest")
+      .choices(["up", "down", "down-all", "latest"])
+      .default("latest")
+      .argOptional()
   )
   .option("-s, --with-seed", "Seed the database with fake data", false)
-  .action(async (name: "up" | "down" | "latest", option) => {
+  .option("-f, --with-fixtures", "Add predictable data to the database", false)
+  .action(async (name: "up" | "down" | "down-all" | "latest", option) => {
     const migrator = createMigrator(db)
     let res: MigrationResultSet
+
+    let handlesItself = false
     switch (name) {
       case "up": {
         res = await migrator.migrateUp()
@@ -26,23 +32,46 @@ program
         res = await migrator.migrateDown()
         break
       }
+      case "down-all": {
+        handlesItself = true
+
+        do {
+          res = await migrator.migrateDown()
+          if (res.results && !res.error) {
+            res.results.forEach((r) => logger.info(`${r.direction} ${r.migrationName}: ${r.status}`))
+          }
+        } while (res.results && res.results.length > 0 && !res.results[0].migrationName.startsWith("0001"))
+
+        if (res.error) {
+          logger.error(`Failed to down all in migration "${res.results?.[0].migrationName}": ${res.error}`)
+        }
+        break
+      }
       case "latest": {
         res = await migrator.migrateToLatest()
         break
       }
     }
-    if (res.results) {
-      logger.info(
-        "Migrating...\n" +
-          res.results.map((r, i) => `${i + 1}. ${r.direction} ${r.migrationName}: ${r.status}`).join("\n")
-      )
-    } else {
-      logger.warn(res)
+
+    if (!handlesItself) {
+      if (res.results) {
+        logger.info(
+          "Migrating...\n" +
+            res.results.map((r, i) => `${i + 1}. ${r.direction} ${r.migrationName}: ${r.status}`).join("\n")
+        )
+      } else {
+        logger.warn(res)
+      }
     }
 
     if (option.withSeed) {
       const { seed } = await import("./seed")
       await seed()
+    }
+    if (option.withFixtures) {
+      const { runFixtures } = await import("./fixture")
+      await runFixtures()
+      logger.info("Successfully inserted fixtures")
     }
     process.exit()
   })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test": "turbo run test",
     "dev": "dotenv -e .env -- turbo run dev",
     "migrate": "dotenv -e .env -- turbo run migrate",
+    "migrate-down": "dotenv -e .env -- turbo run migrate -- down",
+    "migrate-down-all": "dotenv -e .env -- turbo run migrate -- down-all",
     "migrate-dev": "dotenv -e .env.local -- turbo run migrate -- latest --with-seed",
+    "migrate-with-fixtures": "dotenv -e .env -- turbo run migrate -- latest --with-fixtures",
     "storybook": "turbo run storybook --filter=storybook",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         version: 2.8.4
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.16.1)(typescript@4.9.5)
+        version: 10.9.1(@types/node@16.18.25)(typescript@4.9.5)
       tsc-watch:
         specifier: ^6.0.0
         version: 6.0.0(typescript@4.9.5)
@@ -164,6 +164,9 @@ importers:
       '@dotkomonline/db':
         specifier: '*'
         version: link:../../packages/ow-db
+      '@dotkomonline/types':
+        specifier: '*'
+        version: link:../../packages/types
       chalk:
         specifier: ^5.1.2
         version: 5.1.2
@@ -224,7 +227,7 @@ importers:
         version: 18.2.0
       sanity:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@18.16.1)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6)
+        version: 3.2.4(@types/node@16.18.25)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       styled-components:
         specifier: ^5.2.0
         version: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -309,7 +312,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^3.0.4
-        version: 3.2.4(@types/node@18.16.1)
+        version: 3.2.4(@types/node@16.18.25)
 
   apps/web:
     dependencies:
@@ -4553,7 +4556,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@4.9.5)
       typescript: 4.9.5
-      vite: 3.2.4(@types/node@18.16.1)
+      vite: 3.2.4(@types/node@16.18.25)
     dev: true
 
   /@jridgewell/gen-mapping@0.1.1:
@@ -6338,7 +6341,7 @@ packages:
       '@storybook/csf-plugin': 7.0.0-beta.34
       '@storybook/csf-tools': 7.0.0-beta.34
       '@storybook/global': 5.0.0
-      '@storybook/mdx2-csf': 1.1.0-next.0
+      '@storybook/mdx2-csf': 1.1.0-next.1
       '@storybook/node-logger': 7.0.0-beta.34
       '@storybook/postinstall': 7.0.0-beta.34
       '@storybook/preview-api': 7.0.0-beta.34
@@ -6636,7 +6639,7 @@ packages:
       '@storybook/client-logger': 7.0.0-beta.39
       '@storybook/core-common': 7.0.0-beta.39(glob@7.2.3)
       '@storybook/csf-plugin': 7.0.0-beta.39
-      '@storybook/mdx2-csf': 1.1.0-next.0
+      '@storybook/mdx2-csf': 1.1.0-next.1
       '@storybook/node-logger': 7.0.0-beta.39
       '@storybook/preview': 7.0.0-beta.39
       '@storybook/preview-api': 7.0.0-beta.39
@@ -6651,7 +6654,7 @@ packages:
       rollup: 3.10.0
       slash: 3.0.0
       typescript: 4.9.5
-      vite: 3.2.4(@types/node@18.16.1)
+      vite: 3.2.4(@types/node@16.18.25)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7066,8 +7069,8 @@ packages:
     resolution: {integrity: sha512-E/wvYu31hVHvCKb1wVyHSnX6WvpuGuk2cPBo8BGZAqA53QeDYuLTdgvcSqA0mRZKioMvNZzlf03FsYfMGxyKWQ==}
     dev: true
 
-  /@storybook/mdx2-csf@1.1.0-next.0:
-    resolution: {integrity: sha512-DeXEULA683XaoNJpAwqJU4lKnpCAACdIiSDqCuAfKzhHYAv11snQ8VjPrtR1I0WcWG4ATi+TawT1dWFnsYhhAQ==}
+  /@storybook/mdx2-csf@1.1.0-next.1:
+    resolution: {integrity: sha512-ONvFBZySHsBIkUYGrUM8FCG2tDKf663TIErztPSOghOpmBGyFLjSsXJHkNWiRi4c740PoemLqJd2XZZVlXRVLQ==}
     dev: true
 
   /@storybook/node-logger@6.5.13:
@@ -7170,7 +7173,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 3.2.4(@types/node@18.16.1)
+      vite: 3.2.4(@types/node@16.18.25)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - glob
@@ -8050,7 +8053,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.20.12)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 3.2.4(@types/node@18.16.1)
+      vite: 3.2.4(@types/node@16.18.25)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8066,7 +8069,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.20.12)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.0.4(@types/node@18.16.1)
+      vite: 4.0.4(@types/node@16.18.25)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12747,7 +12750,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 16.18.25
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12937,7 +12940,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /jsx-ast-utils@3.3.3:
@@ -14537,7 +14540,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.19
-      ts-node: 10.9.1(@types/node@18.16.1)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@16.18.25)(typescript@4.9.5)
       yaml: 1.10.2
 
   /postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.1):
@@ -14554,7 +14557,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.21
-      ts-node: 10.9.1(@types/node@18.16.1)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@16.18.25)(typescript@4.9.5)
       yaml: 1.10.2
 
   /postcss-load-config@3.1.4(postcss@8.4.23)(ts-node@10.9.1):
@@ -14571,7 +14574,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.23
-      ts-node: 10.9.1(@types/node@18.16.1)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@16.18.25)(typescript@4.9.5)
       yaml: 1.10.2
     dev: true
 
@@ -15660,7 +15663,7 @@ packages:
       diff-match-patch: 1.0.5
     dev: false
 
-  /sanity@3.2.4(@types/node@18.16.1)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6):
+  /sanity@3.2.4(@types/node@16.18.25)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6):
     resolution: {integrity: sha512-CQMXAlRrW0awRJprHIAfj6v1CSmwaUCzt7sdIuMtvAVmgZCWx+wODtYD7a1wItXDI83A4AS3j38YikQotXJTeg==}
     engines: {node: '>=14.18.0'}
     hasBin: true
@@ -15773,7 +15776,7 @@ packages:
       ts-md5: 1.3.1
       use-device-pixel-ratio: 1.1.2(react@18.2.0)
       use-hot-module-reload: 1.0.2(react@18.2.0)
-      vite: 4.0.4(@types/node@18.16.1)
+      vite: 4.0.4(@types/node@16.18.25)
       yargs: 17.3.1
     transitivePeerDependencies:
       - '@types/node'
@@ -17070,7 +17073,7 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /ts-node@10.9.1(@types/node@18.16.1)(typescript@4.9.5):
+  /ts-node@10.9.1(@types/node@16.18.25)(typescript@4.9.5):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -17089,7 +17092,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.16.1
+      '@types/node': 16.18.25
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -17871,41 +17874,6 @@ packages:
       rollup: 3.10.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /vite@4.0.4(@types/node@18.16.1):
-    resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.16.1
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.10.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
 
   /vitest@0.28.4(@vitest/ui@0.28.4):
     resolution: {integrity: sha512-sfWIy0AdlbyGRhunm+TLQEJrFH9XuRPdApfubsyLcDbCRrUX717BRQKInTgzEfyl2Ipi1HWoHB84Nqtcwxogcg==}


### PR DESCRIPTION
- Adds three new commands
  - `pnpm migrate-down` - Migrates down to the previous migration
  - `pnpm migrate-down-all` - Migrates down all migrations in the correct order
  - `pnpm migrate-with-fixtures` - Migrates to the latest migration and inserts predictable fixture data