### PR TITLE
keep expanded navbar labels when navigating dashboard

### DIFF
--- a/apps/dashboard/src/app/ApplicationShell.tsx
+++ b/apps/dashboard/src/app/ApplicationShell.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FC, PropsWithChildren } from "react"
+import { FC, PropsWithChildren, useState, useEffect } from "react"
 import { useDisclosure } from "@mantine/hooks"
 import {
   AppShellHeader,
@@ -66,7 +66,22 @@ const navigations = [
 export const ApplicationShell: FC<PropsWithChildren> = ({ children }) => {
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure()
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true)
+  const [expandedNavs, setExpandedNavs] = useState<string[]>([])
 
+  useEffect(() => {
+    const savedNavs = localStorage.getItem("expandedNavs")
+    if (savedNavs) {
+      setExpandedNavs(JSON.parse(savedNavs))
+    }
+  }, [])
+
+  const handleNavToggle = (label: string) => () => {
+    const isExpanded = expandedNavs.includes(label)
+    const updatedNavs = isExpanded ? expandedNavs.filter((nav) => nav !== label) : [...expandedNavs, label]
+
+    setExpandedNavs(updatedNavs)
+    localStorage.setItem("expandedNavs", JSON.stringify(updatedNavs))
+  }
   return (
     <AppShell
       header={{ height: 60 }}
@@ -95,6 +110,8 @@ export const ApplicationShell: FC<PropsWithChildren> = ({ children }) => {
             label={navigation.label}
             leftSection={<Icon icon={navigation.icon} />}
             childrenOffset={28}
+            opened={expandedNavs.includes(navigation.label)}
+            onChange={handleNavToggle(navigation.label)}
           >
             {navigation.children.map((child) => (
               <NavLink key={child.label} label={child.label} href={child.href} />

--- a/apps/dashboard/src/app/ApplicationShell.tsx
+++ b/apps/dashboard/src/app/ApplicationShell.tsx
@@ -63,21 +63,19 @@ const navigations = [
   },
 ] as const
 
+const getInitialExpandedNavs = () => {
+  const savedNavs = localStorage.getItem("expandedNavs")
+  return savedNavs ? JSON.parse(savedNavs) : []
+}
+
 export const ApplicationShell: FC<PropsWithChildren> = ({ children }) => {
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure()
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true)
-  const [expandedNavs, setExpandedNavs] = useState<string[]>([])
-
-  useEffect(() => {
-    const savedNavs = localStorage.getItem("expandedNavs")
-    if (savedNavs) {
-      setExpandedNavs(JSON.parse(savedNavs))
-    }
-  }, [])
+  const [expandedNavs, setExpandedNavs] = useState(getInitialExpandedNavs)
 
   const handleNavToggle = (label: string) => () => {
     const isExpanded = expandedNavs.includes(label)
-    const updatedNavs = isExpanded ? expandedNavs.filter((nav) => nav !== label) : [...expandedNavs, label]
+    const updatedNavs = isExpanded ? expandedNavs.filter((nav: string) => nav !== label) : [...expandedNavs, label]
 
     setExpandedNavs(updatedNavs)
     localStorage.setItem("expandedNavs", JSON.stringify(updatedNavs))

--- a/apps/dashboard/src/app/ApplicationShell.tsx
+++ b/apps/dashboard/src/app/ApplicationShell.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FC, PropsWithChildren, useState, useEffect } from "react"
+import { FC, PropsWithChildren, useState } from "react"
 import { useDisclosure } from "@mantine/hooks"
 import {
   AppShellHeader,


### PR DESCRIPTION
Stores the opened labels in local storage and reopens them on page load so that their state persists