### PR TITLE
Add committee page

### DIFF
--- a/apps/db-migrator/src/fixture.ts
+++ b/apps/db-migrator/src/fixture.ts
@@ -49,6 +49,9 @@ export const runFixtures = async () => {
       oc.column("id").doUpdateSet({
         createdAt: (eb) => eb.ref("excluded.createdAt"),
         name: (eb) => eb.ref("excluded.name"),
+        description: (eb) => eb.ref("excluded.description"),
+        email: (eb) => eb.ref("excluded.email"),
+        image: (eb) => eb.ref("excluded.image"),
       })
     )
     .execute()

--- a/apps/db-migrator/src/fixtures/committee.ts
+++ b/apps/db-migrator/src/fixtures/committee.ts
@@ -6,20 +6,38 @@ export const committees: Insertable<Database["committee"]>[] = [
     id: "060bc7ee-d9ac-43bb-bc97-178deceb42cc",
     createdAt: new Date("2023-02-22 13:30:04.713+00"),
     name: "Dotkom",
+    description:
+      "Drifts- og Utviklingskomiteen er komiteen som er ansvarlig for utvikling og vedlikehold av Online sine nettsider, samt drift av maskinparken.\n\nDotkom har også ansvaret for å sikre at Online på best mulig måte benytter IT i sine arbeidsprosesser, der Online er tjent med det. Dotkom er som følge av det, også forpliktet til å utvikle og vedlikeholde IT-systemer som Online er tjent med - med hensyn til Online som linjeforening og Online sine studenter.",
+    email: "dotkom@online.ntnu.no",
+    image:
+      "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/0990ab67-0f5b-4c4d-95f1-50a5293335a5.png",
   },
   {
     id: "23361509-94d5-4123-81ca-fd2795223942",
     createdAt: new Date("2023-02-23 11:03:49.289+00"),
     name: "Bedkom",
+    description:
+      "Bedriftskomiteen er bindeleddet mellom næringslivet og informatikkstudenter, og skal i tillegg samarbeide med andre linjeforeninger på NTNU for å ivareta informatikkstudentenes interesser. Vårt mål er å kommunisere og formidle våre studenter som potensielle arbeidstakere til aktuelle bedrifter på en positiv måte. For å fremme dette er bedriftspresentasjoner en viktig del av vårt virke, i tillegg til andre måter å kommunisere ut informasjon til studentene - på en god måte.\n\nVi er en hardtarbeidende komitè som igjennom mange år har opparbeidet oss et meget stort kontaktnett av bedrifter. Bedriftskomiteen opererer som en kontaktpunkt for bedrifter og studentene på informatikkstudiet.\n\nSom medlem i bedriftskomiteen får du en unik mulighet til å komme i kontakt med mange bedrifter, som vil gagne dine medstudenter og deg selv.",
+    email: "bedkom@online.ntnu.no",
+    image:
+      "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/974b88bd-de01-4b59-856f-f53d9bb600a0.png",
   },
   {
     id: "d19021fb-2f10-4b5c-92dd-098fe5cee4d7",
     createdAt: new Date("2023-02-25 11:03:49.289+00"),
     name: "Arrkom",
+    description:
+      "Arrangementskomiteen har som hovedansvar å arrangere sosiale tilstelninger for informatikkstudenter.\n\nOnline arrangerer både tradisjonsrike fester, og andre sosiale arrangementer, i løpet av skoleåret. Dette er et tilbud til deg slik at du kan ha det moro og knytte nye kontakter innad i linjeforeningen. Vi bidrar jobber for økt samhold og sosialisering blant Onlines medlemmer. Dette gjør vi ved å bidra til et variert sosialt tilbud for alle Onlinere.\n\nVi skal være en aktiv og synlig komité som inkluderer alle og sørger for å tilby et så variert tilbud av arrangementer at enhver av Onlines medlemmer kan stille på flest mulig av disse.",
+    email: "arrkom@online.ntnu.no",
+    image:
+      "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/0954f3de-da25-44eb-b3a9-7dbba7e23f25.png",
   },
   {
     id: "97913415-399b-4ddc-9a1e-deedc886c1b4",
     createdAt: new Date("2023-02-15 11:03:49.289+00"),
     name: "Hovedstyret",
+    email: "hovedstyret@online.ntnu.no",
+    description:
+      "Hovedstyret velges av linjeforeningens medlemmer på generalforsamlingen i løpet av vårsemesteret og sitter ett år frem i tid. Styret består av leder, nestleder, økonomiansvarlig og alle styremedlemmene.\n\nHovedstyret er først og fremst en møteplass for koordinering av de forskjellige komiteene. Styret driver også med økonomistyring og annet administrativt arbeid.\n\nHovedstyret er også linjeforeningens ansikt utad, og opprettholder kontakten med fakultet, institutt og representerer Online ved forskjellige anledninger.",
   },
 ]

