### PR TITLE
Make core expose contract apis, not direct implementation apis

### DIFF
--- a/apps/dashboard/src/modules/event/mutations/use-register-for-event-mutation.ts
+++ b/apps/dashboard/src/modules/event/mutations/use-register-for-event-mutation.ts
@@ -14,7 +14,7 @@ export const useRegisterForEventMutation = () => {
     onSuccess: (data) => {
       notification.complete({
         title: "Påmelding vellykket",
-        message: `Bruker ${data.userId} ble påmeldt arrangementet.`,
+        message: `Bruker ${data?.userId} ble påmeldt arrangementet.`,
       })
     },
     onError: (err) => {

--- a/apps/dashboard/src/modules/event/mutations/use-update-event-attendance-mutation.ts
+++ b/apps/dashboard/src/modules/event/mutations/use-update-event-attendance-mutation.ts
@@ -13,7 +13,7 @@ export const useUpdateEventAttendanceMutation = () => {
     onSuccess: (data) => {
       notification.complete({
         title: "Oppmøte oppdatert",
-        message: `Oppmøte er ${data.attended ? "registrert" : "fjernet"} for bruker ${data.userId}.`,
+        message: `Oppmøte er ${data?.attended ? "registrert" : "fjernet"} for bruker ${data?.userId}.`,
       })
     },
     onError: (err) => {

--- a/infra/auth0/main.tf
+++ b/infra/auth0/main.tf
@@ -148,6 +148,7 @@ locals {
   monoweb = {
     web       = data.auth0_client.monoweb_web
     dashboard = data.auth0_client.monoweb_dashboard
+    gtx       = data.auth0_client.gtx
   }
 }
 
@@ -317,6 +318,33 @@ resource "auth0_resource_server" "auth0_management_api" {
   identifier  = "https://${data.auth0_tenant.tenant.domain}/api/v2/"
   name        = "Auth0 Management API"
   signing_alg = "RS256"
+}
+
+resource "auth0_client" "gtx" {
+  allowed_clients = []
+  allowed_origins = []
+  app_type        = "non_interactive" # this is a machine to machine application
+  grant_types     = ["client_credentials"]
+  name            = "gtx"
+  is_first_party  = true
+  oidc_conformant = true
+
+  jwt_configuration {
+    alg = "RS256"
+  }
+}
+
+data "auth0_client" "gtx" {
+  client_id = auth0_client.gtx.client_id
+}
+
+resource "auth0_client_grant" "monoweb_backend_mgmt_grant" {
+  audience  = "https://${data.auth0_tenant.tenant.domain}/api/v2/"
+  client_id = auth0_client.gtx.client_id
+  scopes = [
+    "read:users",
+    "read:user_idp_tokens"
+  ]
 }
 
 resource "auth0_client" "onlineweb4" {

--- a/packages/core/src/modules/core.ts
+++ b/packages/core/src/modules/core.ts
@@ -1,46 +1,64 @@
-import { type Kysely } from "kysely"
 import { type Database } from "@dotkomonline/db"
-import { EventRepositoryImpl } from "./event/event-repository"
-import { CommitteeRepositoryImpl } from "./committee/committee-repository"
-import { CompanyRepositoryImpl } from "./company/company-repository"
-import { EventCompanyRepositoryImpl } from "./event/event-company-repository"
-import { AttendanceRepositoryImpl } from "./event/attendance-repository"
-import { UserRepositoryImpl } from "./user/user-repository"
-import { ProductRepositoryImpl } from "./payment/product-repository"
-import { PaymentRepositoryImpl } from "./payment/payment-repository"
-import { ProductPaymentProviderRepositoryImpl } from "./payment/product-payment-provider-repository"
-import { RefundRequestRepositoryImpl } from "./payment/refund-request-repository"
-import { MarkRepositoryImpl } from "./mark/mark-repository"
-import { PersonalMarkRepositoryImpl } from "./mark/personal-mark-repository"
-import { PrivacyPermissionsRepositoryImpl } from "./user/privacy-permissions-repository"
-import { NotificationPermissionsRepositoryImpl } from "./user/notification-permissions-repository"
-import { UserServiceImpl } from "./user/user-service"
-import { EventServiceImpl } from "./event/event-service"
-import { AttendanceServiceImpl } from "./event/attendance-service"
-import { CommitteeServiceImpl } from "./committee/committee-service"
-import { CompanyServiceImpl } from "./company/company-service"
-import { EventCompanyServiceImpl } from "./event/event-company-service"
-import { ProductServiceImpl } from "./payment/product-service"
-import { PaymentServiceImpl } from "./payment/payment-service"
-import { ProductPaymentProviderServiceImpl } from "./payment/product-payment-provider-service"
-import { RefundRequestServiceImpl } from "./payment/refund-request-service"
-import { MarkServiceImpl } from "./mark/mark-service"
-import { PersonalMarkServiceImpl } from "./mark/personal-mark-service"
-import { CompanyEventRepositoryImpl } from "./company/company-event-repository"
-import { CompanyEventServiceImpl } from "./company/company-event-service"
-import { EventCommitteeServiceImpl } from "./event/event-committee-service"
-import { EventCommitteeRepositoryImpl } from "./event/event-committee-repository"
-import { JobListingRepositoryImpl } from "./job-listing/job-listing-repository"
-import { JobListingServiceImpl } from "./job-listing/job-listing-service"
-import { JobListingLocationRepositoryImpl } from "./job-listing/job-listing-location-repository"
-import { JobListingLocationLinkRepositoryImpl } from "./job-listing/job-listing-location-link-repository"
-import { OfflineRepositoryImpl } from "./offline/offline-repository"
-import { OfflineServiceImpl } from "./offline/offline-service"
-import { ArticleRepositoryImpl } from "./article/article-repository"
-import { ArticleTagLinkRepositoryImpl } from "./article/article-tag-link-repository"
-import { ArticleServiceImpl } from "./article/article-service"
-import { ArticleTagRepositoryImpl } from "./article/article-tag-repository"
-import { s3RepositoryImpl } from "../lib/s3/s3-repository"
+import { type Kysely } from "kysely"
+import { type ArticleRepository, ArticleRepositoryImpl } from "./article/article-repository"
+import { type ArticleService, ArticleServiceImpl } from "./article/article-service"
+import { type ArticleTagLinkRepository, ArticleTagLinkRepositoryImpl } from "./article/article-tag-link-repository"
+import { type ArticleTagRepository, ArticleTagRepositoryImpl } from "./article/article-tag-repository"
+import { type CommitteeRepository, CommitteeRepositoryImpl } from "./committee/committee-repository"
+import { type CommitteeService, CommitteeServiceImpl } from "./committee/committee-service"
+import { type CompanyEventRepository, CompanyEventRepositoryImpl } from "./company/company-event-repository"
+import { type CompanyEventService, CompanyEventServiceImpl } from "./company/company-event-service"
+import { type CompanyRepository, CompanyRepositoryImpl } from "./company/company-repository"
+import { type CompanyService, CompanyServiceImpl } from "./company/company-service"
+import { type AttendanceRepository, AttendanceRepositoryImpl } from "./event/attendance-repository"
+import { type AttendanceService, AttendanceServiceImpl } from "./event/attendance-service"
+import { type EventCommitteeRepository, EventCommitteeRepositoryImpl } from "./event/event-committee-repository"
+import { type EventCommitteeService, EventCommitteeServiceImpl } from "./event/event-committee-service"
+import { type EventCompanyRepository, EventCompanyRepositoryImpl } from "./event/event-company-repository"
+import { type EventCompanyService, EventCompanyServiceImpl } from "./event/event-company-service"
+import { type EventRepository, EventRepositoryImpl } from "./event/event-repository"
+import { type EventService, EventServiceImpl } from "./event/event-service"
+import {
+  type JobListingLocationLinkRepository,
+  JobListingLocationLinkRepositoryImpl,
+} from "./job-listing/job-listing-location-link-repository"
+import {
+  type JobListingLocationRepository,
+  JobListingLocationRepositoryImpl,
+} from "./job-listing/job-listing-location-repository"
+import { type JobListingRepository, JobListingRepositoryImpl } from "./job-listing/job-listing-repository"
+import { type JobListingService, JobListingServiceImpl } from "./job-listing/job-listing-service"
+import { type MarkRepository, MarkRepositoryImpl } from "./mark/mark-repository"
+import { type MarkService, MarkServiceImpl } from "./mark/mark-service"
+import { type PersonalMarkRepository, PersonalMarkRepositoryImpl } from "./mark/personal-mark-repository"
+import { type PersonalMarkService, PersonalMarkServiceImpl } from "./mark/personal-mark-service"
+import { type OfflineRepository, OfflineRepositoryImpl } from "./offline/offline-repository"
+import { type OfflineService, OfflineServiceImpl } from "./offline/offline-service"
+import { type PaymentRepository, PaymentRepositoryImpl } from "./payment/payment-repository"
+import { type PaymentService, PaymentServiceImpl } from "./payment/payment-service"
+import {
+  type ProductPaymentProviderRepository,
+  ProductPaymentProviderRepositoryImpl,
+} from "./payment/product-payment-provider-repository"
+import {
+  type ProductPaymentProviderService,
+  ProductPaymentProviderServiceImpl,
+} from "./payment/product-payment-provider-service"
+import { type ProductRepository, ProductRepositoryImpl } from "./payment/product-repository"
+import { type ProductService, ProductServiceImpl } from "./payment/product-service"
+import { type RefundRequestRepository, RefundRequestRepositoryImpl } from "./payment/refund-request-repository"
+import { type RefundRequestService, RefundRequestServiceImpl } from "./payment/refund-request-service"
+import {
+  type NotificationPermissionsRepository,
+  NotificationPermissionsRepositoryImpl,
+} from "./user/notification-permissions-repository"
+import {
+  type PrivacyPermissionsRepository,
+  PrivacyPermissionsRepositoryImpl,
+} from "./user/privacy-permissions-repository"
+import { type UserRepository, UserRepositoryImpl } from "./user/user-repository"
+import { type UserService, UserServiceImpl } from "./user/user-service"
+import { type S3Repository, s3RepositoryImpl } from "../lib/s3/s3-repository"
 
 export type ServiceLayer = Awaited<ReturnType<typeof createServiceLayer>>
 
@@ -49,66 +67,77 @@ export interface ServerLayerOptions {
 }
 
 export const createServiceLayer = async ({ db }: ServerLayerOptions) => {
-  const s3Repository = new s3RepositoryImpl()
-  const eventRepository = new EventRepositoryImpl(db)
-  const committeeRepository = new CommitteeRepositoryImpl(db)
-  const jobListingRepository = new JobListingRepositoryImpl(db)
-  const jobListingLocationRepository = new JobListingLocationRepositoryImpl(db)
-  const jobListingLocationLinkRepository = new JobListingLocationLinkRepositoryImpl(db)
-  const companyRepository = new CompanyRepositoryImpl(db)
-  const companyEventRepository = new CompanyEventRepositoryImpl(db)
-  const eventCompanyRepository = new EventCompanyRepositoryImpl(db)
-  const committeeOrganizerRepository = new EventCommitteeRepositoryImpl(db)
-  const attendanceRepository = new AttendanceRepositoryImpl(db)
-  const userRepository = new UserRepositoryImpl(db)
-  const productRepository = new ProductRepositoryImpl(db)
-  const paymentRepository = new PaymentRepositoryImpl(db)
-  const productPaymentProviderRepository = new ProductPaymentProviderRepositoryImpl(db)
-  const refundRequestRepository = new RefundRequestRepositoryImpl(db)
-  const markRepository = new MarkRepositoryImpl(db)
-  const personalMarkRepository = new PersonalMarkRepositoryImpl(db)
-  const privacyPermissionsRepository = new PrivacyPermissionsRepositoryImpl(db)
-  const notificationPermissionsRepository = new NotificationPermissionsRepositoryImpl(db)
-  const offlineRepository = new OfflineRepositoryImpl(db)
-  const articleRepository = new ArticleRepositoryImpl(db)
-  const articleTagRepository = new ArticleTagRepositoryImpl(db)
-  const articleTagLinkRepository = new ArticleTagLinkRepositoryImpl(db)
+  const s3Repository: S3Repository = new s3RepositoryImpl()
+  const eventRepository: EventRepository = new EventRepositoryImpl(db)
+  const committeeRepository: CommitteeRepository = new CommitteeRepositoryImpl(db)
+  const jobListingRepository: JobListingRepository = new JobListingRepositoryImpl(db)
+  const jobListingLocationRepository: JobListingLocationRepository = new JobListingLocationRepositoryImpl(db)
+  const jobListingLocationLinkRepository: JobListingLocationLinkRepository = new JobListingLocationLinkRepositoryImpl(
+    db
+  )
+  const companyRepository: CompanyRepository = new CompanyRepositoryImpl(db)
+  const companyEventRepository: CompanyEventRepository = new CompanyEventRepositoryImpl(db)
+  const eventCompanyRepository: EventCompanyRepository = new EventCompanyRepositoryImpl(db)
+  const committeeOrganizerRepository: EventCommitteeRepository = new EventCommitteeRepositoryImpl(db)
+  const attendanceRepository: AttendanceRepository = new AttendanceRepositoryImpl(db)
+  const userRepository: UserRepository = new UserRepositoryImpl(db)
+  const productRepository: ProductRepository = new ProductRepositoryImpl(db)
+  const paymentRepository: PaymentRepository = new PaymentRepositoryImpl(db)
+  const productPaymentProviderRepository: ProductPaymentProviderRepository = new ProductPaymentProviderRepositoryImpl(
+    db
+  )
+  const refundRequestRepository: RefundRequestRepository = new RefundRequestRepositoryImpl(db)
+  const markRepository: MarkRepository = new MarkRepositoryImpl(db)
+  const personalMarkRepository: PersonalMarkRepository = new PersonalMarkRepositoryImpl(db)
+  const privacyPermissionsRepository: PrivacyPermissionsRepository = new PrivacyPermissionsRepositoryImpl(db)
+  const notificationPermissionsRepository: NotificationPermissionsRepository =
+    new NotificationPermissionsRepositoryImpl(db)
+  const offlineRepository: OfflineRepository = new OfflineRepositoryImpl(db)
+  const articleRepository: ArticleRepository = new ArticleRepositoryImpl(db)
+  const articleTagRepository: ArticleTagRepository = new ArticleTagRepositoryImpl(db)
+  const articleTagLinkRepository: ArticleTagLinkRepository = new ArticleTagLinkRepositoryImpl(db)
 
-  const userService = new UserServiceImpl(
+  const userService: UserService = new UserServiceImpl(
     userRepository,
     privacyPermissionsRepository,
     notificationPermissionsRepository
   )
-  const eventService = new EventServiceImpl(eventRepository, attendanceRepository)
-  const eventCommitteeService = new EventCommitteeServiceImpl(committeeOrganizerRepository)
-  const attendanceService = new AttendanceServiceImpl(attendanceRepository)
-  const committeeService = new CommitteeServiceImpl(committeeRepository)
-  const jobListingService = new JobListingServiceImpl(
+  const eventService: EventService = new EventServiceImpl(eventRepository, attendanceRepository)
+  const eventCommitteeService: EventCommitteeService = new EventCommitteeServiceImpl(committeeOrganizerRepository)
+  const attendanceService: AttendanceService = new AttendanceServiceImpl(attendanceRepository)
+  const committeeService: CommitteeService = new CommitteeServiceImpl(committeeRepository)
+  const jobListingService: JobListingService = new JobListingServiceImpl(
     jobListingRepository,
     jobListingLocationRepository,
     jobListingLocationLinkRepository
   )
-  const companyService = new CompanyServiceImpl(companyRepository)
-  const companyEventService = new CompanyEventServiceImpl(companyEventRepository)
-  const eventCompanyService = new EventCompanyServiceImpl(eventCompanyRepository)
-  const productService = new ProductServiceImpl(productRepository)
-  const paymentService = new PaymentServiceImpl(
+  const companyService: CompanyService = new CompanyServiceImpl(companyRepository)
+  const companyEventService: CompanyEventService = new CompanyEventServiceImpl(companyEventRepository)
+  const eventCompanyService: EventCompanyService = new EventCompanyServiceImpl(eventCompanyRepository)
+  const productService: ProductService = new ProductServiceImpl(productRepository)
+  const paymentService: PaymentService = new PaymentServiceImpl(
     paymentRepository,
     productRepository,
     eventRepository,
     refundRequestRepository
   )
-  const productPaymentProviderService = new ProductPaymentProviderServiceImpl(productPaymentProviderRepository)
-  const refundRequestService = new RefundRequestServiceImpl(
+  const productPaymentProviderService: ProductPaymentProviderService = new ProductPaymentProviderServiceImpl(
+    productPaymentProviderRepository
+  )
+  const refundRequestService: RefundRequestService = new RefundRequestServiceImpl(
     refundRequestRepository,
     paymentRepository,
     productRepository,
     paymentService
   )
-  const markService = new MarkServiceImpl(markRepository)
-  const personalMarkService = new PersonalMarkServiceImpl(personalMarkRepository, markService)
-  const offlineService = new OfflineServiceImpl(offlineRepository, s3Repository)
-  const articleService = new ArticleServiceImpl(articleRepository, articleTagRepository, articleTagLinkRepository)
+  const markService: MarkService = new MarkServiceImpl(markRepository)
+  const personalMarkService: PersonalMarkService = new PersonalMarkServiceImpl(personalMarkRepository, markService)
+  const offlineService: OfflineService = new OfflineServiceImpl(offlineRepository, s3Repository)
+  const articleService: ArticleService = new ArticleServiceImpl(
+    articleRepository,
+    articleTagRepository,
+    articleTagLinkRepository
+  )
 
   return {
     userService,

--- a/packages/core/src/modules/event/event-committee-service.ts
+++ b/packages/core/src/modules/event/event-committee-service.ts
@@ -1,5 +1,5 @@
 import { type Committee, type CommitteeId, type EventCommittee, type EventId } from "@dotkomonline/types"
-import { type EventCommitteeRepositoryImpl } from "./event-committee-repository"
+import { type EventCommitteeRepository } from "./event-committee-repository"
 
 export interface EventCommitteeService {
   getCommitteesForEvent(eventId: EventId): Promise<Committee[]>
@@ -8,21 +8,21 @@ export interface EventCommitteeService {
 }
 
 export class EventCommitteeServiceImpl implements EventCommitteeService {
-  constructor(private readonly committeeOrganizerRepository: EventCommitteeRepositoryImpl) {}
+  constructor(private readonly committeeOrganizerRepository: EventCommitteeRepository) {}
 
   async getCommitteesForEvent(eventId: EventId): Promise<Committee[]> {
-    const committees = await this.committeeOrganizerRepository.getAllCommittees(eventId)
+    const committees = await this.committeeOrganizerRepository.getAllCommittees(eventId, 999)
     return committees
   }
 
   async getEventCommitteesForEvent(eventId: EventId): Promise<EventCommittee[]> {
-    const eventCommittees = await this.committeeOrganizerRepository.getAllEventCommittees(eventId)
+    const eventCommittees = await this.committeeOrganizerRepository.getAllEventCommittees(eventId, 999)
     return eventCommittees
   }
 
   async setEventCommittees(eventId: EventId, committees: CommitteeId[]): Promise<EventCommittee[]> {
     // Fetch all committees associated with the event
-    const eventCommittees = await this.committeeOrganizerRepository.getAllEventCommittees(eventId)
+    const eventCommittees = await this.committeeOrganizerRepository.getAllEventCommittees(eventId, 999)
     const currentCommitteeIds = eventCommittees.map((committee) => committee.committeeId)
 
     // Identify committees to add and remove

--- a/packages/core/src/modules/mark/personal-mark-repository.ts
+++ b/packages/core/src/modules/mark/personal-mark-repository.ts
@@ -8,7 +8,7 @@ export const mapToPersonalMark = (payload: Selectable<Database["personalMark"]>)
   PersonalMarkSchema.parse(payload)
 
 export interface PersonalMarkRepository {
-  getByMarkId(markId: MarkId): Promise<PersonalMark[]>
+  getByMarkId(markId: MarkId, take: number, cursor?: Cursor): Promise<PersonalMark[]>
   getAllByUserId(userId: UserId, take: number, cursor?: Cursor): Promise<PersonalMark[]>
   getAllMarksByUserId(userId: UserId, take: number, cursor?: Cursor): Promise<Mark[]>
   addToUserId(userId: UserId, markId: MarkId): Promise<PersonalMark | undefined>
@@ -48,8 +48,12 @@ export class PersonalMarkRepositoryImpl implements PersonalMarkRepository {
     return marks.map(mapToMark)
   }
 
-  async getByMarkId(markId: MarkId): Promise<PersonalMark[]> {
-    const personalMarks = await this.db.selectFrom("personalMark").selectAll().where("markId", "=", markId).execute()
+  async getByMarkId(markId: MarkId, take: number, cursor?: Cursor): Promise<PersonalMark[]> {
+    const query = orderedQuery(
+      this.db.selectFrom("personalMark").selectAll().where("markId", "=", markId).limit(take),
+      cursor
+    )
+    const personalMarks = await query.execute()
     return personalMarks.map(mapToPersonalMark)
   }
 

--- a/packages/core/src/modules/mark/personal-mark-service.ts
+++ b/packages/core/src/modules/mark/personal-mark-service.ts
@@ -32,8 +32,8 @@ export class PersonalMarkServiceImpl implements PersonalMarkService {
     return personalMarks
   }
 
-  async getPersonalMarksByMarkId(markId: MarkId): Promise<PersonalMark[]> {
-    const personalMarks = await this.personalMarkRepository.getByMarkId(markId)
+  async getPersonalMarksByMarkId(markId: MarkId, take: number, cursor?: Cursor): Promise<PersonalMark[]> {
+    const personalMarks = await this.personalMarkRepository.getByMarkId(markId, take, cursor)
     return personalMarks
   }
 

--- a/packages/core/src/modules/user/user-service.ts
+++ b/packages/core/src/modules/user/user-service.ts
@@ -16,7 +16,7 @@ export interface UserService {
   getUserById(id: UserId): Promise<User | undefined>
   getUserBySubject(id: User["auth0Sub"]): Promise<User | undefined>
   getAllUsers(limit: number): Promise<User[]>
-  searchUsers(searchQuery: string, take: number): Promise<User[]>
+  searchUsers(searchQuery: string, take: number, cursor?: Cursor): Promise<User[]>
   createUser(input: UserWrite): Promise<User>
   updateUser(id: UserId, payload: Partial<UserWrite>): Promise<User>
   getPrivacyPermissionsByUserId(id: string): Promise<PrivacyPermissions>
@@ -24,6 +24,11 @@ export interface UserService {
     id: UserId,
     data: Partial<Omit<PrivacyPermissionsWrite, "userId">>
   ): Promise<PrivacyPermissions>
+  getNotificationPermissionsByUserId(id: string): Promise<NotificationPermissions>
+  updateNotificationPermissionsForUserId(
+    id: string,
+    data: Partial<Omit<NotificationPermissionsWrite, "userId">>
+  ): Promise<NotificationPermissions>
 }
 
 export class UserServiceImpl implements UserService {

--- a/packages/gateway-trpc/src/modules/mark/personal-mark-router.ts
+++ b/packages/gateway-trpc/src/modules/mark/personal-mark-router.ts
@@ -11,7 +11,7 @@ export const personalMarkRouter = t.router({
     ),
   getByMark: protectedProcedure
     .input(z.object({ id: PersonalMarkSchema.shape.markId, paginate: PaginateInputSchema }))
-    .query(async ({ input, ctx }) => ctx.personalMarkService.getPersonalMarksByMarkId(input.id)),
+    .query(async ({ input, ctx }) => ctx.personalMarkService.getPersonalMarksByMarkId(input.id, input.paginate.take)),
   addToUser: protectedProcedure
     .input(PersonalMarkSchema)
     .mutation(async ({ input, ctx }) => ctx.personalMarkService.addPersonalMarkToUserId(input.userId, input.markId)),


### PR DESCRIPTION
Core should only expose the contracts of repositories/services and not the individual implementations. This way we force the contracts to stay updated as well, as previously you could add new methods to a service and get access to it thorugh core without updating interface.

Includes fix for EventCommitteeServiceImpl which was not following the EventCommitteeService interface.

All this PR does is adding the interface types to all repositories/services in core and fixes some issues that arose from this
