### PR TITLE
Prevent tooltip buttons from submitting the form

### DIFF
--- a/apps/rif/src/app/checkbox.tsx
+++ b/apps/rif/src/app/checkbox.tsx
@@ -23,7 +23,7 @@ export const CheckboxWithTooltip: FC<CheckboxWithTooltipProps> = ({ label, name,
           <Checkbox label={label} onCheckedChange={field.onChange} checked={field.value as boolean} />
           <Tooltip.Provider>
             <Tooltip.Root>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger type="button">
                 <Icon icon="tabler:info-circle" />
               </Tooltip.Trigger>
               <Tooltip.Portal>


### PR DESCRIPTION
Fixes the problem where the tooltip triggers acted as submit buttons triggering both accidental submit and accidental validation