### PR TITLE
Fixed users table title

### DIFF
--- a/apps/dashboard/src/app/user/page.tsx
+++ b/apps/dashboard/src/app/user/page.tsx
@@ -15,8 +15,8 @@ export default function UsersPage() {
   return (
     <Flex direction="column" p="md" gap="md">
       <div>
-        <Title>Komiteer</Title>
-        <Text>Oversikt over eksisterende komiteer</Text>
+        <Title>Brukere</Title>
+        <Text>Oversikt over brukere</Text>
       </div>
       {isLoading ? "Loading" : <UsersTable users={users} />}
     </Flex>


### PR DESCRIPTION
Users table was copy pasted without changing the title, this fixes it. 