### PR TITLE
Add stub for pg-native for dashboard

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -34,6 +34,7 @@
     "dayjs": "^1.11.10",
     "next": "^13.5.6",
     "next-auth": "^4.24.4",
+    "pg-native": "file:./stubs/pg-native",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",

--- a/apps/dashboard/stubs/pg-native/package.json
+++ b/apps/dashboard/stubs/pg-native/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pg-native",
+  "private": true,
+  "main": "pgnative.stub.cjs"
+}

--- a/apps/dashboard/stubs/pg-native/pgnative.stub.cjs
+++ b/apps/dashboard/stubs/pg-native/pgnative.stub.cjs
@@ -1,0 +1,1 @@
+module.exports = null;


### PR DESCRIPTION
Next.js tries to include pg-native which is a module that uses C++ addons into the webpack build on the server (because we have transpilePackages)

It errors because it thinks the package will end up on the client, but it won't so for webpack we will just stub it