### PR TITLE
Use self-released version of neon provider

### DIFF
--- a/infra/neon/.terraform.lock.hcl
+++ b/infra/neon/.terraform.lock.hcl
@@ -1,25 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/terraform-community-providers/neon" {
-  version     = "0.1.4"
-  constraints = "~> 0.1.4"
+provider "registry.terraform.io/dotkom/neon" {
+  version     = "0.1.1"
+  constraints = "~> 0.1.1"
   hashes = [
-    "h1:XE/UjIPhtxZFuAA+ymWMpSK0IkGjcZj3tbVk43ApaKs=",
-    "zh:04efe46a889c351d1be554ba5a3f182e324839b5b74fe6dcbe68e88692836385",
-    "zh:0ed90f16394f57c69e563fb28ea1f6547e2e2dc85a44bb314f68a2bd858d323e",
-    "zh:0eecb68d659ee93fcb33e1c2d69f5c6cbe50da82472d864f34b39da9ce6479b3",
-    "zh:23a7b664bb26a2aa6ef026bb3b93e8e6cd6573220598a5ceb6135aea2ae4d0b7",
-    "zh:39b4004cfc70ebc592601b0b639aabc652cc4164bedc282350a557a29c58f2c1",
-    "zh:43416d864425f8068f7ad994754a30728234f840604ad66fa7b89845d5ea6987",
-    "zh:4df277e035be2d16c3879265387fd05d7a394ebf80773d17a6203ad995ac61c1",
-    "zh:63fd5d3cd4baa4246d666c471ff0b4379172ae0db938adfcba0b25b9f213d60a",
-    "zh:67be14d55ace893b861bd269da3008a8c67ee6f2be712da90d743bd04eb2b34e",
-    "zh:6d4f79ac3169d68e26b5d77e00733f9893d3a551ef36efc99dc64b3e5e1c9551",
-    "zh:72757bf3f6c73da33699076a7125e7d95c739997487356c4592eb92c7fcf9ae1",
-    "zh:83fb62f69d27c8379c8f84ea5eccb12c1c486f77e4c29b13be6bdef0c313aa9e",
+    "h1:EQnK1qD2muAfygKiriFNilX8k3X1FjOAHJ9Upkc3PJs=",
+    "zh:0480f3b4a8e2458589200954b63eea06f233c47f6f349c9e5516af77b67c3b34",
+    "zh:0ba21253c5fe844cdbe353af1b45ee4fd58e917fa727830010a92c5148099d8c",
+    "zh:1430432a3775ce27327c823e7ea8fadc1f50cb144876e25d2fe81a3ef159d3f2",
+    "zh:21478aa5ba5fd4ce215160ebc1f45c8a95cd8d5f44aaf6cc5710bce3524d130d",
+    "zh:2c3d8bd26350bad86261736c6e3f9936d499cd50b6913afb9e6c38755ba7bc81",
+    "zh:40be30480bd00991d13df0884e361a64f346369f49110995b90833a0e45ee5f8",
+    "zh:7cf7669ca3292f9dab9100196063b3fedee8713131eb1c6838d73fa7cd48590f",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a458e83823679fe67cfd6f950de1eaf01efcde69c6c5c6e51228f051392f392d",
-    "zh:ce8222dfb532a605e02fb363c26f2a18377cc54256c26295127fd05f153bf69c",
+    "zh:94a86eb3262ed3cbf11a6b596166bbedf3b52984af96380b83423d3e98c0123a",
+    "zh:9eafefeccac17b728e4d350af39cfbe1ce2fbeba4fb3501130b9b26eec575604",
+    "zh:a9dda996bb9d99b40756200435e4413cf813b0d290e5428d8854817b1ae3bfc3",
+    "zh:b06988e27421ff70f39881925b1b9d5cebca99d87ae08591a72f92994af5969b",
+    "zh:bab1e8cb61314a56aaf3a82fb65e42761a29e89e21b439e4eefe49d12a2408e4",
+    "zh:fd8f4585fe4be9b6bbe9974f95e4fb723414b6c69f872a67cfa5d5c3f5f01fbf",
+    "zh:fdd8f024350506ecd0ff56bf9b741a448512b84b2074b3b746e3f6d63a4443f0",
   ]
 }

--- a/infra/neon/terraform.tf
+++ b/infra/neon/terraform.tf
@@ -9,8 +9,8 @@ terraform {
 
   required_providers {
     neon = {
-      source  = "terraform-community-providers/neon"
-      version = "~> 0.1.4"
+      source  = "dotkom/neon"
+      version = "~> 0.1.1"
     }
   }
 }


### PR DESCRIPTION
Should prevent any bad actors from messing with the original package, also means we manage our own release cycle for the neon provider

- https://registry.terraform.io/providers/dotkom/neon/latest
- https://github.com/dotkom/terraform-provider-neon