### PR TITLE
add auth0 client for making management api calls from sdk in backend

### DIFF
--- a/infra/auth0/main.tf
+++ b/infra/auth0/main.tf
@@ -148,6 +148,7 @@ locals {
   monoweb = {
     web       = data.auth0_client.monoweb_web
     dashboard = data.auth0_client.monoweb_dashboard
+    gtx       = data.auth0_client.gtx
   }
 }
 
@@ -317,6 +318,33 @@ resource "auth0_resource_server" "auth0_management_api" {
   identifier  = "https://${data.auth0_tenant.tenant.domain}/api/v2/"
   name        = "Auth0 Management API"
   signing_alg = "RS256"
+}
+
+resource "auth0_client" "gtx" {
+  allowed_clients = []
+  allowed_origins = []
+  app_type        = "non_interactive" # this is a machine to machine application
+  grant_types     = ["client_credentials"]
+  name            = "gtx"
+  is_first_party  = true
+  oidc_conformant = true
+
+  jwt_configuration {
+    alg = "RS256"
+  }
+}
+
+data "auth0_client" "gtx" {
+  client_id = auth0_client.gtx.client_id
+}
+
+resource "auth0_client_grant" "monoweb_backend_mgmt_grant" {
+  audience  = "https://${data.auth0_tenant.tenant.domain}/api/v2/"
+  client_id = auth0_client.gtx.client_id
+  scopes = [
+    "read:users",
+    "read:user_idp_tokens"
+  ]
 }
 
 resource "auth0_client" "onlineweb4" {


### PR DESCRIPTION
https://github.com/auth0/node-auth0
> Management API Client
The Auth0 Management API is meant to be used by back-end servers or trusted parties performing administrative tasks. Generally speaking, anything that can be done through the Auth0 dashboard (and more) can also be done through this API.
> 
> Initialize your client class with a client ID, client secret and a domain.
> 
> import { ManagementClient } from 'auth0';
> 
> var management = new ManagementClient({
  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
  clientId: '{YOUR_CLIENT_ID}',
  clientSecret: '{YOUR_CLIENT_SECRET}',
});


We need the backend to be able to talk to the management api. One use case is for implementing user search in the dashbaord for event attendance. This PR creates an auth0 machine to machine application (client) with the necessary permissions for doing just this.