### PR TITLE
Register AWS Route53 zone for vinstraff.no

### DIFF
--- a/infra/core/main.tf
+++ b/infra/core/main.tf
@@ -20,3 +20,7 @@ resource "aws_route53_record" "null_record" {
   ttl     = 3600
   records = ["127.0.0.1"]
 }
+
+resource "aws_route53_zone" "vinstraff_no" {
+  name = "vinstraff.no"
+}


### PR DESCRIPTION
DNS :skull: 