--- a/apps/db-migrator/src/fixtures/event.ts
+++ b/apps/db-migrator/src/fixtures/event.ts
@@ -35,7 +35,7 @@ export const events: Insertable<Database["event"]>[] = [
     imageUrl:
       "https://online.ntnu.no/_next/image?url=https%3A%2F%2Fonlineweb4-prod.s3.eu-north-1.amazonaws.com%2Fmedia%2Fimages%2Fresponsive%2Flg%2Fdf32b932-f4c4-4a49-9129-a8ab528b1e33.jpeg&w=1200&q=75",
     location: "Åre, Sverige",
-    committeeId: null,
+    committeeId: "d19021fb-2f10-4b5c-92dd-098fe5cee4d7",
     waitlist: null,
   },
 ]

--- a/apps/sanity/package.json
+++ b/apps/sanity/package.json
@@ -19,7 +19,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
-    "sanity": "^3.0.0"
+    "sanity": "^3.0.0",
+    "styled-components": "^5.2"
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^2.0.1",

--- a/apps/web/src/components/layout/EntryDetailLayout.tsx
+++ b/apps/web/src/components/layout/EntryDetailLayout.tsx
@@ -1,0 +1,25 @@
+import { FC, PropsWithChildren } from "react"
+import { cn } from "@dotkomonline/ui"
+
+export interface EntryDetailLayoutProps {
+  title: string
+  type?: string
+  color?: "BLUE" | "GREEN" | "AMBER"
+}
+
+export const EntryDetailLayout: FC<PropsWithChildren<EntryDetailLayoutProps>> = ({ children, title, type, color }) => {
+  const borderColorClass = color ? `border-${color.toLowerCase()}-8` : "border-blue-8"
+  const textColorClass = color ? `text-${color.toLowerCase()}-11` : "text-blue-11"
+
+  return (
+    <div className="mx-auto mb-20 flex w-[90vw] max-w-screen-lg flex-col gap-y-16">
+      <div className="flex flex-col gap-y-7">
+        <div className={cn("flex w-full items-end justify-between gap-x-2 border-b-2 pb-2", borderColorClass)}>
+          <h1>{title}</h1>
+          {type && <div className={cn("text-2xl", textColorClass)}>{type}</div>}
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/EntryDetailLayout.tsx
+++ b/apps/web/src/components/layout/EntryDetailLayout.tsx
@@ -7,9 +7,22 @@ export interface EntryDetailLayoutProps {
   color?: "BLUE" | "GREEN" | "AMBER"
 }
 
-export const EntryDetailLayout: FC<PropsWithChildren<EntryDetailLayoutProps>> = ({ children, title, type, color }) => {
-  const borderColorClass = color ? `border-${color.toLowerCase()}-8` : "border-blue-8"
-  const textColorClass = color ? `text-${color.toLowerCase()}-11` : "text-blue-11"
+export const EntryDetailLayout: FC<PropsWithChildren<EntryDetailLayoutProps>> = ({
+  children,
+  title,
+  type,
+  color = "BLUE",
+}) => {
+  const borderColorClass = cn({
+    "border-blue-8": color === "BLUE",
+    "border-green-8": color === "GREEN",
+    "border-amber-8": color === "AMBER",
+  })
+  const textColorClass = cn({
+    "text-blue-11": color === "BLUE",
+    "text-green-11": color === "GREEN",
+    "text-amber-11": color === "AMBER",
+  })
 
   return (
     <div className="mx-auto mb-20 flex w-[90vw] max-w-screen-lg flex-col gap-y-16">

--- a/apps/web/src/components/views/CommitteeView/index.tsx
+++ b/apps/web/src/components/views/CommitteeView/index.tsx
@@ -1,4 +1,4 @@
-import { Company, Event } from "@dotkomonline/types"
+import { Committee, Event } from "@dotkomonline/types"
 
 import { EventList } from "@/components/organisms/EventList"
 import { FC } from "react"
@@ -6,31 +6,24 @@ import { Icon } from "@dotkomonline/ui"
 import Image from "next/image"
 import { EntryDetailLayout } from "@/components/layout/EntryDetailLayout"
 
-interface CompanyViewProps {
-  company: Company
+interface CommitteeViewProps {
+  committee: Committee
   events?: Event[]
   isLoadingEvents: boolean
 }
 
-export const CompanyView: FC<CompanyViewProps> = (props: CompanyViewProps) => {
-  const { name, description, phone, email, website, location, type, image } = props.company
+export const CommitteeView: FC<CommitteeViewProps> = (props: CommitteeViewProps) => {
+  const { name, image, email, description } = props.committee
 
-  const icons = [
-    { icon: "material-symbols:location-on", text: location, href: null },
-    { icon: "ph:globe-bold", text: "Nettside", href: website },
-    { icon: "material-symbols:mail", text: email, href: `mailto:${email}` },
-    { icon: "material-symbols:phone-enabled", text: phone, href: `tel:${phone}` },
-  ]
+  const icons = [{ icon: "material-symbols:mail", text: email, href: `mailto:${email}` }]
 
   return (
-    <EntryDetailLayout title={name} type={type} color={"BLUE"}>
+    <EntryDetailLayout title={name} color={"BLUE"}>
       <div className="grid gap-x-12 gap-y-6 sm:grid-cols-[18rem_minmax(100px,_1fr)] md:grid-cols-[24rem_minmax(100px,_1fr)]">
         <div className="border-blue-7 flex h-fit flex-col gap-y-3 rounded-lg border-none sm:gap-y-2">
           {image && (
             <div className="relative mb-4 h-64 w-full overflow-hidden rounded-lg bg-[#fff]">
-              <a href={website} target="_blank" rel="noreferrer">
-                <Image src={image} alt="Company logo" fill style={{ objectFit: "contain" }} className="w-full" />
-              </a>
+              <Image src={image} alt="Committee logo" fill style={{ objectFit: "contain" }} className="w-full" />
             </div>
           )}
 
@@ -54,8 +47,8 @@ export const CompanyView: FC<CompanyViewProps> = (props: CompanyViewProps) => {
       {/* TODO: Redesign later */}
       <div className="mt-6 flex flex-col gap-x-16 gap-y-12 lg:flex-row">
         <EventList title={`Kommende arrangementer`} events={props.events} isLoading={props.isLoadingEvents} />
-        <EventList title={`Åpne jobbtilbud`} events={props.events} isLoading={props.isLoadingEvents} />{" "}
-        {/* TODO: Separate listings list later */}
+        <EventList title={`Tidligere arrangementer`} events={props.events} isLoading={props.isLoadingEvents} />{" "}
+        {/* TODO: Separate logic for earlier eventlist later */}
       </div>
     </EntryDetailLayout>
   )

--- a/apps/web/src/pages/committee/[id].tsx
+++ b/apps/web/src/pages/committee/[id].tsx
@@ -1,0 +1,63 @@
+import { GetStaticPaths, GetStaticPropsContext, InferGetStaticPropsType } from "next"
+import { appRouter, createContextInner, transformer } from "@dotkomonline/api"
+
+import { Committee } from "@dotkomonline/types"
+import { CommitteeView } from "@/components/views/CommitteeView"
+import { FC } from "react"
+import { createServerSideHelpers } from "@trpc/react-query/server"
+import { trpc } from "@/utils/trpc"
+import { useRouter } from "next/router"
+
+const CommitteePage: FC<InferGetStaticPropsType<typeof getStaticProps>> = (props) => {
+  const router = useRouter()
+  const { id } = router.query as { id: string }
+
+  const { data: eventsData, isLoading: isLoadingEvents } = trpc.event.allByCommittee.useQuery({ id })
+
+  return <CommitteeView committee={props.committee} events={eventsData} isLoadingEvents={isLoadingEvents} />
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const ssg = createServerSideHelpers({
+    router: appRouter,
+    ctx: await createContextInner({
+      auth: null,
+    }),
+    transformer: transformer,
+  })
+  const companies = await ssg.committee.all.fetch()
+  return {
+    paths: companies.map(({ id }) => ({ params: { id } })),
+    fallback: "blocking",
+  }
+}
+
+export const getStaticProps = async (ctx: GetStaticPropsContext<{ id: string }>) => {
+  const ssg = createServerSideHelpers({
+    router: appRouter,
+    ctx: await createContextInner({
+      auth: null,
+    }),
+    transformer: transformer,
+  })
+  const id = ctx.params?.id
+  if (!id) {
+    return { notFound: true }
+  }
+
+  let committee: Committee
+  try {
+    committee = await ssg.committee.get.fetch(id)
+  } catch (e) {
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      committee,
+    },
+    revalidate: 86400,
+  }
+}
+
+export default CommitteePage

--- a/apps/web/src/pages/committee/index.tsx
+++ b/apps/web/src/pages/committee/index.tsx
@@ -1,0 +1,20 @@
+import { trpc } from "@/utils/trpc"
+import Link from "next/link"
+
+const CommitteePage = () => {
+  const { data, isLoading } = trpc.committee.all.useQuery()
+
+  if (isLoading) return <p>Loading...</p>
+
+  return (
+    <ul className="text-blue-11 text-center text-2xl">
+      {data?.map((committee) => (
+        <li className="text-blue-11 hover:text-blue-9 cursor-pointer" key={committee.id}>
+          <Link href={`committee/${committee.id}`}>{committee.name}</Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default CommitteePage

--- a/packages/api/src/modules/event/event-repository.ts
+++ b/packages/api/src/modules/event/event-repository.ts
@@ -9,6 +9,7 @@ export interface EventRepository {
   create(data: EventWrite): Promise<Event | undefined>
   update(id: Event["id"], data: Omit<EventWrite, "id">): Promise<Event>
   getAll(take: number, cursor?: Cursor): Promise<Event[]>
+  getAllByCommitteeId(committeeId: string, take: number, cursor?: Cursor): Promise<Event[]>
   getById(id: string): Promise<Event | undefined>
 }
 
@@ -30,6 +31,16 @@ export class EventRepositoryImpl implements EventRepository {
   }
   async getAll(take: number, cursor?: Cursor): Promise<Event[]> {
     let query = this.db.selectFrom("event").selectAll().limit(take)
+    if (cursor) {
+      query = paginateQuery(query, cursor)
+    } else {
+      query = query.orderBy("createdAt", "desc").orderBy("id", "desc")
+    }
+    const events = await query.execute()
+    return events.map(mapToEvent)
+  }
+  async getAllByCommitteeId(committeeId: string, take: number, cursor?: Cursor): Promise<Event[]> {
+    let query = this.db.selectFrom("event").selectAll().where("committeeId", "=", committeeId).limit(take)
     if (cursor) {
       query = paginateQuery(query, cursor)
     } else {

--- a/packages/api/src/modules/event/event-router.ts
+++ b/packages/api/src/modules/event/event-router.ts
@@ -26,6 +26,11 @@ export const eventRouter = t.router({
     .query(({ input, ctx }) => {
       return ctx.eventCompanyService.getEventsByCompanyId(input.id, input.paginate.take, input.paginate.cursor)
     }),
+  allByCommittee: publicProcedure
+    .input(z.object({ id: z.string().uuid(), paginate: PaginateInputSchema }))
+    .query(({ input, ctx }) => {
+      return ctx.eventService.getEventsByCommitteeId(input.id, input.paginate.take, input.paginate.cursor)
+    }),
   get: publicProcedure.input(z.string().uuid()).query(({ input, ctx }) => {
     return ctx.eventService.getEventById(input)
   }),

--- a/packages/api/src/modules/event/event-service.ts
+++ b/packages/api/src/modules/event/event-service.ts
@@ -10,6 +10,7 @@ export interface EventService {
   updateEvent(id: Event["id"], payload: Omit<EventWrite, "id">): Promise<Event>
   getEventById(id: Event["id"]): Promise<Event>
   getEvents(take: number, cursor?: Cursor): Promise<Event[]>
+  getEventsByCommitteeId(committeeId: string, take: number, cursor?: Cursor): Promise<Event[]>
 
   createAttendance(eventId: Event["id"], attendanceWrite: AttendanceWrite): Promise<Attendance>
   listAttendance(eventId: Event["id"]): Promise<Attendance[]>
@@ -32,6 +33,15 @@ export class EventServiceImpl implements EventService {
 
   async getEvents(take: number, cursor?: Cursor): Promise<Event[]> {
     const events = await this.eventRepository.getAll(take, cursor)
+    return events
+  }
+
+  async getEventsByCommitteeId(
+    committeeId: string,
+    take: number,
+    cursor?: { id: string; createdAt: Date } | undefined
+  ): Promise<Event[]> {
+    const events = await this.eventRepository.getAllByCommitteeId(committeeId, take, cursor)
     return events
   }
 

--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -82,6 +82,14 @@ module.exports = {
     require("@tailwindcss/typography"),
     require("tailwindcss-animate"),
   ],
+  safelist: [
+    {
+      pattern: /text-(blue|amber|red|green|indigo)-11/,
+    },
+    {
+      pattern: /border-(blue|amber|red|green|indigo)-8/,
+    },
+  ],
 }
 
 // #FFCB47 #fab759

--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -82,14 +82,6 @@ module.exports = {
     require("@tailwindcss/typography"),
     require("tailwindcss-animate"),
   ],
-  safelist: [
-    {
-      pattern: /text-(blue|amber|red|green|indigo)-11/,
-    },
-    {
-      pattern: /border-(blue|amber|red|green|indigo)-8/,
-    },
-  ],
 }
 
 // #FFCB47 #fab759

--- a/packages/ow-db/src/migrations/0011_alter_committee.ts
+++ b/packages/ow-db/src/migrations/0011_alter_committee.ts
@@ -1,0 +1,14 @@
+import { Kysely } from "kysely"
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable("committee")
+    .addColumn("description", "text", (col) => col.notNull().defaultTo(""))
+    .addColumn("email", "text", (col) => col.notNull())
+    .addColumn("image", "text")
+    .execute()
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema.alterTable("committee").dropColumn("description").dropColumn("email").dropColumn("image").execute()
+}

--- a/packages/ow-db/src/types/committee.ts
+++ b/packages/ow-db/src/types/committee.ts
@@ -5,6 +5,9 @@ export interface CommitteeTable {
   createdAt: Generated<Date>
   updatedAt: Generated<Date>
   name: string
+  description: string
+  email: string | null
+  image: string | null
 }
 
 export interface EventCommitteeTable {

--- a/packages/types/src/committee.ts
+++ b/packages/types/src/committee.ts
@@ -4,6 +4,9 @@ export const CommitteeSchema = z.object({
   id: z.string().uuid(),
   createdAt: z.date(),
   name: z.string(),
+  description: z.string(),
+  email: z.string(),
+  image: z.string().nullable(),
 })
 
 export type Committee = z.infer<typeof CommitteeSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       sanity:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@18.0.0)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6)
+      styled-components:
+        specifier: ^5.2
+        version: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     devDependencies:
       '@sanity/eslint-config-studio':
         specifier: ^2.0.1
@@ -1740,7 +1743,7 @@ packages:
     resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -1929,12 +1932,6 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
-  /@babel/helper-module-imports@7.18.6:
-    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.4
-
   /@babel/helper-module-imports@7.21.4:
     resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
@@ -1961,13 +1958,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.21.4
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4(supports-color@5.5.0)
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2080,7 +2077,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4(supports-color@5.5.0)
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2118,7 +2115,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/parser@7.20.7:
     resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
@@ -2923,10 +2920,10 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.12)
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.20.2):
@@ -2937,10 +2934,10 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.2)
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.20.2):
@@ -3328,7 +3325,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -3349,7 +3346,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -3387,6 +3384,7 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
@@ -3680,7 +3678,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.21.4
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.4)
       '@babel/runtime': 7.20.1
       '@emotion/hash': 0.9.0
@@ -6857,7 +6855,7 @@ packages:
   /@storybook/csf-tools@7.0.0-beta.34:
     resolution: {integrity: sha512-UzERP8LWsFROyAZ0Cm8vBAvhCZJzGJCYc445u6dOoh+mfinSBGL0H+BwXhnhI3j4VGEltI+UtHjUzshzkE4niQ==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-beta.34
       fs-extra: 11.1.0
@@ -12706,7 +12704,7 @@ packages:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: true
 
   /json5@2.2.1:
@@ -14269,7 +14267,7 @@ packages:
       klona: 2.0.5
       loader-utils: 2.0.4
       postcss: 7.0.39
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       semver: 7.3.8
       webpack: 5.82.0(esbuild@0.16.17)
     dev: true
@@ -15451,15 +15449,6 @@ packages:
   /schema-utils@2.7.1:
     resolution: {integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==}
     engines: {node: '>= 8.9.0'}
-    dependencies:
-      '@types/json-schema': 7.0.11
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
-    dev: true
-
-  /schema-utils@3.1.1:
-    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
-    engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 6.12.6
@@ -16722,7 +16711,7 @@ packages:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.1
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
 
@@ -17312,7 +17301,7 @@ packages:
       - terser
     dev: true
 
-  /vite-node@0.28.5(@types/node@16.18.25):
+  /vite-node@0.28.5(@types/node@18.0.0):
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -17324,7 +17313,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 3.2.4(@types/node@16.18.25)
+      vite: 3.2.4(@types/node@18.0.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -17344,40 +17333,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /vite@3.2.4(@types/node@16.18.25):
-    resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 16.18.25
-      esbuild: 0.15.15
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@3.2.4(@types/node@18.0.0):
@@ -17583,7 +17538,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 16.18.25
+      '@types/node': 18.0.0
       '@vitest/expect': 0.28.5
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
@@ -17602,8 +17557,8 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.1
       tinyspy: 1.0.2
-      vite: 3.2.4(@types/node@16.18.25)
-      vite-node: 0.28.5(@types/node@16.18.25)
+      vite: 3.2.4(@types/node@18.0.0)
+      vite-node: 0.28.5(@types/node@18.0.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Changelog

- Adds a page to display info about a committee. Uses the same layout as the company page
- Extends the committee table with additional fields such as `description`, `email` and `image`

## How to test

1. Run migrations (I recommend `pnpm migrate-with-fixtures` for the latest fixture data)
2. Spin monoweb up and go to `/committee`

## Preview
![image](https://github.com/dotkom/monoweb/assets/40792825/01d64028-cfe5-42e0-b047-931b8ac0b4a9)

