### PR TITLE
Create penalty page

### DIFF
--- a/apps/web/src/components/layout/ProfileLayout.tsx
+++ b/apps/web/src/components/layout/ProfileLayout.tsx
@@ -31,7 +31,7 @@ const ProfileLayout: FC<PropsWithChildren> = ({ children }) => {
           <ProfileMenuContainer />
           <ProfileContext.Provider value={{ editMode, setEditMode }}>
             <div className="mx-5 mt-16 md:min-w-[600px]">
-              {currentLink ? <PageTitle title={currentLink?.title} icon={currentLink.icon} /> : ""}
+              {currentLink && <PageTitle title={currentLink?.title} icon={currentLink.icon} />}
               <div className="my-2 ml-5">{children}</div>
             </div>
           </ProfileContext.Provider>

--- a/apps/web/src/components/layout/ProfileLayout.tsx
+++ b/apps/web/src/components/layout/ProfileLayout.tsx
@@ -20,7 +20,8 @@ const PageTitle: FC<PageTitleProps> = ({ title, icon }) => {
 }
 
 const ProfileLayout: FC<PropsWithChildren> = ({ children }) => {
-  const currentLink = profileItems.find((item) => item.slug === usePathname())
+  const currentSlug = usePathname()
+  const currentLink = profileItems.find((item) => item.slug === currentSlug)
   const [editMode, setEditMode] = useState(false)
 
   return (

--- a/apps/web/src/components/layout/ProfileLayout.tsx
+++ b/apps/web/src/components/layout/ProfileLayout.tsx
@@ -1,8 +1,26 @@
 import { FC, PropsWithChildren, useState } from "react"
 import ProfileMenuContainer from "../organisms/Navbar/components/profile/ProfileMenu/ProfileMenuContainer"
 import { ProfileContext } from "../views/ProfileView/context/ProfileContext"
+import { Icon } from "@dotkomonline/ui"
+import { usePathname } from "next/navigation"
+import { profileItems } from "@/utils/profileLinks"
+
+interface PageTitleProps {
+  title: string
+  icon: string
+}
+
+const PageTitle: FC<PageTitleProps> = ({ title, icon }) => {
+  return (
+    <div className="flex h-10 space-x-2">
+      <Icon icon={icon} width={"w-10"} />
+      <p className="text-3xl">{title}</p>
+    </div>
+  )
+}
 
 const ProfileLayout: FC<PropsWithChildren> = ({ children }) => {
+  const currentLink = profileItems.find((item) => item.slug === usePathname())
   const [editMode, setEditMode] = useState(false)
 
   return (
@@ -11,7 +29,10 @@ const ProfileLayout: FC<PropsWithChildren> = ({ children }) => {
         <div className="flex w-full flex-row">
           <ProfileMenuContainer />
           <ProfileContext.Provider value={{ editMode, setEditMode }}>
-            <div className="mx-5 mt-[42.5px] md:min-w-[600px]">{children}</div>
+            <div className="mx-5 mt-16 md:min-w-[600px]">
+              {currentLink ? <PageTitle title={currentLink?.title} icon={currentLink.icon} /> : ""}
+              <div className="my-2 ml-5">{children}</div>
+            </div>
           </ProfileContext.Provider>
         </div>
       </div>

--- a/apps/web/src/components/organisms/Navbar/components/profile/ProfileMenu/ProfileMenuContainer.tsx
+++ b/apps/web/src/components/organisms/Navbar/components/profile/ProfileMenu/ProfileMenuContainer.tsx
@@ -3,7 +3,7 @@ import ProfileMenuItem from "./ProfileMenuItem"
 
 const ProfileMenuContainer = () => {
   return (
-    <div className=" border-r-1 border-slate-5 pr-5 pt-[42.5px]">
+    <div className=" border-slate-5 border-r-[1px] pr-5 pt-10 ">
       {profileItems.map((item) => (
         <ProfileMenuItem key={item.title} menuItem={item} />
       ))}

--- a/apps/web/src/components/views/ProfileView/components/ProfileLanding.tsx
+++ b/apps/web/src/components/views/ProfileView/components/ProfileLanding.tsx
@@ -36,38 +36,35 @@ const FormInput: React.FC<IFormInput> = ({ name, children, addMore, clickable = 
 
 const Landing: NextPage<{ user: User }> = ({ user }) => {
   return (
-    <div className="my-8 w-full">
+    <div className="w-full">
       <div className="flex w-full flex-col">
-        <div className="ml-7 mt-4">
-          <p className="text-4xl">Profil</p>
-          <p className="opacity-70">Administrer dine kontoinnstillinger</p>
-          <FormInput name="Profil">
+        <p className="text-slate-10">Administrer dine kontoinnstillinger</p>
+        <FormInput name="Profil">
+          <div>
+            <Avatar></Avatar>
+            {user.name ?? "No registred name"}
+          </div>
+        </FormInput>
+        <FormInput name="Epost" addMore="Add Email Address">
+          <div>{user.email ?? "No registred email"}</div>
+        </FormInput>
+        <FormInput name="Telefon" addMore="Add Phone Number">
+          <div> (+47) 482 49 100</div>
+        </FormInput>
+        <FormInput name="Studie" clickable={false}>
+          <div className="space-y-8">
             <div>
-              <Avatar></Avatar>
-              {user.name ?? "No registred name"}
+              <p>Klassetrinn: </p>
             </div>
-          </FormInput>
-          <FormInput name="Epost" addMore="Add Email Address">
-            <div>{user.email ?? "No registred email"}</div>
-          </FormInput>
-          <FormInput name="Telefon" addMore="Add Phone Number">
-            <div> (+47) 482 49 100</div>
-          </FormInput>
-          <FormInput name="Studie" clickable={false}>
-            <div className="space-y-8">
-              <div>
-                <p>Klassetrinn: </p>
-              </div>
-              <div>
-                <p>Startår:</p>
-              </div>
-              <div className="flex items-center space-x-10 ">
-                <p>Studieløp:</p>
-                <StudentProgress year={0} />
-              </div>
+            <div>
+              <p>Startår:</p>
             </div>
-          </FormInput>
-        </div>
+            <div className="flex items-center space-x-10 ">
+              <p>Studieløp:</p>
+              <StudentProgress year={0} />
+            </div>
+          </div>
+        </FormInput>
       </div>
     </div>
   )

--- a/apps/web/src/pages/profile/email.tsx
+++ b/apps/web/src/pages/profile/email.tsx
@@ -7,22 +7,10 @@ const EmailPage: NextPageWithLayout = () => {
   return <div>Email</div>
 }
 
-const EmailHeader = () => {
-  return (
-    <div className="flex items-center">
-      <Icon icon={"tabler:mail-filled"} width={24} />
-      <p className="ml-2">Epost</p>
-    </div>
-  )
-}
-
 EmailPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <EmailHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
   )
 }

--- a/apps/web/src/pages/profile/email.tsx
+++ b/apps/web/src/pages/profile/email.tsx
@@ -1,7 +1,6 @@
 import MainLayout from "@/components/layout/MainLayout"
 import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
-import { Icon } from "@dotkomonline/ui"
 
 const EmailPage: NextPageWithLayout = () => {
   return <div>Email</div>

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -5,7 +5,6 @@ import { NextPageWithLayout } from "../_app"
 import { GetServerSideProps, InferGetServerSidePropsType } from "next"
 import { getServerSession, User } from "next-auth"
 import { authOptions } from "@dotkomonline/auth/src/web.app"
-import { Icon } from "@dotkomonline/ui"
 
 const LandingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServerSideProps>> = ({ user }) => {
   return <ProfileLanding user={user} />

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -11,22 +11,10 @@ const LandingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
   return <ProfileLanding user={user} />
 }
 
-const LandingPageHeader = () => {
-  return (
-    <div className="flex items-center">
-      <Icon icon={"tabler:user-circle"} width={24} />
-      <p className="ml-2">Min Profil</p>
-    </div>
-  )
-}
-
 LandingPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <LandingPageHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
   )
 }

--- a/apps/web/src/pages/profile/membership.tsx
+++ b/apps/web/src/pages/profile/membership.tsx
@@ -7,22 +7,10 @@ const MembershipPage: NextPageWithLayout = () => {
   return <div>Membership</div>
 }
 
-const MembershipHeader = () => {
-  return (
-    <div className="flex items-center">
-      <Icon icon={"tabler:award"} width={24} />
-      <p className="ml-2">Medlemskap</p>
-    </div>
-  )
-}
-
 MembershipPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <MembershipHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
   )
 }

--- a/apps/web/src/pages/profile/membership.tsx
+++ b/apps/web/src/pages/profile/membership.tsx
@@ -1,7 +1,6 @@
 import MainLayout from "@/components/layout/MainLayout"
 import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
-import { Icon } from "@dotkomonline/ui"
 
 const MembershipPage: NextPageWithLayout = () => {
   return <div>Membership</div>

--- a/apps/web/src/pages/profile/password.tsx
+++ b/apps/web/src/pages/profile/password.tsx
@@ -7,22 +7,10 @@ const PasswordPage: NextPageWithLayout = () => {
   return <div>Password</div>
 }
 
-const PasswordHeader = () => {
-  return (
-    <div className="flex items-center">
-      <Icon icon={"tabler:lock"} width={24} />
-      <p className="ml-2">Passord</p>
-    </div>
-  )
-}
-
 PasswordPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <PasswordHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
   )
 }

--- a/apps/web/src/pages/profile/password.tsx
+++ b/apps/web/src/pages/profile/password.tsx
@@ -1,7 +1,6 @@
 import MainLayout from "@/components/layout/MainLayout"
 import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
-import { Icon } from "@dotkomonline/ui"
 
 const PasswordPage: NextPageWithLayout = () => {
   return <div>Password</div>

--- a/apps/web/src/pages/profile/penalties.tsx
+++ b/apps/web/src/pages/profile/penalties.tsx
@@ -6,7 +6,6 @@ import { DotFilledIcon } from "@radix-ui/react-icons"
 
 import { FC } from "react"
 import PenaltyRules from "@/utils/penalty-rules"
-import { trpc } from "@/utils/trpc"
 import { addMinutes, format } from "date-fns"
 
 /* TODO - Set up connection to Users marks router */

--- a/apps/web/src/pages/profile/penalties.tsx
+++ b/apps/web/src/pages/profile/penalties.tsx
@@ -5,9 +5,9 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@d
 import { DotFilledIcon } from "@radix-ui/react-icons"
 
 import { FC } from "react"
-import { format } from "date-fns"
 import PenaltyRules from "@/utils/penalty-rules"
 import { trpc } from "@/utils/trpc"
+import { addMinutes, format } from "date-fns"
 
 /* TODO - Set up connection to Users marks router */
 
@@ -19,6 +19,7 @@ const PenaltiesPage: NextPageWithLayout = () => {
       <div className="flex flex-col">
         <p className="text-2xl font-medium">Aktive Prikker</p>
         {/* TODO - Get active marks */}
+        <PenaltyAccordion title="TestPrikk" category="Sosial" givenAt={new Date()} duration={2000} details="Testing" />
         <p>Ingen aktive prikker</p>
       </div>
       <div>
@@ -50,7 +51,7 @@ PenaltiesPage.getLayout = (page) => {
 interface PenaltyAccordionProps {
   title: string
   category: string
-  givenAt: dateFns
+  givenAt: Date
   duration: number
   details: string
 }
@@ -67,13 +68,16 @@ const PenaltyAccordion: FC<PenaltyAccordionProps> = (props) => {
         </AccordionTrigger>
         <AccordionContent className="ml-4">
           <div className="flex flex-col space-y-4">
-            <p>Du har fått en prikk på grunn av {props.details} den</p>
+            <p>
+              Du har fått en prikk på grunn av {props.details} den {format(props.givenAt, "dd/MM/yyyy")}
+            </p>
             <p className="text-lg">
               <span className="font-bold">Katergori: </span>
               {props.category}
             </p>
             <p className="text-lg">
               <span className="font-bold">Utløpsdato: </span>
+              {format(addMinutes(props.givenAt, props.duration), "dd/MM/yyyy")}
             </p>
           </div>
         </AccordionContent>

--- a/apps/web/src/pages/profile/penalties.tsx
+++ b/apps/web/src/pages/profile/penalties.tsx
@@ -3,26 +3,32 @@ import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@dotkomonline/ui"
 import { DotFilledIcon } from "@radix-ui/react-icons"
-import PenaltyRules from "./penaltyRules"
-import { Mark, User } from "@dotkomonline/types"
+
 import { FC } from "react"
 import { format } from "date-fns"
+import PenaltyRules from "@/utils/penalty-rules"
+import { trpc } from "@/utils/trpc"
 
 /* TODO - Set up connection to Users marks router */
+
 const PenaltiesPage: NextPageWithLayout = () => {
+  const personalMarks = trpc.personalMark.getByUser
   return (
     <div className="ml-3 flex flex-col space-y-12">
       <p className="text-slate-10">Oversikt over dine prikker</p>
       <div className="flex flex-col">
         <p className="text-2xl font-medium">Aktive Prikker</p>
+        {/* TODO - Get active marks */}
         <p>Ingen aktive prikker</p>
       </div>
       <div>
         <p className="text-2xl font-medium">Gamle Prikker</p>
+        {/* TODO - Get old marks */}
         <p>Ingen gamle prikker</p>
       </div>
       <div className="flex flex-col space-y-2">
         <p className="text-2xl font-medium">Suspensjoner</p>
+        {/* TODO - Get suspensions */}
         <p>Ingen suspensjoner</p>
       </div>
       <div>

--- a/apps/web/src/pages/profile/penalties.tsx
+++ b/apps/web/src/pages/profile/penalties.tsx
@@ -1,17 +1,34 @@
 import MainLayout from "@/components/layout/MainLayout"
 import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
-import { Icon } from "@dotkomonline/ui"
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@dotkomonline/ui"
+import { DotFilledIcon } from "@radix-ui/react-icons"
+import PenaltyRules from "./penaltyRules"
+import { Mark, User } from "@dotkomonline/types"
+import { FC } from "react"
+import { format } from "date-fns"
 
+/* TODO - Set up connection to Users marks router */
 const PenaltiesPage: NextPageWithLayout = () => {
-  return <div>Penalties</div>
-}
-
-const PenaltyHeader = () => {
   return (
-    <div className="flex items-center">
-      <Icon icon="pajamas:cancel" className="w-4" />
-      <p className="ml-2">Prikker og Suspensjoner</p>
+    <div className="ml-3 flex flex-col space-y-12">
+      <p className="text-slate-10">Oversikt over dine prikker</p>
+      <div className="flex flex-col">
+        <p className="text-2xl font-medium">Aktive Prikker</p>
+        <p>Ingen aktive prikker</p>
+      </div>
+      <div>
+        <p className="text-2xl font-medium">Gamle Prikker</p>
+        <p>Ingen gamle prikker</p>
+      </div>
+      <div className="flex flex-col space-y-2">
+        <p className="text-2xl font-medium">Suspensjoner</p>
+        <p>Ingen suspensjoner</p>
+      </div>
+      <div>
+        <p className="text-2xl font-medium">PrikkeRegler</p>
+        <PenaltyRules />
+      </div>
     </div>
   )
 }
@@ -19,11 +36,43 @@ const PenaltyHeader = () => {
 PenaltiesPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <PenaltyHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
+  )
+}
+
+interface PenaltyAccordionProps {
+  title: string
+  category: string
+  givenAt: dateFns
+  duration: number
+  details: string
+}
+
+const PenaltyAccordion: FC<PenaltyAccordionProps> = (props) => {
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="item-1">
+        <AccordionTrigger className="accordions ml-1 text-lg">
+          <span className="flex">
+            <DotFilledIcon className="mt-1" />
+            {props.title}
+          </span>
+        </AccordionTrigger>
+        <AccordionContent className="ml-4">
+          <div className="flex flex-col space-y-4">
+            <p>Du har fått en prikk på grunn av {props.details} den</p>
+            <p className="text-lg">
+              <span className="font-bold">Katergori: </span>
+              {props.category}
+            </p>
+            <p className="text-lg">
+              <span className="font-bold">Utløpsdato: </span>
+            </p>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   )
 }
 

--- a/apps/web/src/pages/profile/penalties.tsx
+++ b/apps/web/src/pages/profile/penalties.tsx
@@ -12,7 +12,6 @@ import { addMinutes, format } from "date-fns"
 /* TODO - Set up connection to Users marks router */
 
 const PenaltiesPage: NextPageWithLayout = () => {
-  const personalMarks = trpc.personalMark.getByUser
   return (
     <div className="ml-3 flex flex-col space-y-12">
       <p className="text-slate-10">Oversikt over dine prikker</p>

--- a/apps/web/src/pages/profile/privacy.tsx
+++ b/apps/web/src/pages/profile/privacy.tsx
@@ -1,7 +1,6 @@
 import MainLayout from "@/components/layout/MainLayout"
 import ProfileLayout from "@/components/layout/ProfileLayout"
 import { NextPageWithLayout } from "../_app"
-import { Icon } from "@dotkomonline/ui"
 
 const PrivacyPage: NextPageWithLayout = () => {
   return <div>Privacy</div>

--- a/apps/web/src/pages/profile/privacy.tsx
+++ b/apps/web/src/pages/profile/privacy.tsx
@@ -7,22 +7,10 @@ const PrivacyPage: NextPageWithLayout = () => {
   return <div>Privacy</div>
 }
 
-const PrivacyHeader = () => {
-  return (
-    <div className="flex items-center">
-      <Icon icon={"tabler:shield-half-filled"} width={24} />
-      <p className="ml-2">Personvern</p>
-    </div>
-  )
-}
-
 PrivacyPage.getLayout = (page) => {
   return (
     <MainLayout>
-      <ProfileLayout>
-        <PrivacyHeader />
-        {page}
-      </ProfileLayout>
+      <ProfileLayout>{page}</ProfileLayout>
     </MainLayout>
   )
 }

--- a/apps/web/src/utils/penalty-rules.tsx
+++ b/apps/web/src/utils/penalty-rules.tsx
@@ -1,0 +1,88 @@
+const PenaltyRules = () => {
+  return (
+    <div className="mb-8 flex flex-col space-y-4">
+      <h4>Hva er en prikk?</h4>
+      <p>
+        Det at du har aktive prikker innebærer at du vil måtte vente 24 timer etter ordinær påmeldingsstart for å melde
+        deg på et arrangement. Hver prikk varer i 20 dager, dersom du får ny prikk og du allerede har en aktiv prikk
+        blir de nye 20 dagene lagt til på slutten av virkeperioden til eksisterende prikk(er). Varigheten til prikker er
+        fryst i ferier. Disse er definert fra 1. desember til 15. januar og 1. juni til 15. august. Dersom en prikk gis
+        15. mai vil altså denne prikken utløpe 20. august. Grunnen til at vi deler ut prikker er å sørge for at
+        medlemmer følger reglene.
+      </p>
+      <h4>Hva gir prikk?</h4>
+      <div className="flex flex-col space-y-3">
+        <p>Dette er en kort punktliste. Unntak og videre forklaringer finner du lenger ned.</p>
+        <ul className="ml-8 list-disc">
+          <li>Å melde seg av etter avmeldingsfristen.</li>
+          <li>Å ikke møte opp på et arrangement man har plass på.</li>
+          <li>Å møte opp etter arrangementets start eller innslipp er ferdig.</li>
+          <li>Å ikke svare på tilbakemeldingsskjema innen tidsfristen.</li>
+          <li>
+            Å ikke overholde betalingsfristen. Dette medfører i tillegg suspensjon fra alle Onlines arrangementer inntil
+            betaling er gjennomført.
+          </li>
+        </ul>
+        <p>Den ansvarlige komiteen kan også foreta en skjønnsmessig vurdering som gagner deltakeren.</p>
+      </div>
+      <h4>Avmelding</h4>
+      <ul className="ml-8 list-disc space-y-1">
+        <li>
+          Ved sykdom eller andre ekstraordinære hendelser vil man ikke få prikk ved avmelding 5 timer før
+          arrangementsstart.
+        </li>
+        <li>
+          Alle komiteer ønsker at du melder deg av arrangementer selv om du vet dette vil medføre prikk. Dette er slik
+          at noen andre kan bli obs på plassen sin så tidlig som mulig.
+        </li>
+      </ul>
+      <h4>Venteliste</h4>
+      <ul className="ml-8 list-disc space-y-1">
+        <li>Hvis du står på venteliste kan du melde deg av helt til arrangementet starter.</li>
+        <li>
+          Når du står på venteliste er du inneforstått med at du når som helst kan få plass på arrangementet og dermed
+          er bundet til reglene for arrangementet på lik linje med andre påmeldte.
+        </li>
+      </ul>
+      <h4>Betaling</h4>
+      <ul className="ml-8 list-disc space-y-1">
+        <li>Ved manglende betaling suspenderes man fra alle Onlines arrangementer inntil betalingen er gjennomført.</li>
+        <li>
+          Ved betalt arrangement, men manglende oppmøte, vil man ikke få tilbakebetalt dersom avmelding skjer etter
+          frist. Dersom neste på venteliste er tilgjengelig kan dette gjøres unntak for.
+        </li>
+      </ul>
+      <h4>Oppførsel</h4>
+      <ul className="ml-8 list-disc space-y-1">
+        <li>
+          Ved upassende oppførsel under et av Onlines arrangement vil du stå økonomisk ansvarlig for eventuelle skader,
+          og i verste fall risikere utestengelse fra alle Onlines arrangement.
+        </li>
+      </ul>
+      <h4>Bedriftspresentasjoner</h4>
+      <ul className="ml-8 list-disc space-y-1">
+        <li>
+          Ved bedriftsarrangementer åpner dørene i henhold til starttid på arrangementet. Ti minutter etter at dørene
+          åpner slippes oppmøte på ventelisten inn dersom det er plass. 15 minutter etter at dørene åpner stenger
+          innslippet.
+        </li>
+        <li>
+          Det kreves at en deltaker svarer på den elektroniske tilbakemeldingen etter bedriftsarrangementer. Det vil
+          komme e-post etter arrangementet med lenke til tilbakemeldingsskjema som må besvares innen denoppgitte
+          fristen. Dersom en deltager ikke svarer innen fristen vil dette gi en prikk.
+        </li>
+      </ul>
+      <h4>Hvorfor har jeg fått prikk?</h4>
+      <p>
+        Under &rdquo;Min profil&rdquo; og &rdquo;Prikker og suspensjoner&rdquo; {/*TODO - Legg til linken*/} vil du
+        kunne se prikkene dine, og eventuelle begrunnelser.
+      </p>
+      <p>
+        Dersom du mener noe feil har skjedd, vennligst ta kontakt med arrangøren som står oppført på arrangementet.
+        Kontaktinfo for arrangerende komité vises på arrangementssiden.
+      </p>
+    </div>
+  )
+}
+
+export default PenaltyRules

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./components/Accordion"
 export * from "./components/Alert"
 export * from "./components/Badge"
 export * from "./components/Button"


### PR DESCRIPTION
Closes: #..

## Checklist

- [x] I have created penalty page
- [x] I have updated to automatic titles
- [x] I have removed titles from existing titles 

## Changelog
- Created penalty page without functionality
- Updated to automatically show titles in profile pages
- Removed hardcoded title/header from pages in profile (Not notifications, accesscard and payments because they will be removed in another branch by @hanlun0804 )
- Exported Accordion from storybook

## How to test
- Run monoweb
- Navigate to <code>/profile</code> in URL
