### PR TITLE
Import vercel project into terraform configuration

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,0 +1,34 @@
+name: Terraform Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout source code
+
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - uses: terraform-linters/setup-tflint@v3
+        name: Setup TFLint
+        with:
+          tflint_version: v0.44.1
+
+      - name: Init TFLint
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run TFLint
+        run: tflint -f compact

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,30 @@
+# Infrastructure
+
+All infrastructure as code defined in Terraform lies here.
+
+Make sure you are using Terraform Workspaces to separate deployment environments. For a primer on workspaces in
+terraform, see https://developer.hashicorp.com/terraform/language/state/workspaces.
+
+Monoweb deploys to three environments:
+
+- dev
+- stg
+- prd
+
+Each environment maps to the environment with the same name in the Doppler workspace.
+
+## Tags
+
+To keep track of the origin of any AWS resource, ensure you are properly tagging the resources created. Each resource
+should have the `Project` tag set to `Monoweb`. Each resource should also have a `Module` tag set to the terraform module/
+project it originates from. There should also be an `Environment` tag that matches the deployment environment name.
+
+The easiest way to ensure this happens, is by adding the following `default_tags` to your AWS provider block:
+
+```terraform
+tags = {
+  Project     = "Monoweb"
+  Module      = "vercel"
+  Environment = terraform.workspace
+}
+```

--- a/infra/vercel/.terraform.lock.hcl
+++ b/infra/vercel/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.10.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:AgF54/79Nb/oQjbAMMewENSIa1PEScMn20Xa91hZR2g=",
+    "zh:24f8b40ba25521ec809906623ce1387542f3da848952167bc960663583a7b2c7",
+    "zh:3c12afbda4e8ed44ab8315d16bbba4329ef3f18ffe3c0d5ea456dd05472fa610",
+    "zh:4da2de97535c7fb51ede8ef9b6bd45c790005aec36daac4317a6175d2ff632fd",
+    "zh:5631fd3c02c5abe5e51a73bd77ddeaaf97b2d508845ea03bc1e5955b52d94706",
+    "zh:5bdef27b4e5b2dcd0661125fcc1e70826d545903b1e19bb8d28d2a0c812468d5",
+    "zh:7b7f6b3e00ad4b7bfaa9872388f7b8014d8c9a1fe5c3f9f57865535865727633",
+    "zh:935f7a599a3f55f69052b096491262d59787625ce5d52f729080328e5088e823",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a451a24f6675f8ad643a9b218cdb54c2af75a53d6a712daff46f64b81ec61032",
+    "zh:a5bcf820baefdc9f455222878f276a7f406a1092ac7b4c0cdbd6e588bff84847",
+    "zh:c9ab7b838a75bbcacc298658c1a04d1f0ee5935a928d821afcbe08c98cca7c5f",
+    "zh:d83855b6d66aaa03b1e66e03b7d0a4d1c9f992fce06f00011edde2a6ad6d91d6",
+    "zh:f1793e9a1e3ced98ca301ef1a294f46c06f77f6eb10f4d67ffef87ea60835421",
+    "zh:f366c99ddb16d75e07a687a60c015e8e2e0cdb593dea902385629571bd604859",
+    "zh:fb3ec60ea72144f480f495634c6d3e7a7638d7061a77c228a30768c1ae0b91f6",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "0.15.0"
+  constraints = "~> 0.4"
+  hashes = [
+    "h1:cKld8QrCykqizbLQKKO7QflGmxi31V7Zxan+VTtt+3Y=",
+    "zh:0485112496b989b0396f16ec0faf73664e5f922fe33761df4eadf27fab3b575b",
+    "zh:171bdda3290a6fd7377e444299d7ffe4b58abb69e96e67bab45f04ee4a03c515",
+    "zh:321d8039ed334a74ac288d8a1ea42f22957ce4027c76e9cfc2c0c84c426dac92",
+    "zh:45dcab1b6547622e96deedff38e172b3a6a256a01e4a464497705a3a692d4335",
+    "zh:530f8e97f0db8c895bffd8b21a23a2f26404cf50825c70c504e88e50250d12e2",
+    "zh:790d9488dd857d807ba194e031d83cdb84ac3505ba9ac539339dae9c4f62978c",
+    "zh:7f3a777939bc411ca9d259fddb41fdd6cebcb1e2f843c5c3d82e7d8fdf4fcf21",
+    "zh:824a0ce69382313dcad1523b7f26a937fbccf16800605d3d2f8d95c7ecc4e666",
+    "zh:a6561702cb08a2a2d3abd96c0921cbdfe96558442dacddd3f7d9aceff017f4db",
+    "zh:b6a3a09a2bab4b9a4b9edee7e157d2efeb093d6dfc2735172fdd686a80508217",
+    "zh:bc5e2ecb79d45f322a45df03184222b4bf5ecf3656485e0acc4e41e096925d61",
+    "zh:ce748e58799b280fd1beb9b307d13b3dbe0ec5f671fddae464523877bfb68c4d",
+    "zh:da09f2fbe05cd9a3354118a80a1bb3989c7a648dd768e06454c98a5db76e73c1",
+    "zh:dbb1c6cbb5aa58f8f0d186d9fc17fcccb2e368b6aee7d130835dd625ba56e1f3",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/infra/vercel/dns.tf
+++ b/infra/vercel/dns.tf
@@ -1,0 +1,11 @@
+data "aws_route53_zone" "online" {
+  name = "online.ntnu.no"
+}
+
+resource "aws_route53_record" "domain" {
+  name    = "${terraform.workspace}.monoweb.online.ntnu.no"
+  zone_id = data.aws_route53_zone.online.zone_id
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["cname.vercel-dns.com"]
+}

--- a/infra/vercel/main.tf
+++ b/infra/vercel/main.tf
@@ -1,0 +1,27 @@
+import {
+  to = vercel_project.monoweb
+  id = "prj_ojfJBhSht8MDWDP1gxeTRAa6vV75"
+}
+
+resource "vercel_project" "monoweb" {
+  name      = "monoweb"
+  framework = "nextjs"
+
+  git_repository = {
+    production_branch = "main"
+    type              = "github"
+    repo              = "dotkom/monoweb"
+  }
+
+  build_command  = "cd ../.. &&  pnpm build:web"
+  root_directory = "apps/web"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "vercel_project_domain" "domain" {
+  domain     = aws_route53_record.domain.name
+  project_id = vercel_project.monoweb.id
+}

--- a/infra/vercel/providers.tf
+++ b/infra/vercel/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "eu-north-1"
+
+  default_tags {
+    tags = {
+      Project     = "Monoweb"
+      Module      = "vercel"
+      Environment = terraform.workspace
+    }
+  }
+}
+
+provider "vercel" {
+  team = "dotkom"
+}

--- a/infra/vercel/terraform.tf
+++ b/infra/vercel/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+    bucket = "monoweb-infra"
+    key    = "vercel-monoweb"
+    region = "eu-north-1"
+  }
+
+  required_version = "~> 1.5.4"
+
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 0.4"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds terraform configuration and mini setup guide on how we use workspaces.

The branch is currently applied onto the `dev` workspace which means https://dev.monoweb.online.ntnu.no/ is publicly reachable.