### PR TITLE
committee organizer

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
@@ -1,8 +1,8 @@
+import { EventEditSchema } from "@dotkomonline/types"
 import { FC } from "react"
-import { useEventWriteForm } from "../write-form"
-import { EventWriteSchema } from "@dotkomonline/types"
-import { useEventDetailsContext } from "./provider"
 import { useEditEventMutation } from "../../../../modules/event/mutations/use-edit-event-mutation"
+import { useEventWriteForm } from "../write-form"
+import { useEventDetailsContext } from "./provider"
 
 export const EventEditCard: FC = () => {
   const { event } = useEventDetailsContext()
@@ -10,8 +10,11 @@ export const EventEditCard: FC = () => {
   const FormComponent = useEventWriteForm({
     label: "Oppdater arrangement",
     onSubmit: (data) => {
-      const result = EventWriteSchema.required({ id: true }).parse(data)
-      edit.mutate(result)
+      const result = EventEditSchema.parse(data)
+      edit.mutate({
+        id: result.id,
+        changes: result,
+      })
     },
     defaultValues: { ...event },
   })

--- a/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
@@ -1,9 +1,8 @@
 import { EventEditSchema } from "@dotkomonline/types"
 import { FC } from "react"
 import { useEditEventMutation } from "../../../../modules/event/mutations/use-edit-event-mutation"
-import { useEventWriteForm } from "../write-form"
-import { useEventDetailsContext } from "./provider"
 import { useEventEditForm } from "../edit-form"
+import { useEventDetailsContext } from "./provider"
 
 export const EventEditCard: FC = () => {
   const { event } = useEventDetailsContext()

--- a/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/[id]/edit-card.tsx
@@ -3,11 +3,12 @@ import { FC } from "react"
 import { useEditEventMutation } from "../../../../modules/event/mutations/use-edit-event-mutation"
 import { useEventWriteForm } from "../write-form"
 import { useEventDetailsContext } from "./provider"
+import { useEventEditForm } from "../edit-form"
 
 export const EventEditCard: FC = () => {
   const { event } = useEventDetailsContext()
   const edit = useEditEventMutation()
-  const FormComponent = useEventWriteForm({
+  const FormComponent = useEventEditForm({
     label: "Oppdater arrangement",
     onSubmit: (data) => {
       const result = EventEditSchema.parse(data)

--- a/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
@@ -1,3 +1,5 @@
+import { EventEdit, EventEditSchema } from "@dotkomonline/types"
+import { useCommitteeAllQuery } from "../../../modules/committee/queries/use-committee-all-query"
 import {
   createCheckboxInput,
   createDateTimeInput,
@@ -6,10 +8,8 @@ import {
   createTextInput,
   useFormBuilder,
 } from "../../form"
-import { useCommitteeAllQuery } from "../../../modules/committee/queries/use-committee-all-query"
-import { EventEdit, EventEditSchema } from "@dotkomonline/types"
 
-const EVENT_FORM_DEFAULT_VALUES: Partial<EventEdit | EventEdit> = {
+const EVENT_FORM_DEFAULT_VALUES: Partial<EventEdit> = {
   start: new Date(),
   end: new Date(),
   description: "Mer informasjon og påmelding kommer når arrangementet nærmer seg!",

--- a/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
@@ -1,0 +1,100 @@
+import {
+  createCheckboxInput,
+  createDateTimeInput,
+  createSelectInput,
+  createTextareaInput,
+  createTextInput,
+  useFormBuilder,
+} from "../../form"
+import { useCommitteeAllQuery } from "../../../modules/committee/queries/use-committee-all-query"
+import { EventEdit, EventEditSchema } from "@dotkomonline/types"
+
+const EVENT_FORM_DEFAULT_VALUES: Partial<EventEdit | EventEdit> = {
+  start: new Date(),
+  end: new Date(),
+  description: "Mer informasjon og påmelding kommer når arrangementet nærmer seg!",
+  imageUrl: null,
+  location: null,
+  subtitle: null,
+  waitlist: null,
+  committeeId: null,
+}
+
+type UseEventEditFormProps = {
+  onSubmit: (data: EventEdit) => void
+  defaultValues?: Partial<EventEdit>
+  label?: string
+}
+
+export const useEventEditForm = ({
+  onSubmit,
+  label = "Opprett arrangement",
+  defaultValues = EVENT_FORM_DEFAULT_VALUES,
+}: UseEventEditFormProps) => {
+  const { committees } = useCommitteeAllQuery()
+  return useFormBuilder({
+    schema: EventEditSchema,
+    defaultValues,
+    onSubmit,
+    label,
+    fields: {
+      title: createTextInput({
+        label: "Arrangementnavn",
+        placeholder: "Åre 2024",
+        withAsterisk: true,
+      }),
+      subtitle: createTextInput({
+        label: "Ingress",
+        placeholder:
+          "Tidspunktet for Åreturen 2023 er endelig satt, og det er bare å gjøre seg klar for ÅREts høydepunkt!!",
+      }),
+      description: createTextareaInput({
+        label: "Beskrivelse",
+        placeholder: "Mer informasjon og påmelding kommer når arrangementet nærmer seg!",
+      }),
+      location: createTextInput({
+        label: "Sted",
+        placeholder: "Åre",
+      }),
+      imageUrl: createTextInput({
+        label: "Bildelenke",
+      }),
+      start: createDateTimeInput({
+        label: "Starttidspunkt",
+        withAsterisk: true,
+      }),
+      end: createDateTimeInput({
+        label: "Sluttidspunkt",
+        withAsterisk: true,
+      }),
+      committeeId: createSelectInput({
+        label: "Arrangør",
+        placeholder: "Arrkom",
+        data: committees.map((committee) => ({ value: committee.id, label: committee.name })),
+      }),
+      status: createSelectInput({
+        label: "Event status",
+        placeholder: "Velg en",
+        data: [
+          { value: "TBA", label: "TBA" },
+          { value: "PUBLIC", label: "Public" },
+          { value: "NO_LIMIT", label: "No Limit" },
+          { value: "ATTENDANCE", label: "Attendance" },
+        ],
+        withAsterisk: true,
+      }),
+      type: createSelectInput({
+        label: "Type",
+        placeholder: "Velg en",
+        data: [
+          { value: "SOCIAL", label: "Sosialt" },
+          { value: "COMPANY", label: "Bedriftsarrangement" },
+        ],
+        withAsterisk: true,
+      }),
+      public: createCheckboxInput({
+        label: "Offentlig arrangement",
+      }),
+    },
+  })
+}

--- a/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/edit-form.tsx
@@ -3,6 +3,7 @@ import { useCommitteeAllQuery } from "../../../modules/committee/queries/use-com
 import {
   createCheckboxInput,
   createDateTimeInput,
+  createMultipleSelectInput,
   createSelectInput,
   createTextareaInput,
   createTextInput,
@@ -17,7 +18,6 @@ const EVENT_FORM_DEFAULT_VALUES: Partial<EventEdit> = {
   location: null,
   subtitle: null,
   waitlist: null,
-  committeeId: null,
 }
 
 type UseEventEditFormProps = {
@@ -67,7 +67,7 @@ export const useEventEditForm = ({
         label: "Sluttidspunkt",
         withAsterisk: true,
       }),
-      committeeId: createSelectInput({
+      committeeOrganizers: createMultipleSelectInput({
         label: "Arrangør",
         placeholder: "Arrkom",
         data: committees.map((committee) => ({ value: committee.id, label: committee.name })),

--- a/apps/dashboard/src/app/(dashboard)/event/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/page.tsx
@@ -39,16 +39,21 @@ export default function EventPage() {
         header: () => "Startdato",
         cell: (info) => formatDate(info.getValue()),
       }),
-      columnHelper.accessor("committeeId", {
+      columnHelper.accessor("committeeOrganizers", {
         header: () => "Arrangør",
         cell: (info) => {
-          const match = committees.find((committee) => committee.id === info.getValue()) ?? null
-          if (match !== null) {
-            return (
-              <Anchor size="sm" href={`/committee/${match.id}`}>
-                {match.name}
+          console.log(info.getValue())
+          const matches = info.getValue()?.map((id) => committees.find((c) => c.id === id))
+          if (matches) {
+            return matches.map((match, i) => (
+              <Anchor size="sm" href={`/committee/${match?.id}`}>
+                {match?.name}
+                {i < matches.length - 1 ? ", " : ""}
               </Anchor>
-            )
+            ))
+            // <Anchor size="sm" href={`/committee/${match.id}`}>
+            //   {match.name}
+            // </Anchor>
           }
           return "Ukjent arrangør"
         },

--- a/apps/dashboard/src/app/(dashboard)/event/write-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/event/write-form.tsx
@@ -1,6 +1,7 @@
 import {
   createCheckboxInput,
   createDateTimeInput,
+  createMultipleSelectInput,
   createSelectInput,
   createTextareaInput,
   createTextInput,
@@ -17,7 +18,7 @@ const EVENT_FORM_DEFAULT_VALUES: Partial<EventWrite> = {
   location: null,
   subtitle: null,
   waitlist: null,
-  committeeId: null,
+  committeeOrganizers: [],
 }
 
 type UseEventWriteFormProps = {
@@ -67,7 +68,7 @@ export const useEventWriteForm = ({
         label: "Sluttidspunkt",
         withAsterisk: true,
       }),
-      committeeId: createSelectInput({
+      committeeOrganizers: createMultipleSelectInput({
         label: "Arrangør",
         placeholder: "Arrkom",
         data: committees.map((committee) => ({ value: committee.id, label: committee.name })),

--- a/apps/dashboard/src/app/form.tsx
+++ b/apps/dashboard/src/app/form.tsx
@@ -125,7 +125,7 @@ function entriesOf<T extends Record<string, unknown>, K extends keyof T & string
 }
 
 type FormBuilderOptions<T extends z.ZodRawShape> = {
-  schema: z.ZodObject<T>
+  schema: z.ZodObject<T> | z.ZodEffects<z.ZodObject<T>>
   fields: Partial<{
     [K in keyof z.infer<z.ZodObject<T>>]: InputProducerResult<z.infer<z.ZodObject<T>>>
   }>

--- a/apps/dashboard/src/app/form.tsx
+++ b/apps/dashboard/src/app/form.tsx
@@ -5,6 +5,8 @@ import {
   Checkbox,
   CheckboxProps,
   Flex,
+  MultiSelect,
+  MultiSelectProps,
   Select,
   SelectProps,
   Textarea,
@@ -34,6 +36,27 @@ type InputFieldContext<T extends FieldValues> = {
   defaultValue: FieldValue<T>
 }
 type InputProducerResult<F extends FieldValues> = FC<InputFieldContext<F>>
+
+export function createMultipleSelectInput<F extends FieldValues>({
+  ...props
+}: Omit<MultiSelectProps, "error">): InputProducerResult<F> {
+  return function FormSelectInput({ name, state, control }) {
+    return (
+      <Controller
+        control={control}
+        name={name}
+        render={({ field }) => (
+          <MultiSelect
+            {...props}
+            error={state.errors[name] && <ErrorMessage errors={state.errors} name={name} />}
+            onChange={field.onChange}
+            value={field.value}
+          />
+        )}
+      />
+    )
+  }
+}
 
 export function createSelectInput<F extends FieldValues>({
   ...props

--- a/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
+++ b/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
@@ -1,4 +1,3 @@
-import { EventWriteSchema } from "@dotkomonline/types"
 import { ContextModalProps, modals } from "@mantine/modals"
 import { FC } from "react"
 import { useEventWriteForm } from "../../../app/(dashboard)/event/write-form"

--- a/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
+++ b/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
@@ -1,14 +1,16 @@
-import { FC } from "react"
-import { useCreateEventMutation } from "../mutations/use-create-event-mutation"
-import { useEventWriteForm } from "../../../app/(dashboard)/event/write-form"
+import { EventWriteSchema } from "@dotkomonline/types"
 import { ContextModalProps, modals } from "@mantine/modals"
+import { FC } from "react"
+import { useEventWriteForm } from "../../../app/(dashboard)/event/write-form"
+import { useCreateEventMutation } from "../mutations/use-create-event-mutation"
 
 export const CreateEventModal: FC<ContextModalProps> = ({ context, id }) => {
   const close = () => context.closeModal(id)
   const create = useCreateEventMutation()
   const FormComponent = useEventWriteForm({
     onSubmit: (data) => {
-      create.mutate(data)
+      const result = EventWriteSchema.parse(data)
+      create.mutate(result)
       close()
     },
   })

--- a/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
+++ b/apps/dashboard/src/modules/event/modals/create-event-modal.tsx
@@ -9,8 +9,7 @@ export const CreateEventModal: FC<ContextModalProps> = ({ context, id }) => {
   const create = useCreateEventMutation()
   const FormComponent = useEventWriteForm({
     onSubmit: (data) => {
-      const result = EventWriteSchema.parse(data)
-      create.mutate(result)
+      create.mutate(data)
       close()
     },
   })

--- a/apps/db-migrator/src/fixture.ts
+++ b/apps/db-migrator/src/fixture.ts
@@ -9,6 +9,7 @@ import { marks } from "./fixtures/mark"
 import { productPaymentProviders } from "./fixtures/product-payment-provider"
 import { products } from "./fixtures/product"
 import { users } from "./fixtures/user"
+import { committeeOrganizers } from "./fixtures/committee-organizer"
 
 export const runFixtures = async () => {
   await db
@@ -74,7 +75,6 @@ export const runFixtures = async () => {
         subtitle: (eb) => eb.ref("excluded.subtitle"),
         imageUrl: (eb) => eb.ref("excluded.imageUrl"),
         location: (eb) => eb.ref("excluded.location"),
-        committeeId: (eb) => eb.ref("excluded.committeeId"),
         waitlist: (eb) => eb.ref("excluded.waitlist"),
       })
     )
@@ -157,5 +157,12 @@ export const runFixtures = async () => {
     .insertInto("productPaymentProvider")
     .values(productPaymentProviders)
     .onConflict((oc) => oc.columns(["productId", "paymentProviderId"]).doNothing())
+    .execute()
+
+  await db
+    .insertInto("committeeOrganizer")
+    .values(committeeOrganizers)
+    .returning("committeeId")
+    .onConflict((oc) => oc.columns(["committeeId", "eventId"]).doNothing())
     .execute()
 }

--- a/apps/db-migrator/src/fixtures/committee-organizer.ts
+++ b/apps/db-migrator/src/fixtures/committee-organizer.ts
@@ -1,0 +1,17 @@
+import { Database } from "@dotkomonline/db"
+import { Insertable } from "kysely"
+
+export const committeeOrganizers: Insertable<Database["committeeOrganizer"]>[] = [
+  {
+    eventId: "abdcc9c3-6d6a-4767-8d8a-608d8c091eb1",
+    committeeId: "060bc7ee-d9ac-43bb-bc97-178deceb42cc",
+  },
+  {
+    eventId: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+    committeeId: "23361509-94d5-4123-81ca-fd2795223942",
+  },
+  {
+    eventId: "395fa3ec-2e2b-4cd6-829b-0388761b6917",
+    committeeId: "d19021fb-2f10-4b5c-92dd-098fe5cee4d7",
+  },
+]

--- a/apps/db-migrator/src/fixtures/event.ts
+++ b/apps/db-migrator/src/fixtures/event.ts
@@ -17,7 +17,6 @@ export const events: Insertable<Database["event"]>[] = [
     imageUrl:
       "https://online.ntnu.no/_next/image?url=https%3A%2F%2Fonlineweb4-prod.s3.eu-north-1.amazonaws.com%2Fmedia%2Fimages%2Fresponsive%2Flg%2Fdf32b932-f4c4-4a49-9129-a8ab528b1e33.jpeg&w=1200&q=75",
     location: "Hovedbygget",
-    committeeId: null,
     waitlist: null,
   },
   {
@@ -35,7 +34,6 @@ export const events: Insertable<Database["event"]>[] = [
     imageUrl:
       "https://online.ntnu.no/_next/image?url=https%3A%2F%2Fonlineweb4-prod.s3.eu-north-1.amazonaws.com%2Fmedia%2Fimages%2Fresponsive%2Flg%2Fdf32b932-f4c4-4a49-9129-a8ab528b1e33.jpeg&w=1200&q=75",
     location: "Åre, Sverige",
-    committeeId: "d19021fb-2f10-4b5c-92dd-098fe5cee4d7",
     waitlist: null,
   },
 ]

--- a/packages/core/src/modules/committee/committee-repository.ts
+++ b/packages/core/src/modules/committee/committee-repository.ts
@@ -4,7 +4,7 @@ import { Kysely, Selectable } from "kysely"
 
 import { Database } from "@dotkomonline/db"
 
-const mapToCommittee = (payload: Selectable<Database["committee"]>): Committee => {
+export const mapToCommittee = (payload: Selectable<Database["committee"]>): Committee => {
   return CommitteeSchema.parse(payload)
 }
 

--- a/packages/core/src/modules/core.ts
+++ b/packages/core/src/modules/core.ts
@@ -28,6 +28,8 @@ import { MarkServiceImpl } from "./mark/mark-service"
 import { PersonalMarkServiceImpl } from "./mark/personal-mark-service"
 import { CompanyEventRepositoryImpl } from "./company/company-event-repository"
 import { CompanyEventServiceImpl } from "./company/company-event-service"
+import { CommitteeOrganizerServiceImpl } from "./event/committee-organizer-service"
+import { CommitteeOrganizerRepositoryImpl } from "./event/committee-organizer-repository"
 
 export type ServiceLayer = Awaited<ReturnType<typeof createServiceLayer>>
 
@@ -41,6 +43,7 @@ export const createServiceLayer = async ({ db }: ServerLayerOptions) => {
   const companyRepository = new CompanyRepositoryImpl(db)
   const companyEventRepository = new CompanyEventRepositoryImpl(db)
   const eventCompanyRepository = new EventCompanyRepositoryImpl(db)
+  const committeeOrganizerRepository = new CommitteeOrganizerRepositoryImpl(db)
   const attendanceRepository = new AttendanceRepositoryImpl(db)
   const userRepository = new UserRepositoryImpl(db)
   const productRepository = new ProductRepositoryImpl(db)
@@ -58,6 +61,7 @@ export const createServiceLayer = async ({ db }: ServerLayerOptions) => {
     notificationPermissionsRepository
   )
   const eventService = new EventServiceImpl(eventRepository, attendanceRepository)
+  const committeeOrganizerService = new CommitteeOrganizerServiceImpl(committeeOrganizerRepository)
   const attendanceService = new AttendanceServiceImpl(attendanceRepository)
   const committeeService = new CommitteeServiceImpl(committeeRepository)
   const companyService = new CompanyServiceImpl(companyRepository)
@@ -94,5 +98,6 @@ export const createServiceLayer = async ({ db }: ServerLayerOptions) => {
     refundRequestService,
     markService,
     personalMarkService,
+    committeeOrganizerService,
   }
 }

--- a/packages/core/src/modules/event/committee-organizer-repository.ts
+++ b/packages/core/src/modules/event/committee-organizer-repository.ts
@@ -1,0 +1,32 @@
+import { Cursor, paginateQuery } from "../../utils/db-utils"
+import { Kysely, Selectable } from "kysely"
+
+import { Database } from "@dotkomonline/db"
+import { CommiteeOrganizerSchema, CommitteeOrganizer } from "../../../../types/src/committee-event-organizer"
+import { Committee, Event } from "@dotkomonline/types"
+import { mapToCommittee } from "../committee/committee-repository"
+
+export const mapToCommitteeOrganizer = (payload: Selectable<Database["committeeOrganizer"]>): CommitteeOrganizer => {
+  return CommiteeOrganizerSchema.parse(payload)
+}
+
+export interface CommitteeOrganizerRepository {
+  getAllCommitteesByEventId(eventId: Event["id"], take: number, cursor?: Cursor): Promise<Committee[]>
+  // addToEvent(eventId: Event["id"], committeeId: Committee["id"]): Promise<CommitteeOrganizer>
+  // removeFromEvent(eventId: Event["id"], committeeId: Committee["id"]): Promise<CommitteeOrganizer>
+}
+
+export class CommitteeOrganizerRepositoryImpl implements CommitteeOrganizerRepository {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  async getAllCommitteesByEventId(eventId: Event["id"]): Promise<Committee[]> {
+    let query = this.db
+      .selectFrom("committee")
+      .leftJoin("committeeOrganizer", "committeeOrganizer.committeeId", "committee.id")
+      .selectAll("committee")
+      .where("eventId", "=", eventId)
+
+    const committees = await query.execute()
+    return committees.map(mapToCommittee)
+  }
+}

--- a/packages/core/src/modules/event/committee-organizer-service.ts
+++ b/packages/core/src/modules/event/committee-organizer-service.ts
@@ -1,0 +1,15 @@
+import { Committee, Event } from "@dotkomonline/types"
+import { CommitteeOrganizerRepositoryImpl } from "./committee-organizer-repository"
+
+export interface CommitteeOrganizerService {
+  getCommitteesForEvent(eventId: Event["id"]): Promise<Committee[]>
+}
+
+export class CommitteeOrganizerServiceImpl implements CommitteeOrganizerService {
+  constructor(private readonly committeeOrganizerRepository: CommitteeOrganizerRepositoryImpl) {}
+
+  async getCommitteesForEvent(eventId: Event["id"]): Promise<Committee[]> {
+    const committees = await this.committeeOrganizerRepository.getAllCommitteesByEventId(eventId)
+    return committees
+  }
+}

--- a/packages/core/src/modules/event/event-company-repository.ts
+++ b/packages/core/src/modules/event/event-company-repository.ts
@@ -9,7 +9,6 @@ export interface EventCompanyRepository {
   createCompany: (id: Event["id"], company: Company["id"]) => Promise<void>
   deleteCompany: (id: Event["id"], company: Company["id"]) => Promise<void>
   getCompaniesByEventId: (id: Event["id"], take: number, cursor?: Cursor) => Promise<Company[]>
-  getEventsByCompanyId: (id: Company["id"], take: number, cursor?: Cursor) => Promise<Event[]>
 }
 
 export class EventCompanyRepositoryImpl implements EventCompanyRepository {
@@ -49,21 +48,5 @@ export class EventCompanyRepositoryImpl implements EventCompanyRepository {
     }
     const companies = await query.execute()
     return companies.map(mapToCompany)
-  }
-
-  async getEventsByCompanyId(companyId: string, take: number, cursor?: Cursor): Promise<Event[]> {
-    let query = this.db
-      .selectFrom("event")
-      .leftJoin("eventCompany", "eventCompany.eventId", "event.id")
-      .selectAll("event")
-      .where("eventCompany.companyId", "=", companyId)
-      .limit(take)
-    if (cursor) {
-      query = paginateQuery(query, cursor)
-    } else {
-      query = query.orderBy("createdAt", "desc").orderBy("id", "desc")
-    }
-    const events = await query.execute()
-    return events.map(mapToEvent)
   }
 }

--- a/packages/core/src/modules/event/event-repository.ts
+++ b/packages/core/src/modules/event/event-repository.ts
@@ -3,7 +3,14 @@ import { Event, EventSchema, EventWrite } from "@dotkomonline/types"
 import { Kysely, Selectable } from "kysely"
 import { Cursor, paginateQuery } from "../../utils/db-utils"
 
-export const mapToEvent = (data: Selectable<Database["event"]>) => EventSchema.parse(data)
+export const mapToEvent = (data: Selectable<Database["event"]>, committeesIds?: string[]) => {
+  if (!committeesIds) committeesIds = []
+  let eventWithCommittees = {
+    ...data,
+    committeeOrganizers: committeesIds,
+  }
+  return EventSchema.parse(eventWithCommittees)
+}
 
 export interface EventRepository {
   create(data: EventWrite): Promise<Event | undefined>
@@ -17,7 +24,19 @@ export class EventRepositoryImpl implements EventRepository {
   constructor(private readonly db: Kysely<Database>) {}
 
   async create(data: EventWrite): Promise<Event | undefined> {
-    const event = await this.db.insertInto("event").values(data).returningAll().executeTakeFirstOrThrow()
+    const { committeeOrganizers, ...eventInsert } = data
+
+    const event = await this.db.insertInto("event").values(eventInsert).returningAll().executeTakeFirstOrThrow()
+
+    if (committeeOrganizers) {
+      for (const committeeOrganizer of committeeOrganizers) {
+        await this.db
+          .insertInto("committeeOrganizer")
+          .values({ eventId: event.id, committeeId: committeeOrganizer })
+          .execute()
+      }
+    }
+
     return mapToEvent(event)
   }
   async update(id: Event["id"], data: Omit<EventWrite, "id">): Promise<Event> {
@@ -37,20 +56,57 @@ export class EventRepositoryImpl implements EventRepository {
       query = query.orderBy("createdAt", "desc").orderBy("id", "desc")
     }
     const events = await query.execute()
-    return events.map(mapToEvent)
+
+    const result: Event[] = []
+    for (const event of events) {
+      const committeeOrganizers = await this.db
+        .selectFrom("committeeOrganizer")
+        .selectAll()
+        .where("eventId", "=", event.id)
+        .execute()
+
+      result.push(
+        mapToEvent(
+          event,
+          committeeOrganizers.map((co) => co.committeeId)
+        )
+      )
+    }
+
+    return result
   }
   async getAllByCommitteeId(committeeId: string, take: number, cursor?: Cursor): Promise<Event[]> {
-    let query = this.db.selectFrom("event").selectAll().where("committeeId", "=", committeeId).limit(take)
+    // let query = this.db.selectFrom("event").selectAll().where("committeeId", "=", committeeId).limit(take)
+
+    let query = this.db
+      .selectFrom("committeeOrganizer")
+      .where("committeeId", "=", committeeId)
+      .innerJoin("event", "event.id", "committeeOrganizer.eventId")
+      .selectAll("event")
+      .limit(take)
+
     if (cursor) {
       query = paginateQuery(query, cursor)
     } else {
       query = query.orderBy("createdAt", "desc").orderBy("id", "desc")
     }
     const events = await query.execute()
-    return events.map(mapToEvent)
+    return events.map((e) => mapToEvent(e, []))
   }
   async getById(id: string): Promise<Event | undefined> {
     const event = await this.db.selectFrom("event").selectAll().where("id", "=", id).executeTakeFirst()
-    return event ? mapToEvent(event) : undefined
+
+    const committeeOrganizers = await this.db
+      .selectFrom("committeeOrganizer")
+      .selectAll()
+      .where("eventId", "=", id)
+      .execute()
+
+    return event
+      ? mapToEvent(
+          event,
+          committeeOrganizers.map((o) => o.committeeId)
+        )
+      : undefined
   }
 }

--- a/packages/db/src/db.generated.d.ts
+++ b/packages/db/src/db.generated.d.ts
@@ -1,206 +1,202 @@
-import type { ColumnType } from "kysely"
+import type { ColumnType } from "kysely";
 
-export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA"
+export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA";
 
-export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL"
+export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL";
 
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>
+  : ColumnType<T, T | undefined, T>;
 
-export type Int8 = ColumnType<string, string | number | bigint, string | number | bigint>
+export type PaymentProvider = "STRIPE";
 
-export type PaymentProvider = "STRIPE"
+export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID";
 
-export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID"
+export type ProductType = "EVENT";
 
-export type ProductType = "EVENT"
+export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED";
 
-export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED"
-
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export interface Attendance {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  start: Timestamp
-  end: Timestamp
-  deregisterDeadline: Timestamp
-  limit: number
-  eventId: string | null
-  min: Generated<number>
-  max: Generated<number>
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  start: Timestamp;
+  end: Timestamp;
+  deregisterDeadline: Timestamp;
+  limit: number;
+  eventId: string | null;
+  min: Generated<number>;
+  max: Generated<number>;
 }
 
 export interface Attendee {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  userId: string | null
-  attendanceId: string | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  userId: string | null;
+  attendanceId: string | null;
 }
 
 export interface Committee {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  name: string
-  description: Generated<string>
-  email: Generated<string>
-  image: string | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  name: string;
+  description: Generated<string>;
+  email: Generated<string>;
+  image: string | null;
+}
+
+export interface CommitteeOrganizer {
+  committeeId: string;
+  eventId: string;
 }
 
 export interface Company {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  name: string
-  description: string | null
-  phone: string | null
-  email: string | null
-  website: string | null
-  location: string | null
-  type: string | null
-  image: string | null
-}
-
-export interface DrizzleDrizzleMigrations {
-  id: Generated<number>
-  hash: string
-  createdAt: Int8 | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  name: string;
+  description: string;
+  phone: string | null;
+  email: string;
+  website: string;
+  location: string | null;
+  type: string | null;
+  image: string | null;
 }
 
 export interface Event {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  title: string
-  start: Timestamp
-  end: Timestamp
-  status: EventStatus
-  public: boolean
-  description: string | null
-  subtitle: string | null
-  imageUrl: string | null
-  location: string | null
-  committeeId: string | null
-  type: EventType | null
-  waitlist: string | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  title: string;
+  start: Timestamp;
+  end: Timestamp;
+  status: EventStatus;
+  public: boolean;
+  description: string | null;
+  subtitle: string | null;
+  imageUrl: string | null;
+  location: string | null;
+  type: EventType | null;
+  waitlist: string | null;
 }
 
 export interface EventCommittee {
-  eventId: string
-  committeeId: string
+  eventId: string;
+  committeeId: string;
 }
 
 export interface EventCompany {
-  eventId: string
-  companyId: string
+  eventId: string;
+  companyId: string;
 }
 
 export interface Mark {
-  id: Generated<string>
-  updatedAt: Generated<Timestamp>
-  title: string
-  createdAt: Timestamp
-  category: string
-  details: string | null
-  duration: number
+  id: Generated<string>;
+  updatedAt: Generated<Timestamp>;
+  title: string;
+  createdAt: Timestamp;
+  category: string;
+  details: string | null;
+  duration: number;
 }
 
 export interface NotificationPermissions {
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  userId: string
-  applications: Generated<boolean>
-  newArticles: Generated<boolean>
-  standardNotifications: Generated<boolean>
-  groupMessages: Generated<boolean>
-  markRulesUpdates: Generated<boolean>
-  receipts: Generated<boolean>
-  registrationByAdministrator: Generated<boolean>
-  registrationStart: Generated<boolean>
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  userId: string;
+  applications: Generated<boolean>;
+  newArticles: Generated<boolean>;
+  standardNotifications: Generated<boolean>;
+  groupMessages: Generated<boolean>;
+  markRulesUpdates: Generated<boolean>;
+  receipts: Generated<boolean>;
+  registrationByAdministrator: Generated<boolean>;
+  registrationStart: Generated<boolean>;
 }
 
 export interface OwUser {
-  createdAt: Generated<Timestamp>
-  id: Generated<string>
-  cognitoSub: string
+  createdAt: Generated<Timestamp>;
+  id: Generated<string>;
+  cognitoSub: string;
 }
 
 export interface Payment {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  productId: string | null
-  userId: string | null
-  paymentProviderId: string
-  paymentProviderSessionId: string
-  status: PaymentStatus
-  paymentProviderOrderId: string | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  productId: string | null;
+  userId: string | null;
+  paymentProviderId: string;
+  paymentProviderSessionId: string;
+  status: PaymentStatus;
+  paymentProviderOrderId: string | null;
 }
 
 export interface PersonalMark {
-  markId: string
-  userId: string
+  markId: string;
+  userId: string;
 }
 
 export interface PrivacyPermissions {
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  userId: string
-  profileVisible: Generated<boolean>
-  usernameVisible: Generated<boolean>
-  emailVisible: Generated<boolean>
-  phoneVisible: Generated<boolean>
-  addressVisible: Generated<boolean>
-  attendanceVisible: Generated<boolean>
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  userId: string;
+  profileVisible: Generated<boolean>;
+  usernameVisible: Generated<boolean>;
+  emailVisible: Generated<boolean>;
+  phoneVisible: Generated<boolean>;
+  addressVisible: Generated<boolean>;
+  attendanceVisible: Generated<boolean>;
 }
 
 export interface Product {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  type: ProductType
-  objectId: string | null
-  amount: number
-  deletedAt: Timestamp | null
-  isRefundable: Generated<boolean>
-  refundRequiresApproval: Generated<boolean>
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  type: ProductType;
+  objectId: string | null;
+  amount: number;
+  deletedAt: Timestamp | null;
+  isRefundable: Generated<boolean>;
+  refundRequiresApproval: Generated<boolean>;
 }
 
 export interface ProductPaymentProvider {
-  productId: string
-  paymentProvider: PaymentProvider
-  paymentProviderId: string
+  productId: string;
+  paymentProvider: PaymentProvider;
+  paymentProviderId: string;
 }
 
 export interface RefundRequest {
-  id: Generated<string>
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  paymentId: string | null
-  userId: string | null
-  reason: string
-  status: Generated<RefundRequestStatus>
-  handledBy: string | null
+  id: Generated<string>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  paymentId: string | null;
+  userId: string | null;
+  reason: string;
+  status: Generated<RefundRequestStatus>;
+  handledBy: string | null;
 }
 
 export interface DB {
-  attendance: Attendance
-  attendee: Attendee
-  committee: Committee
-  company: Company
-  "drizzle.DrizzleMigrations": DrizzleDrizzleMigrations
-  event: Event
-  eventCommittee: EventCommittee
-  eventCompany: EventCompany
-  mark: Mark
-  notificationPermissions: NotificationPermissions
-  owUser: OwUser
-  payment: Payment
-  personalMark: PersonalMark
-  privacyPermissions: PrivacyPermissions
-  product: Product
-  productPaymentProvider: ProductPaymentProvider
-  refundRequest: RefundRequest
+  attendance: Attendance;
+  attendee: Attendee;
+  committee: Committee;
+  committeeOrganizer: CommitteeOrganizer;
+  company: Company;
+  event: Event;
+  eventCommittee: EventCommittee;
+  eventCompany: EventCompany;
+  mark: Mark;
+  notificationPermissions: NotificationPermissions;
+  owUser: OwUser;
+  payment: Payment;
+  personalMark: PersonalMark;
+  privacyPermissions: PrivacyPermissions;
+  product: Product;
+  productPaymentProvider: ProductPaymentProvider;
+  refundRequest: RefundRequest;
 }

--- a/packages/db/src/migrations/0016_autogenerate_user_id.ts
+++ b/packages/db/src/migrations/0016_autogenerate_user_id.ts
@@ -8,5 +8,8 @@ export async function up(db: Kysely<any>) {
 }
 
 export async function down(db: Kysely<any>) {
-  await db.schema.alterTable("ow_user").alterColumn("id", (col) => col.setDefault(sql`""`))
+  await db.schema
+    .alterTable("ow_user")
+    .alterColumn("id", (col) => col.setDefault(sql`null`))
+    .execute()
 }

--- a/packages/db/src/migrations/0017_add_committee_organizer.ts
+++ b/packages/db/src/migrations/0017_add_committee_organizer.ts
@@ -1,0 +1,21 @@
+import { Kysely } from "kysely"
+
+export async function up(db: Kysely<any>) {
+  await db.schema.alterTable("event").dropColumn("committee_id").execute()
+
+  await db.schema
+    .createTable("committee_organizer")
+    .addColumn("committee_id", "uuid", (col) => col.references("committee.id").onDelete("cascade"))
+    .addColumn("event_id", "uuid", (col) => col.references("event.id").onDelete("cascade"))
+    .addPrimaryKeyConstraint("committee_organizer_pk", ["committee_id", "event_id"])
+    .execute()
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable("event")
+    .addColumn("committee_id", "uuid", (col) => col.references("committee.id").onDelete("cascade"))
+    .execute()
+
+  await db.schema.dropTable("committee_organizer").execute()
+}

--- a/packages/gateway-trpc/src/modules/event/event-router.ts
+++ b/packages/gateway-trpc/src/modules/event/event-router.ts
@@ -1,5 +1,5 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
-import { EventWriteSchema, EventWrite, EventSchema, EventEditSchema } from "@dotkomonline/types"
+import { EventEditSchema, EventSchema, EventWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
 import { protectedProcedure, publicProcedure, t } from "../../trpc"
 import { attendanceRouter } from "./attendance-router"

--- a/packages/gateway-trpc/src/modules/event/event-router.ts
+++ b/packages/gateway-trpc/src/modules/event/event-router.ts
@@ -1,7 +1,7 @@
-import { protectedProcedure, publicProcedure, t } from "../../trpc"
-import { EventWriteSchema } from "@dotkomonline/types"
-import { z } from "zod"
 import { PaginateInputSchema } from "@dotkomonline/core"
+import { EventWriteSchema, EventWrite, EventSchema } from "@dotkomonline/types"
+import { z } from "zod"
+import { protectedProcedure, publicProcedure, t } from "../../trpc"
 import { attendanceRouter } from "./attendance-router"
 import { eventCompanyRouter } from "./event-company-router"
 
@@ -11,12 +11,13 @@ export const eventRouter = t.router({
   }),
   edit: protectedProcedure
     .input(
-      EventWriteSchema.required({
-        id: true,
+      z.object({
+        id: EventSchema.shape.id,
+        changes: EventWriteSchema,
       })
     )
-    .mutation(({ input: changes, ctx }) => {
-      return ctx.eventService.updateEvent(changes.id, changes)
+    .mutation(({ input, ctx }) => {
+      return ctx.eventService.updateEvent(input.id, input.changes)
     }),
   all: publicProcedure.input(PaginateInputSchema).query(({ input, ctx }) => {
     return ctx.eventService.getEvents(input.take, input.cursor)

--- a/packages/gateway-trpc/src/modules/event/event-router.ts
+++ b/packages/gateway-trpc/src/modules/event/event-router.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 import { protectedProcedure, publicProcedure, t } from "../../trpc"
 import { attendanceRouter } from "./attendance-router"
 import { eventCompanyRouter } from "./event-company-router"
+import { committeeOrganizerRouter } from "./organizer-router"
 
 export const eventRouter = t.router({
   create: protectedProcedure.input(EventWriteSchema).mutation(({ input, ctx }) => {
@@ -37,4 +38,5 @@ export const eventRouter = t.router({
   }),
   attendance: attendanceRouter,
   company: eventCompanyRouter,
+  commitee: committeeOrganizerRouter,
 })

--- a/packages/gateway-trpc/src/modules/event/event-router.ts
+++ b/packages/gateway-trpc/src/modules/event/event-router.ts
@@ -1,5 +1,5 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
-import { EventWriteSchema, EventWrite, EventSchema } from "@dotkomonline/types"
+import { EventWriteSchema, EventWrite, EventSchema, EventEditSchema } from "@dotkomonline/types"
 import { z } from "zod"
 import { protectedProcedure, publicProcedure, t } from "../../trpc"
 import { attendanceRouter } from "./attendance-router"
@@ -13,7 +13,7 @@ export const eventRouter = t.router({
     .input(
       z.object({
         id: EventSchema.shape.id,
-        changes: EventWriteSchema,
+        changes: EventEditSchema,
       })
     )
     .mutation(({ input, ctx }) => {

--- a/packages/gateway-trpc/src/modules/event/organizer-router.ts
+++ b/packages/gateway-trpc/src/modules/event/organizer-router.ts
@@ -1,0 +1,16 @@
+import { EventSchema } from "@dotkomonline/types"
+import { z } from "zod"
+import { publicProcedure, t } from "../../trpc"
+
+export const committeeOrganizerRouter = t.router({
+  get: publicProcedure
+    .input(
+      z.object({
+        eventId: EventSchema.shape.id,
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const attendance = await ctx.committeeOrganizerService.getCommitteesForEvent(input.eventId)
+      return attendance
+    }),
+})

--- a/packages/types/src/committee-event-organizer.ts
+++ b/packages/types/src/committee-event-organizer.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const CommiteeOrganizerSchema = z.object({
+  committeeId: z.string(),
+  eventId: z.string(),
+})
+
+export type CommitteeOrganizer = z.infer<typeof CommiteeOrganizerSchema>
+
+export const CommitteeEventOrganizerWriteSchema = CommiteeOrganizerSchema
+
+export type CommitteeEventOrganizerWrite = z.infer<typeof CommitteeEventOrganizerWriteSchema>

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -36,7 +36,7 @@ export const EventWriteSchema = EventSchema.extend({
       return data.start < data.end
     },
     {
-      message: "Starttidspunkt må være før sluttidspunkt",
+      message: "Sluttidspunkt må være etter starttidspunkt",
       path: ["end"],
     }
   )
@@ -50,14 +50,10 @@ export const EventEditSchema = EventSchema.partial({
     return data.start < data.end
   },
   {
-    message: "Starttidspunkt må være før sluttidspunkt",
+    message: "Sluttidspunkt må være etter starttidspunkt",
     path: ["end"],
   }
 )
-
-// EventWriteSchema.refine((data) => data.end > data.start, {
-//   message: "End date must be after the start date",
-// })
 
 export type EventWrite = z.infer<typeof EventWriteSchema>
 export type EventEdit = z.infer<typeof EventEditSchema>

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -14,7 +14,7 @@ export const EventSchema = z.object({
   subtitle: z.string().nullable(),
   imageUrl: z.string().nullable(),
   location: z.string().nullable(),
-  committeeId: z.string().nullable(),
+  committeeOrganizers: z.array(z.string()).nullable().optional(),
   waitlist: z.string().uuid().nullable(),
 })
 

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -21,13 +21,46 @@ export const EventSchema = z.object({
 export type Event = z.infer<typeof EventSchema>
 export type EventId = Event["id"]
 
-export const EventWriteSchema = EventSchema.partial({
-  id: true,
+export const EventWriteSchema = EventSchema.extend({
+  start: z.date().refine((data) => data > new Date(), { message: "Starttidspunkt må være i fremtiden" }),
+  end: z.date().refine((data) => data > new Date(), { message: "Sluttidspunkt må være i fremtiden" }),
+})
+  .partial({
+    id: true,
+    createdAt: true,
+    updatedAt: true,
+  })
+  .refine(
+    (data) => {
+      // data.start < data.end
+      return data.start < data.end
+    },
+    {
+      message: "Starttidspunkt må være før sluttidspunkt",
+      path: ["end"],
+    }
+  )
+
+export const EventEditSchema = EventSchema.partial({
   createdAt: true,
   updatedAt: true,
-})
+}).refine(
+  (data) => {
+    // data.start < data.end
+    return data.start < data.end
+  },
+  {
+    message: "Starttidspunkt må være før sluttidspunkt",
+    path: ["end"],
+  }
+)
+
+// EventWriteSchema.refine((data) => data.end > data.start, {
+//   message: "End date must be after the start date",
+// })
 
 export type EventWrite = z.infer<typeof EventWriteSchema>
+export type EventEdit = z.infer<typeof EventEditSchema>
 
 export const AttendeeSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
- support schemas that have been refined or transformed, i.e. zodeffect type
- fix not working down-migration, "" is not valid sql
- parse user input in event create modal
- Add event edit schema
- keep write schema clean and rewrite to fit zodeffects schema
- factor edit form into seperate component for seperate validation logic
- thank you sonarcloud for finding stupid mistakes
- working multiple comittees
