### PR TITLE
Create paginated collection builder

### DIFF
--- a/apps/dashboard/src/modules/committee/queries/use-committee-all-query.ts
+++ b/apps/dashboard/src/modules/committee/queries/use-committee-all-query.ts
@@ -2,8 +2,8 @@ import { trpc } from "../../../utils/trpc"
 
 export const useCommitteeAllQuery = () => {
   const { data, ...query } = trpc.committee.all.useQuery({ take: 999 })
-  if (query.isLoading) {
+  if (data === undefined || query.isLoading) {
     return { committees: [], ...query }
   }
-  return { committees: data!.data, ...query }
+  return { committees: data.data, ...query }
 }

--- a/apps/dashboard/src/modules/committee/queries/use-committee-all-query.ts
+++ b/apps/dashboard/src/modules/committee/queries/use-committee-all-query.ts
@@ -1,6 +1,9 @@
 import { trpc } from "../../../utils/trpc"
 
 export const useCommitteeAllQuery = () => {
-  const { data: committees = [], ...query } = trpc.committee.all.useQuery({ take: 999 })
-  return { committees, ...query }
+  const { data, ...query } = trpc.committee.all.useQuery({ take: 999 })
+  if (query.isLoading) {
+    return { committees: [], ...query }
+  }
+  return { committees: data!.data, ...query }
 }

--- a/apps/web/src/pages/committee/[id].tsx
+++ b/apps/web/src/pages/committee/[id].tsx
@@ -24,9 +24,11 @@ export const getStaticPaths: GetStaticPaths = async () => {
     }),
     transformer,
   })
-  const companies = await ssg.committee.all.fetch()
+  const committees = await ssg.committee.all.fetch({
+    take: 999,
+  })
   return {
-    paths: companies.map(({ id }) => ({ params: { id } })),
+    paths: committees.data.map(({ id }) => ({ params: { id } })),
     fallback: "blocking",
   }
 }

--- a/packages/core/src/modules/committee/committee-service.ts
+++ b/packages/core/src/modules/committee/committee-service.ts
@@ -1,11 +1,11 @@
 import { type Committee, type CommitteeId, type CommitteeWrite } from "@dotkomonline/types"
 import { type CommitteeRepository } from "./committee-repository"
 import { NotFoundError } from "../../errors/errors"
-import { type Cursor } from "../../utils/db-utils"
+import { type Collection, type Pageable } from "../../utils/db-utils"
 
 export interface CommitteeService {
   getCommittee(id: CommitteeId): Promise<Committee>
-  getCommittees(take: number, cursor?: Cursor): Promise<Committee[]>
+  getCommittees(pageable: Pageable): Promise<Collection<Committee>>
   createCommittee(payload: CommitteeWrite): Promise<Committee>
 }
 
@@ -24,7 +24,7 @@ export class CommitteeServiceImpl implements CommitteeService {
     return await this.committeeRepository.create(payload)
   }
 
-  async getCommittees(take: number, cursor?: Cursor) {
-    return this.committeeRepository.getAll(take, cursor)
+  async getCommittees(pageable: Pageable) {
+    return this.committeeRepository.getAll(pageable)
   }
 }

--- a/packages/core/src/utils/db-utils.ts
+++ b/packages/core/src/utils/db-utils.ts
@@ -13,6 +13,7 @@ export const PaginateInputSchema = z
   .optional()
   .default({ take: 20, cursor: undefined })
 
+export type PaginateInput = z.infer<typeof PaginateInputSchema>
 export type Cursor = z.infer<typeof CursorSchema>
 
 export function orderedQuery<DB, TB extends keyof DB, O>(qb: SelectQueryBuilder<DB, TB, O>, cursor?: Cursor) {
@@ -23,4 +24,61 @@ export function orderedQuery<DB, TB extends keyof DB, O>(qb: SelectQueryBuilder<
   }
 
   return queryBuilder.orderBy(sql`id`, "desc")
+}
+
+/**
+ * Wrap a sub-query with the necessary pagination queries, and return the resulting collection.
+ *
+ * This takes a QueryBuilder created with `db.selectFrom(...)` and a cursor, and fetches the requested page from the
+ * database. Then it maps each database record to a wanted output type.
+ */
+export const paginatedQuery = async <T extends OrderedIdentifier, DB, TB extends keyof DB, O extends OrderedIdentifier>(
+  qb: SelectQueryBuilder<DB, TB, O>,
+  pagination: PaginateInput,
+  mapper: (payload: O) => T
+): Promise<Collection<T>> => {
+  // Take N+1 to determine if there is a record behind `take`.
+  const pageWithNextLength = pagination.take + 1
+  let builder = qb.limit(pageWithNextLength)
+  // If a cursor was provided, skip forwards to the specified record
+  if (pagination.cursor !== undefined) {
+    builder = builder.where(sql`id`, "<", sql`${pagination.cursor.id}`)
+  }
+  // Always perform ordering on id.
+  builder = builder.orderBy(sql`id`, "desc")
+
+  // Perform the query and build the output
+  const records = await builder.execute()
+  const hasNextCursor = records.length !== 0 && records.length === pageWithNextLength
+  const last = records.at(-1)
+
+  let cursor: Cursor | null = null
+  if (hasNextCursor && last !== undefined) {
+    cursor = {
+      id: last.id,
+    }
+  }
+
+  const data = records.slice(0, pagination.take)
+  return {
+    next: cursor,
+    data: data.map(mapper),
+    count: 0,
+  }
+}
+
+/**
+ * Trait type for anything that has an id.
+ *
+ * Any type that should be pageable in the collections system must have an identifier that is monotonically ordered. In
+ * our case, we have ULID identifiers on all resources.
+ */
+export interface OrderedIdentifier {
+  id: string
+}
+
+export interface Collection<T extends OrderedIdentifier> {
+  data: T[]
+  count: number
+  next: Cursor | null
 }

--- a/packages/gateway-trpc/src/modules/committee/committee-router.ts
+++ b/packages/gateway-trpc/src/modules/committee/committee-router.ts
@@ -8,7 +8,7 @@ export const committeeRouter = t.router({
     .mutation(async ({ input, ctx }) => ctx.committeeService.createCommittee(input)),
   all: t.procedure
     .input(PaginateInputSchema)
-    .query(async ({ input, ctx }) => ctx.committeeService.getCommittees(input.take, input.cursor)),
+    .query(async ({ input, ctx }) => ctx.committeeService.getCommittees(input)),
   get: t.procedure
     .input(CommitteeSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.committeeService.getCommittee(input)),


### PR DESCRIPTION
Problems this solves outlined in https://linear.app/dotkom/issue/DOT-426/make-all-backend-endpoints-return-a-collection-type

All the client queries now have a cursor argument they can use to determine if there is more data coming

The end goal is to replace every orderedQuery with paginatedQuery