### PR TITLE
Refactor fixture generation

### DIFF
--- a/packages/db/src/db.generated.d.ts
+++ b/packages/db/src/db.generated.d.ts
@@ -1,281 +1,281 @@
-import type { ColumnType } from "kysely";
+import { type ColumnType } from "kysely"
 
-export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA";
+export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA"
 
-export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL";
+export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL"
 
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+  : ColumnType<T, T | undefined, T>
 
-export type Json = ColumnType<JsonValue, string, string>;
+export type Json = ColumnType<JsonValue, string, string>
 
-export type JsonArray = JsonValue[];
+export type JsonArray = JsonValue[]
 
 export type JsonObject = {
-  [K in string]?: JsonValue;
-};
+  [K in string]?: JsonValue
+}
 
-export type JsonPrimitive = boolean | number | string | null;
+export type JsonPrimitive = boolean | number | string | null
 
-export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
+export type JsonValue = JsonArray | JsonObject | JsonPrimitive
 
-export type PaymentProvider = "STRIPE";
+export type PaymentProvider = "STRIPE"
 
-export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID";
+export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID"
 
-export type ProductType = "EVENT";
+export type ProductType = "EVENT"
 
-export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED";
+export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED"
 
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface Articles {
-  author: string;
-  content: string;
-  createdAt: Generated<Timestamp>;
-  excerpt: string;
-  id: Generated<string>;
-  imageUrl: string;
-  photographer: string;
-  slug: string;
-  title: string;
-  updatedAt: Generated<Timestamp>;
+  author: string
+  content: string
+  createdAt: Generated<Timestamp>
+  excerpt: string
+  id: Generated<string>
+  imageUrl: string
+  photographer: string
+  slug: string
+  title: string
+  updatedAt: Generated<Timestamp>
 }
 
 export interface ArticleTagLink {
-  article: string;
-  tag: string;
+  article: string
+  tag: string
 }
 
 export interface ArticleTags {
-  name: string;
+  name: string
 }
 
 export interface Attendance {
-  createdAt: Generated<Timestamp>;
-  deregisterDeadline: Timestamp;
-  end: Timestamp;
-  eventId: string | null;
-  id: Generated<string>;
-  limit: number;
-  max: Generated<number>;
-  min: Generated<number>;
-  start: Timestamp;
-  updatedAt: Generated<Timestamp>;
+  createdAt: Generated<Timestamp>
+  deregisterDeadline: Timestamp
+  end: Timestamp
+  eventId: string | null
+  id: Generated<string>
+  limit: number
+  max: Generated<number>
+  min: Generated<number>
+  start: Timestamp
+  updatedAt: Generated<Timestamp>
 }
 
 export interface Attendee {
-  attendanceId: string | null;
-  attended: Generated<boolean>;
-  createdAt: Generated<Timestamp>;
-  extrasChoices: Json | null;
-  id: Generated<string>;
-  updatedAt: Generated<Timestamp>;
-  userId: string | null;
+  attendanceId: string | null
+  attended: Generated<boolean>
+  createdAt: Generated<Timestamp>
+  extrasChoices: Json | null
+  id: Generated<string>
+  updatedAt: Generated<Timestamp>
+  userId: string | null
 }
 
 export interface Committee {
-  createdAt: Generated<Timestamp>;
-  description: Generated<string>;
-  email: Generated<string>;
-  id: Generated<string>;
-  image: string | null;
-  name: string;
+  createdAt: Generated<Timestamp>
+  description: Generated<string>
+  email: Generated<string>
+  id: Generated<string>
+  image: string | null
+  name: string
 }
 
 export interface Company {
-  createdAt: Generated<Timestamp>;
-  description: string;
-  email: string;
-  id: Generated<string>;
-  image: string | null;
-  location: string | null;
-  name: string;
-  phone: string | null;
-  type: string | null;
-  website: string;
+  createdAt: Generated<Timestamp>
+  description: string
+  email: string
+  id: Generated<string>
+  image: string | null
+  location: string | null
+  name: string
+  phone: string | null
+  type: string | null
+  website: string
 }
 
 export interface Event {
-  createdAt: Generated<Timestamp>;
-  description: string | null;
-  end: Timestamp;
-  extras: Json | null;
-  id: Generated<string>;
-  imageUrl: string | null;
-  location: string | null;
-  public: boolean;
-  start: Timestamp;
-  status: EventStatus;
-  subtitle: string | null;
-  title: string;
-  type: EventType | null;
-  updatedAt: Generated<Timestamp>;
-  waitlist: string | null;
+  createdAt: Generated<Timestamp>
+  description: string | null
+  end: Timestamp
+  extras: Json | null
+  id: Generated<string>
+  imageUrl: string | null
+  location: string | null
+  public: boolean
+  start: Timestamp
+  status: EventStatus
+  subtitle: string | null
+  title: string
+  type: EventType | null
+  updatedAt: Generated<Timestamp>
+  waitlist: string | null
 }
 
 export interface EventCommittee {
-  committeeId: string;
-  eventId: string;
+  committeeId: string
+  eventId: string
 }
 
 export interface EventCompany {
-  companyId: string;
-  eventId: string;
+  companyId: string
+  eventId: string
 }
 
 export interface JobListing {
-  applicationEmail: string | null;
-  applicationLink: string | null;
-  companyId: string | null;
-  createdAt: Generated<Timestamp>;
-  deadline: Timestamp | null;
-  deadlineAsap: boolean;
-  description: string;
-  employment: string;
-  end: Timestamp;
-  featured: boolean;
-  id: Generated<string>;
-  ingress: string;
-  start: Timestamp;
-  title: string;
+  applicationEmail: string | null
+  applicationLink: string | null
+  companyId: string | null
+  createdAt: Generated<Timestamp>
+  deadline: Timestamp | null
+  deadlineAsap: boolean
+  description: string
+  employment: string
+  end: Timestamp
+  featured: boolean
+  id: Generated<string>
+  ingress: string
+  start: Timestamp
+  title: string
 }
 
 export interface JobListingLocation {
-  createdAt: Generated<Timestamp>;
-  id: Generated<string>;
-  name: string;
+  createdAt: Generated<Timestamp>
+  id: Generated<string>
+  name: string
 }
 
 export interface JobListingLocationLink {
-  createdAt: Generated<Timestamp>;
-  id: Generated<string>;
-  jobListingId: string | null;
-  locationId: string | null;
+  createdAt: Generated<Timestamp>
+  id: Generated<string>
+  jobListingId: string | null
+  locationId: string | null
 }
 
 export interface Mark {
-  category: string;
-  createdAt: Timestamp;
-  details: string | null;
-  duration: number;
-  id: Generated<string>;
-  title: string;
-  updatedAt: Generated<Timestamp>;
+  category: string
+  createdAt: Timestamp
+  details: string | null
+  duration: number
+  id: Generated<string>
+  title: string
+  updatedAt: Generated<Timestamp>
 }
 
 export interface NotificationPermissions {
-  applications: Generated<boolean>;
-  createdAt: Generated<Timestamp>;
-  groupMessages: Generated<boolean>;
-  markRulesUpdates: Generated<boolean>;
-  newArticles: Generated<boolean>;
-  receipts: Generated<boolean>;
-  registrationByAdministrator: Generated<boolean>;
-  registrationStart: Generated<boolean>;
-  standardNotifications: Generated<boolean>;
-  updatedAt: Generated<Timestamp>;
-  userId: string;
+  applications: Generated<boolean>
+  createdAt: Generated<Timestamp>
+  groupMessages: Generated<boolean>
+  markRulesUpdates: Generated<boolean>
+  newArticles: Generated<boolean>
+  receipts: Generated<boolean>
+  registrationByAdministrator: Generated<boolean>
+  registrationStart: Generated<boolean>
+  standardNotifications: Generated<boolean>
+  updatedAt: Generated<Timestamp>
+  userId: string
 }
 
 export interface Offline {
-  createdAt: Generated<Timestamp>;
-  fileUrl: string | null;
-  id: Generated<string>;
-  imageUrl: string | null;
-  published: Timestamp;
-  title: string;
-  updatedAt: Generated<Timestamp>;
+  createdAt: Generated<Timestamp>
+  fileUrl: string | null
+  id: Generated<string>
+  imageUrl: string | null
+  published: Timestamp
+  title: string
+  updatedAt: Generated<Timestamp>
 }
 
 export interface OwUser {
-  auth0Sub: string | null;
-  createdAt: Generated<Timestamp>;
-  id: Generated<string>;
-  studyYear: Generated<number>;
+  auth0Sub: string | null
+  createdAt: Generated<Timestamp>
+  id: Generated<string>
+  studyYear: Generated<number>
 }
 
 export interface Payment {
-  createdAt: Generated<Timestamp>;
-  id: Generated<string>;
-  paymentProviderId: string;
-  paymentProviderOrderId: string | null;
-  paymentProviderSessionId: string;
-  productId: string | null;
-  status: PaymentStatus;
-  updatedAt: Generated<Timestamp>;
-  userId: string | null;
+  createdAt: Generated<Timestamp>
+  id: Generated<string>
+  paymentProviderId: string
+  paymentProviderOrderId: string | null
+  paymentProviderSessionId: string
+  productId: string | null
+  status: PaymentStatus
+  updatedAt: Generated<Timestamp>
+  userId: string | null
 }
 
 export interface PersonalMark {
-  markId: string;
-  userId: string;
+  markId: string
+  userId: string
 }
 
 export interface PrivacyPermissions {
-  addressVisible: Generated<boolean>;
-  attendanceVisible: Generated<boolean>;
-  createdAt: Generated<Timestamp>;
-  emailVisible: Generated<boolean>;
-  phoneVisible: Generated<boolean>;
-  profileVisible: Generated<boolean>;
-  updatedAt: Generated<Timestamp>;
-  userId: string;
-  usernameVisible: Generated<boolean>;
+  addressVisible: Generated<boolean>
+  attendanceVisible: Generated<boolean>
+  createdAt: Generated<Timestamp>
+  emailVisible: Generated<boolean>
+  phoneVisible: Generated<boolean>
+  profileVisible: Generated<boolean>
+  updatedAt: Generated<Timestamp>
+  userId: string
+  usernameVisible: Generated<boolean>
 }
 
 export interface Product {
-  amount: number;
-  createdAt: Generated<Timestamp>;
-  deletedAt: Timestamp | null;
-  id: Generated<string>;
-  isRefundable: Generated<boolean>;
-  objectId: string | null;
-  refundRequiresApproval: Generated<boolean>;
-  type: ProductType;
-  updatedAt: Generated<Timestamp>;
+  amount: number
+  createdAt: Generated<Timestamp>
+  deletedAt: Timestamp | null
+  id: Generated<string>
+  isRefundable: Generated<boolean>
+  objectId: string | null
+  refundRequiresApproval: Generated<boolean>
+  type: ProductType
+  updatedAt: Generated<Timestamp>
 }
 
 export interface ProductPaymentProvider {
-  paymentProvider: PaymentProvider;
-  paymentProviderId: string;
-  productId: string;
+  paymentProvider: PaymentProvider
+  paymentProviderId: string
+  productId: string
 }
 
 export interface RefundRequest {
-  createdAt: Generated<Timestamp>;
-  handledBy: string | null;
-  id: Generated<string>;
-  paymentId: string | null;
-  reason: string;
-  status: Generated<RefundRequestStatus>;
-  updatedAt: Generated<Timestamp>;
-  userId: string | null;
+  createdAt: Generated<Timestamp>
+  handledBy: string | null
+  id: Generated<string>
+  paymentId: string | null
+  reason: string
+  status: Generated<RefundRequestStatus>
+  updatedAt: Generated<Timestamp>
+  userId: string | null
 }
 
 export interface DB {
-  articles: Articles;
-  articleTagLink: ArticleTagLink;
-  articleTags: ArticleTags;
-  attendance: Attendance;
-  attendee: Attendee;
-  committee: Committee;
-  company: Company;
-  event: Event;
-  eventCommittee: EventCommittee;
-  eventCompany: EventCompany;
-  jobListing: JobListing;
-  jobListingLocation: JobListingLocation;
-  jobListingLocationLink: JobListingLocationLink;
-  mark: Mark;
-  notificationPermissions: NotificationPermissions;
-  offline: Offline;
-  owUser: OwUser;
-  payment: Payment;
-  personalMark: PersonalMark;
-  privacyPermissions: PrivacyPermissions;
-  product: Product;
-  productPaymentProvider: ProductPaymentProvider;
-  refundRequest: RefundRequest;
+  articles: Articles
+  articleTagLink: ArticleTagLink
+  articleTags: ArticleTags
+  attendance: Attendance
+  attendee: Attendee
+  committee: Committee
+  company: Company
+  event: Event
+  eventCommittee: EventCommittee
+  eventCompany: EventCompany
+  jobListing: JobListing
+  jobListingLocation: JobListingLocation
+  jobListingLocationLink: JobListingLocationLink
+  mark: Mark
+  notificationPermissions: NotificationPermissions
+  offline: Offline
+  owUser: OwUser
+  payment: Payment
+  personalMark: PersonalMark
+  privacyPermissions: PrivacyPermissions
+  product: Product
+  productPaymentProvider: ProductPaymentProvider
+  refundRequest: RefundRequest
 }

--- a/packages/db/src/db.generated.d.ts
+++ b/packages/db/src/db.generated.d.ts
@@ -1,281 +1,281 @@
-import { type ColumnType } from "kysely"
+import type { ColumnType } from "kysely";
 
-export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA"
+export type EventStatus = "ATTENDANCE" | "NO_LIMIT" | "PUBLIC" | "TBA";
 
-export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL"
+export type EventType = "ACADEMIC" | "BEDPRES" | "COMPANY" | "SOCIAL";
 
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>
+  : ColumnType<T, T | undefined, T>;
 
-export type Json = ColumnType<JsonValue, string, string>
+export type Json = ColumnType<JsonValue, string, string>;
 
-export type JsonArray = JsonValue[]
+export type JsonArray = JsonValue[];
 
 export type JsonObject = {
-  [K in string]?: JsonValue
-}
+  [K in string]?: JsonValue;
+};
 
-export type JsonPrimitive = boolean | number | string | null
+export type JsonPrimitive = boolean | number | string | null;
 
-export type JsonValue = JsonArray | JsonObject | JsonPrimitive
+export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
-export type PaymentProvider = "STRIPE"
+export type PaymentProvider = "STRIPE";
 
-export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID"
+export type PaymentStatus = "PAID" | "REFUNDED" | "UNPAID";
 
-export type ProductType = "EVENT"
+export type ProductType = "EVENT";
 
-export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED"
+export type RefundRequestStatus = "APPROVED" | "PENDING" | "REJECTED";
 
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export interface Articles {
-  author: string
-  content: string
-  createdAt: Generated<Timestamp>
-  excerpt: string
-  id: Generated<string>
-  imageUrl: string
-  photographer: string
-  slug: string
-  title: string
-  updatedAt: Generated<Timestamp>
+  author: string;
+  content: string;
+  createdAt: Generated<Timestamp>;
+  excerpt: string;
+  id: Generated<string>;
+  imageUrl: string;
+  photographer: string;
+  slug: string;
+  title: string;
+  updatedAt: Generated<Timestamp>;
 }
 
 export interface ArticleTagLink {
-  article: string
-  tag: string
+  article: string;
+  tag: string;
 }
 
 export interface ArticleTags {
-  name: string
+  name: string;
 }
 
 export interface Attendance {
-  createdAt: Generated<Timestamp>
-  deregisterDeadline: Timestamp
-  end: Timestamp
-  eventId: string | null
-  id: Generated<string>
-  limit: number
-  max: Generated<number>
-  min: Generated<number>
-  start: Timestamp
-  updatedAt: Generated<Timestamp>
+  createdAt: Generated<Timestamp>;
+  deregisterDeadline: Timestamp;
+  end: Timestamp;
+  eventId: string | null;
+  id: Generated<string>;
+  limit: number;
+  max: Generated<number>;
+  min: Generated<number>;
+  start: Timestamp;
+  updatedAt: Generated<Timestamp>;
 }
 
 export interface Attendee {
-  attendanceId: string | null
-  attended: Generated<boolean>
-  createdAt: Generated<Timestamp>
-  extrasChoices: Json | null
-  id: Generated<string>
-  updatedAt: Generated<Timestamp>
-  userId: string | null
+  attendanceId: string | null;
+  attended: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  extrasChoices: Json | null;
+  id: Generated<string>;
+  updatedAt: Generated<Timestamp>;
+  userId: string | null;
 }
 
 export interface Committee {
-  createdAt: Generated<Timestamp>
-  description: Generated<string>
-  email: Generated<string>
-  id: Generated<string>
-  image: string | null
-  name: string
+  createdAt: Generated<Timestamp>;
+  description: Generated<string>;
+  email: Generated<string>;
+  id: Generated<string>;
+  image: string | null;
+  name: string;
 }
 
 export interface Company {
-  createdAt: Generated<Timestamp>
-  description: string
-  email: string
-  id: Generated<string>
-  image: string | null
-  location: string | null
-  name: string
-  phone: string | null
-  type: string | null
-  website: string
+  createdAt: Generated<Timestamp>;
+  description: string;
+  email: string;
+  id: Generated<string>;
+  image: string | null;
+  location: string | null;
+  name: string;
+  phone: string | null;
+  type: string | null;
+  website: string;
 }
 
 export interface Event {
-  createdAt: Generated<Timestamp>
-  description: string | null
-  end: Timestamp
-  extras: Json | null
-  id: Generated<string>
-  imageUrl: string | null
-  location: string | null
-  public: boolean
-  start: Timestamp
-  status: EventStatus
-  subtitle: string | null
-  title: string
-  type: EventType | null
-  updatedAt: Generated<Timestamp>
-  waitlist: string | null
+  createdAt: Generated<Timestamp>;
+  description: string | null;
+  end: Timestamp;
+  extras: Json | null;
+  id: Generated<string>;
+  imageUrl: string | null;
+  location: string | null;
+  public: boolean;
+  start: Timestamp;
+  status: EventStatus;
+  subtitle: string | null;
+  title: string;
+  type: EventType | null;
+  updatedAt: Generated<Timestamp>;
+  waitlist: string | null;
 }
 
 export interface EventCommittee {
-  committeeId: string
-  eventId: string
+  committeeId: string;
+  eventId: string;
 }
 
 export interface EventCompany {
-  companyId: string
-  eventId: string
+  companyId: string;
+  eventId: string;
 }
 
 export interface JobListing {
-  applicationEmail: string | null
-  applicationLink: string | null
-  companyId: string | null
-  createdAt: Generated<Timestamp>
-  deadline: Timestamp | null
-  deadlineAsap: boolean
-  description: string
-  employment: string
-  end: Timestamp
-  featured: boolean
-  id: Generated<string>
-  ingress: string
-  start: Timestamp
-  title: string
+  applicationEmail: string | null;
+  applicationLink: string | null;
+  companyId: string | null;
+  createdAt: Generated<Timestamp>;
+  deadline: Timestamp | null;
+  deadlineAsap: boolean;
+  description: string;
+  employment: string;
+  end: Timestamp;
+  featured: boolean;
+  id: Generated<string>;
+  ingress: string;
+  start: Timestamp;
+  title: string;
 }
 
 export interface JobListingLocation {
-  createdAt: Generated<Timestamp>
-  id: Generated<string>
-  name: string
+  createdAt: Generated<Timestamp>;
+  id: Generated<string>;
+  name: string;
 }
 
 export interface JobListingLocationLink {
-  createdAt: Generated<Timestamp>
-  id: Generated<string>
-  jobListingId: string | null
-  locationId: string | null
+  createdAt: Generated<Timestamp>;
+  id: Generated<string>;
+  jobListingId: string | null;
+  locationId: string | null;
 }
 
 export interface Mark {
-  category: string
-  createdAt: Timestamp
-  details: string | null
-  duration: number
-  id: Generated<string>
-  title: string
-  updatedAt: Generated<Timestamp>
+  category: string;
+  createdAt: Timestamp;
+  details: string | null;
+  duration: number;
+  id: Generated<string>;
+  title: string;
+  updatedAt: Generated<Timestamp>;
 }
 
 export interface NotificationPermissions {
-  applications: Generated<boolean>
-  createdAt: Generated<Timestamp>
-  groupMessages: Generated<boolean>
-  markRulesUpdates: Generated<boolean>
-  newArticles: Generated<boolean>
-  receipts: Generated<boolean>
-  registrationByAdministrator: Generated<boolean>
-  registrationStart: Generated<boolean>
-  standardNotifications: Generated<boolean>
-  updatedAt: Generated<Timestamp>
-  userId: string
+  applications: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  groupMessages: Generated<boolean>;
+  markRulesUpdates: Generated<boolean>;
+  newArticles: Generated<boolean>;
+  receipts: Generated<boolean>;
+  registrationByAdministrator: Generated<boolean>;
+  registrationStart: Generated<boolean>;
+  standardNotifications: Generated<boolean>;
+  updatedAt: Generated<Timestamp>;
+  userId: string;
 }
 
 export interface Offline {
-  createdAt: Generated<Timestamp>
-  fileUrl: string | null
-  id: Generated<string>
-  imageUrl: string | null
-  published: Timestamp
-  title: string
-  updatedAt: Generated<Timestamp>
+  createdAt: Generated<Timestamp>;
+  fileUrl: string | null;
+  id: Generated<string>;
+  imageUrl: string | null;
+  published: Timestamp;
+  title: string;
+  updatedAt: Generated<Timestamp>;
 }
 
 export interface OwUser {
-  auth0Sub: string | null
-  createdAt: Generated<Timestamp>
-  id: Generated<string>
-  studyYear: Generated<number>
+  auth0Sub: string | null;
+  createdAt: Generated<Timestamp>;
+  id: Generated<string>;
+  studyYear: Generated<number>;
 }
 
 export interface Payment {
-  createdAt: Generated<Timestamp>
-  id: Generated<string>
-  paymentProviderId: string
-  paymentProviderOrderId: string | null
-  paymentProviderSessionId: string
-  productId: string | null
-  status: PaymentStatus
-  updatedAt: Generated<Timestamp>
-  userId: string | null
+  createdAt: Generated<Timestamp>;
+  id: Generated<string>;
+  paymentProviderId: string;
+  paymentProviderOrderId: string | null;
+  paymentProviderSessionId: string;
+  productId: string | null;
+  status: PaymentStatus;
+  updatedAt: Generated<Timestamp>;
+  userId: string | null;
 }
 
 export interface PersonalMark {
-  markId: string
-  userId: string
+  markId: string;
+  userId: string;
 }
 
 export interface PrivacyPermissions {
-  addressVisible: Generated<boolean>
-  attendanceVisible: Generated<boolean>
-  createdAt: Generated<Timestamp>
-  emailVisible: Generated<boolean>
-  phoneVisible: Generated<boolean>
-  profileVisible: Generated<boolean>
-  updatedAt: Generated<Timestamp>
-  userId: string
-  usernameVisible: Generated<boolean>
+  addressVisible: Generated<boolean>;
+  attendanceVisible: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  emailVisible: Generated<boolean>;
+  phoneVisible: Generated<boolean>;
+  profileVisible: Generated<boolean>;
+  updatedAt: Generated<Timestamp>;
+  userId: string;
+  usernameVisible: Generated<boolean>;
 }
 
 export interface Product {
-  amount: number
-  createdAt: Generated<Timestamp>
-  deletedAt: Timestamp | null
-  id: Generated<string>
-  isRefundable: Generated<boolean>
-  objectId: string | null
-  refundRequiresApproval: Generated<boolean>
-  type: ProductType
-  updatedAt: Generated<Timestamp>
+  amount: number;
+  createdAt: Generated<Timestamp>;
+  deletedAt: Timestamp | null;
+  id: Generated<string>;
+  isRefundable: Generated<boolean>;
+  objectId: string | null;
+  refundRequiresApproval: Generated<boolean>;
+  type: ProductType;
+  updatedAt: Generated<Timestamp>;
 }
 
 export interface ProductPaymentProvider {
-  paymentProvider: PaymentProvider
-  paymentProviderId: string
-  productId: string
+  paymentProvider: PaymentProvider;
+  paymentProviderId: string;
+  productId: string;
 }
 
 export interface RefundRequest {
-  createdAt: Generated<Timestamp>
-  handledBy: string | null
-  id: Generated<string>
-  paymentId: string | null
-  reason: string
-  status: Generated<RefundRequestStatus>
-  updatedAt: Generated<Timestamp>
-  userId: string | null
+  createdAt: Generated<Timestamp>;
+  handledBy: string | null;
+  id: Generated<string>;
+  paymentId: string | null;
+  reason: string;
+  status: Generated<RefundRequestStatus>;
+  updatedAt: Generated<Timestamp>;
+  userId: string | null;
 }
 
 export interface DB {
-  articles: Articles
-  articleTagLink: ArticleTagLink
-  articleTags: ArticleTags
-  attendance: Attendance
-  attendee: Attendee
-  committee: Committee
-  company: Company
-  event: Event
-  eventCommittee: EventCommittee
-  eventCompany: EventCompany
-  jobListing: JobListing
-  jobListingLocation: JobListingLocation
-  jobListingLocationLink: JobListingLocationLink
-  mark: Mark
-  notificationPermissions: NotificationPermissions
-  offline: Offline
-  owUser: OwUser
-  payment: Payment
-  personalMark: PersonalMark
-  privacyPermissions: PrivacyPermissions
-  product: Product
-  productPaymentProvider: ProductPaymentProvider
-  refundRequest: RefundRequest
+  articles: Articles;
+  articleTagLink: ArticleTagLink;
+  articleTags: ArticleTags;
+  attendance: Attendance;
+  attendee: Attendee;
+  committee: Committee;
+  company: Company;
+  event: Event;
+  eventCommittee: EventCommittee;
+  eventCompany: EventCompany;
+  jobListing: JobListing;
+  jobListingLocation: JobListingLocation;
+  jobListingLocationLink: JobListingLocationLink;
+  mark: Mark;
+  notificationPermissions: NotificationPermissions;
+  offline: Offline;
+  owUser: OwUser;
+  payment: Payment;
+  personalMark: PersonalMark;
+  privacyPermissions: PrivacyPermissions;
+  product: Product;
+  productPaymentProvider: ProductPaymentProvider;
+  refundRequest: RefundRequest;
 }

--- a/tools/migrator/src/fixture.ts
+++ b/tools/migrator/src/fixture.ts
@@ -30,6 +30,14 @@ export interface ResultIds {
   attendancePool: LengthArray<string, 3>
 }
 
+export const updateResultIds = <T extends keyof ResultIds>(resultIds: ResultIds, key: T, results: { id: string }[]) => {
+  results.forEach((result, index) => {
+    if (index < resultIds[key].length) {
+      resultIds[key][index] = result.id
+    }
+  })
+}
+
 export const runFixtures = async () => {
   const resultIds: ResultIds = {
     owUser: ["", "", "", ""],
@@ -49,11 +57,7 @@ export const runFixtures = async () => {
       })
     )
     .execute()
-    .then((result) => {
-      result.forEach((row, idx) => {
-        resultIds.owUser[idx] = row.id
-      })
-    })
+    .then(updateResultIds.bind(null, resultIds, "owUser"))
 
   const companyFixtures = getCompanyFixtures()
   await db
@@ -74,11 +78,7 @@ export const runFixtures = async () => {
       })
     )
     .execute()
-    .then((result) => {
-      result.forEach((row, idx) => {
-        resultIds.company[idx] = row.id
-      })
-    })
+    .then(updateResultIds.bind(null, resultIds, "company"))
 
   const committeFixtures = getCommitteeFixtures()
   await db
@@ -95,11 +95,7 @@ export const runFixtures = async () => {
       })
     )
     .execute()
-    .then((result) => {
-      result.forEach((row, idx) => {
-        resultIds.committee[idx] = row.id
-      })
-    })
+    .then(updateResultIds.bind(null, resultIds, "committee"))
 
   const eventFixtures = getEventFixtures()
   await db
@@ -123,11 +119,7 @@ export const runFixtures = async () => {
       })
     )
     .execute()
-    .then((result) => {
-      result.forEach((row, idx) => {
-        resultIds.event[idx] = row.id
-      })
-    })
+    .then(updateResultIds.bind(null, resultIds, "event"))
 
   const eventCompanyFixtures = getEventCompany(resultIds.event, resultIds.company)
   await db
@@ -155,11 +147,7 @@ export const runFixtures = async () => {
       })
     )
     .execute()
-    .then((result) => {
-      result.forEach((row, idx) => {
-        resultIds.attendance[idx] = row.id
-      })
-    })
+    .then(updateResultIds.bind(null, resultIds, "attendance"))
 
   const attendeeFixtures = getAttendeeFixtures(resultIds.attendance, resultIds.owUser)
   await db.insertInto("attendee").values(attendeeFixtures).returning("id").execute()

--- a/tools/migrator/src/fixture.ts
+++ b/tools/migrator/src/fixture.ts
@@ -18,23 +18,15 @@ import { getProductFixtures } from "./fixtures/product"
 import { getProductPaymentProviderFixtures } from "./fixtures/product-payment-provider"
 import { getUserFixtures } from "./fixtures/user"
 
+interface WithIdentifier {
+  id: string
+}
+
 export type InsertedIds = {
   [K in keyof DB]: string[]
 }
 
-export const updateResultIds = <T extends keyof InsertedIds>(
-  resultIds: InsertedIds,
-  key: T,
-  results: { id: string }[]
-) => {
-  results.forEach((result, index) => {
-    if (index < resultIds[key].length) {
-      resultIds[key][index] = result.id
-    }
-  })
-}
-
-const mapId = (results: { id: string }[]) => results.map((res) => res.id)
+const mapId = (results: WithIdentifier[]) => results.map((res) => res.id)
 
 export const runFixtures = async () => {
   const insertedIds = {} as InsertedIds

--- a/tools/migrator/src/fixture.ts
+++ b/tools/migrator/src/fixture.ts
@@ -104,6 +104,5 @@ export const runFixtures = async () => {
     .values(getEventCommitteeFixtures(insertedIds.event, insertedIds.committee))
     .execute()
   await db.insertInto("productPaymentProvider").values(getProductPaymentProviderFixtures(insertedIds.product)).execute()
-
   await db.insertInto("personalMark").values(getPersonalMarkFixtures(insertedIds.mark, insertedIds.owUser)).execute()
 }

--- a/tools/migrator/src/fixture.ts
+++ b/tools/migrator/src/fixture.ts
@@ -1,3 +1,4 @@
+import { type DB } from "@dotkomonline/db/src/db.generated"
 import { db } from "./db"
 import { getAttendanceFixtures } from "./fixtures/attendance"
 import { getAttendeeFixtures } from "./fixtures/attendee"
@@ -5,7 +6,6 @@ import { getCommitteeFixtures } from "./fixtures/committee"
 import { getEventCommitteeFixtures } from "./fixtures/committee-organizer"
 import { getCompanyFixtures } from "./fixtures/company"
 import { getEventFixtures } from "./fixtures/event"
-import { getEventCompany } from "./fixtures/event-company"
 import { getJobListingFixtures, jobListingLocationLinks, jobListingLocations } from "./fixtures/job-listing"
 import { marks } from "./fixtures/mark"
 import { offlines } from "./fixtures/offline"
@@ -14,20 +14,19 @@ import { products } from "./fixtures/product"
 import { productPaymentProviders } from "./fixtures/product-payment-provider"
 import { users } from "./fixtures/user"
 
-// https://stackoverflow.com/a/74801694
-type LengthArray<T, N extends number, R extends T[] = []> = number extends N
-  ? T[]
-  : R["length"] extends N
-  ? R
-  : LengthArray<T, N, [T, ...R]>
+async function insert(tableName: keyof DB, fixtures: unknown[]) {
+  const resultIds = await db.insertInto(tableName).values(fixtures).execute()
+  console.log(`Inserted ${resultIds.length} rows into ${tableName}`)
+}
 
-export interface ResultIds {
-  owUser: LengthArray<string, 4>
-  company: LengthArray<string, 2>
-  committee: LengthArray<string, 2>
-  event: LengthArray<string, 2>
-  attendance: LengthArray<string, 2>
-  attendancePool: LengthArray<string, 3>
+async function insertReturn(tableName: keyof DB, fixtures: unknown[]): Promise<string[]> {
+  const resultIds = await db.insertInto(tableName).values(fixtures).returning("id").execute()
+  console.log(`Inserted ${resultIds.length} rows into ${tableName}`)
+  return resultIds.map((result) => result.id)
+}
+
+export type ResultIds = {
+  [K in keyof DB]: string[]
 }
 
 export const updateResultIds = <T extends keyof ResultIds>(resultIds: ResultIds, key: T, results: { id: string }[]) => {
@@ -39,199 +38,21 @@ export const updateResultIds = <T extends keyof ResultIds>(resultIds: ResultIds,
 }
 
 export const runFixtures = async () => {
-  const resultIds: ResultIds = {
-    owUser: ["", "", "", ""],
-    company: ["", ""],
-    committee: ["", ""],
-    event: ["", ""],
-    attendance: ["", ""],
-    attendancePool: ["", "", ""],
-  }
-  await db
-    .insertInto("owUser")
-    .values(users)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-      })
-    )
-    .execute()
-    .then(updateResultIds.bind(null, resultIds, "owUser"))
+  const resultIds: ResultIds = {} as ResultIds
 
-  const companyFixtures = getCompanyFixtures()
-  await db
-    .insertInto("company")
-    .values(companyFixtures)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        name: (eb) => eb.ref("excluded.name"),
-        description: (eb) => eb.ref("excluded.description"),
-        phone: (eb) => eb.ref("excluded.phone"),
-        email: (eb) => eb.ref("excluded.email"),
-        website: (eb) => eb.ref("excluded.website"),
-        location: (eb) => eb.ref("excluded.location"),
-        type: (eb) => eb.ref("excluded.type"),
-        image: (eb) => eb.ref("excluded.image"),
-      })
-    )
-    .execute()
-    .then(updateResultIds.bind(null, resultIds, "company"))
-
-  const committeFixtures = getCommitteeFixtures()
-  await db
-    .insertInto("committee")
-    .values(committeFixtures)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        name: (eb) => eb.ref("excluded.name"),
-        description: (eb) => eb.ref("excluded.description"),
-        email: (eb) => eb.ref("excluded.email"),
-        image: (eb) => eb.ref("excluded.image"),
-      })
-    )
-    .execute()
-    .then(updateResultIds.bind(null, resultIds, "committee"))
-
-  const eventFixtures = getEventFixtures()
-  await db
-    .insertInto("event")
-    .values(eventFixtures)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
-        title: (eb) => eb.ref("excluded.title"),
-        start: (eb) => eb.ref("excluded.start"),
-        end: (eb) => eb.ref("excluded.end"),
-        status: (eb) => eb.ref("excluded.status"),
-        type: (eb) => eb.ref("excluded.type"),
-        public: (eb) => eb.ref("excluded.public"),
-        description: (eb) => eb.ref("excluded.description"),
-        subtitle: (eb) => eb.ref("excluded.subtitle"),
-        imageUrl: (eb) => eb.ref("excluded.imageUrl"),
-        location: (eb) => eb.ref("excluded.location"),
-      })
-    )
-    .execute()
-    .then(updateResultIds.bind(null, resultIds, "event"))
-
-  const eventCompanyFixtures = getEventCompany(resultIds.event, resultIds.company)
-  await db
-    .insertInto("eventCompany")
-    .values(eventCompanyFixtures)
-    .onConflict((oc) => oc.columns(["eventId", "companyId"]).doNothing())
-    .execute()
-
-  const attendanceFixtures = getAttendanceFixtures(resultIds.event)
-  await db
-    .insertInto("attendance")
-    .values(attendanceFixtures)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
-        start: (eb) => eb.ref("excluded.start"),
-        end: (eb) => eb.ref("excluded.end"),
-        deregisterDeadline: (eb) => eb.ref("excluded.deregisterDeadline"),
-        limit: (eb) => eb.ref("excluded.limit"),
-        eventId: (eb) => eb.ref("excluded.eventId"),
-        min: (eb) => eb.ref("excluded.min"),
-        max: (eb) => eb.ref("excluded.max"),
-      })
-    )
-    .execute()
-    .then(updateResultIds.bind(null, resultIds, "attendance"))
-
-  const attendeeFixtures = getAttendeeFixtures(resultIds.attendance, resultIds.owUser)
-  await db.insertInto("attendee").values(attendeeFixtures).returning("id").execute()
-
-  await db
-    .insertInto("mark")
-    .values(marks)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
-        title: (eb) => eb.ref("excluded.title"),
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        category: (eb) => eb.ref("excluded.category"),
-        details: (eb) => eb.ref("excluded.details"),
-        duration: (eb) => eb.ref("excluded.duration"),
-      })
-    )
-    .execute()
-
-  await db
-    .insertInto("personalMark")
-    .values(personalMarks)
-    .onConflict((oc) => oc.columns(["userId", "markId"]).doNothing())
-    .execute()
-
-  await db
-    .insertInto("product")
-    .values(products)
-    .returning("id")
-    .onConflict((oc) =>
-      oc.column("id").doUpdateSet({
-        createdAt: (eb) => eb.ref("excluded.createdAt"),
-        updatedAt: (eb) => eb.ref("excluded.updatedAt"),
-        type: (eb) => eb.ref("excluded.type"),
-        objectId: (eb) => eb.ref("excluded.objectId"),
-        amount: (eb) => eb.ref("excluded.amount"),
-        deletedAt: (eb) => eb.ref("excluded.deletedAt"),
-        isRefundable: (eb) => eb.ref("excluded.isRefundable"),
-        refundRequiresApproval: (eb) => eb.ref("excluded.refundRequiresApproval"),
-      })
-    )
-    .execute()
-
-  await db
-    .insertInto("productPaymentProvider")
-    .values(productPaymentProviders)
-    .onConflict((oc) => oc.columns(["productId", "paymentProviderId"]).doNothing())
-    .execute()
-
-  const eventCommitteFixtures = getEventCommitteeFixtures(resultIds.event, resultIds.committee)
-  await db
-    .insertInto("eventCommittee")
-    .values(eventCommitteFixtures)
-    .returning("committeeId")
-    .onConflict((oc) => oc.columns(["committeeId", "eventId"]).doNothing())
-    .execute()
-
-  const jobListingFixtures = getJobListingFixtures(resultIds.company)
-  await db
-    .insertInto("jobListing")
-    .values(jobListingFixtures)
-    .returning("id")
-    .onConflict((oc) => oc.column("id").doNothing())
-    .execute()
-
-  await db
-    .insertInto("jobListingLocation")
-    .values(jobListingLocations)
-    .returning(["id", "name"])
-    .onConflict((oc) => oc.column("id").doNothing())
-    .execute()
-
-  await db
-    .insertInto("jobListingLocationLink")
-    .values(jobListingLocationLinks)
-    .returning("id")
-    .onConflict((oc) => oc.column("id").doNothing())
-    .execute()
-
-  await db
-    .insertInto("offline")
-    .values(offlines)
-    .returning("id")
-    .onConflict((oc) => oc.column("id").doNothing())
-    .execute()
+  resultIds.owUser = await insertReturn("owUser", users)
+  resultIds.company = await insertReturn("company", getCompanyFixtures())
+  resultIds.committee = await insertReturn("committee", getCommitteeFixtures())
+  resultIds.event = await insertReturn("event", getEventFixtures())
+  resultIds.attendance = await insertReturn("attendance", getAttendanceFixtures(resultIds.event))
+  resultIds.attendee = await insertReturn("attendee", getAttendeeFixtures(resultIds.attendance, resultIds.owUser))
+  resultIds.mark = await insertReturn("mark", marks)
+  await insert("personalMark", personalMarks)
+  resultIds.product = await insertReturn("product", products)
+  await insert("productPaymentProvider", productPaymentProviders)
+  await insert("eventCommittee", getEventCommitteeFixtures(resultIds.event, resultIds.committee))
+  resultIds.jobListing = await insertReturn("jobListing", getJobListingFixtures(resultIds.company))
+  resultIds.jobListingLocation = await insertReturn("jobListingLocation", jobListingLocations)
+  resultIds.jobListingLocationLink = await insertReturn("jobListingLocationLink", jobListingLocationLinks)
+  resultIds.offline = await insertReturn("offline", offlines)
 }

--- a/tools/migrator/src/fixture.ts
+++ b/tools/migrator/src/fixture.ts
@@ -39,20 +39,34 @@ const mapId = (results: { id: string }[]) => results.map((res) => res.id)
 export const runFixtures = async () => {
   const insertedIds = {} as InsertedIds
 
-  insertedIds.owUser = await db.insertInto("owUser").values(getUserFixtures()).returning("id").execute().then(mapId)
+  insertedIds.owUser = await db //
+    .insertInto("owUser")
+    .values(getUserFixtures())
+    .returning("id")
+    .execute()
+    .then(mapId)
+
   insertedIds.company = await db
     .insertInto("company")
     .values(getCompanyFixtures())
     .returning("id")
     .execute()
     .then(mapId)
+
   insertedIds.committee = await db
     .insertInto("committee")
     .values(getCommitteeFixtures())
     .returning("id")
     .execute()
     .then(mapId)
-  insertedIds.event = await db.insertInto("event").values(getEventFixtures()).returning("id").execute().then(mapId)
+
+  insertedIds.event = await db //
+    .insertInto("event")
+    .values(getEventFixtures())
+    .returning("id")
+    .execute()
+    .then(mapId)
+
   insertedIds.attendance = await db
     .insertInto("attendance")
     .values(getAttendanceFixtures(insertedIds.event))
@@ -67,31 +81,41 @@ export const runFixtures = async () => {
     .execute()
     .then(mapId)
 
-  insertedIds.mark = await db.insertInto("mark").values(getMarkFixtures()).returning("id").execute().then(mapId)
+  insertedIds.mark = await db //
+    .insertInto("mark")
+    .values(getMarkFixtures())
+    .returning("id")
+    .execute()
+    .then(mapId)
+
   insertedIds.product = await db
     .insertInto("product")
     .values(getProductFixtures())
     .returning("id")
     .execute()
     .then(mapId)
+
   insertedIds.jobListing = await db
     .insertInto("jobListing")
     .values(getJobListingFixtures(insertedIds.company))
     .returning("id")
     .execute()
     .then(mapId)
+
   insertedIds.jobListingLocation = await db
     .insertInto("jobListingLocation")
     .values(getJobListingLocationFixtures())
     .returning("id")
     .execute()
     .then(mapId)
+
   insertedIds.jobListingLocationLink = await db
     .insertInto("jobListingLocationLink")
     .values(getJobListingLocationLinkFixtures(insertedIds.jobListing, insertedIds.jobListingLocation))
     .returning("id")
     .execute()
     .then(mapId)
+
   insertedIds.offline = await db
     .insertInto("offline")
     .values(getOfflineFixtures())
@@ -99,10 +123,19 @@ export const runFixtures = async () => {
     .execute()
     .then(mapId)
 
+  // Tables with keys that are not used in other tables
   await db
     .insertInto("eventCommittee")
     .values(getEventCommitteeFixtures(insertedIds.event, insertedIds.committee))
     .execute()
-  await db.insertInto("productPaymentProvider").values(getProductPaymentProviderFixtures(insertedIds.product)).execute()
-  await db.insertInto("personalMark").values(getPersonalMarkFixtures(insertedIds.mark, insertedIds.owUser)).execute()
+
+  await db //
+    .insertInto("productPaymentProvider")
+    .values(getProductPaymentProviderFixtures(insertedIds.product))
+    .execute()
+
+  await db //
+    .insertInto("personalMark")
+    .values(getPersonalMarkFixtures(insertedIds.mark, insertedIds.owUser))
+    .execute()
 }

--- a/tools/migrator/src/fixtures/attendance.ts
+++ b/tools/migrator/src/fixtures/attendance.ts
@@ -1,41 +1,41 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
+import { type ResultIds } from "../fixture"
 
-export const attendances: Insertable<Database["attendance"]>[] = [
+export const getAttendanceFixtures: (eventIds: ResultIds["event"]) => Insertable<Database["attendance"]>[] = (
+  eventIds
+) => [
   {
-    id: "01HB64JAPWJBMZN3HN6RF5GPVF",
     createdAt: new Date("2023-02-22 13:30:04.713+00"),
     updatedAt: new Date("2023-02-22 13:30:04.713+00"),
     start: new Date("2023-06-11 15:00:00+00"),
     end: new Date("2023-06-12 15:00:00+00"),
     deregisterDeadline: new Date("2023-06-13 15:00:00+00"),
     limit: 20,
-    eventId: "01HB64TWZK1C5YK5J7VGNZPDGW",
+    eventId: eventIds[0],
     min: 0,
-    max: 5,
+    max: 1,
   },
   {
-    id: "01HB64JAPW86EXS7A4XG8D6K3X",
     createdAt: new Date("2023-02-23 11:03:49.289+00"),
     updatedAt: new Date("2023-02-23 11:03:49.289+00"),
     start: new Date("2023-06-16 15:00:00+00"),
     end: new Date("2023-06-17 15:00:00+00"),
     deregisterDeadline: new Date("2023-06-18 15:00:00+00"),
     limit: 5,
-    eventId: "01HB64TWZK1C5YK5J7VGNZPDGW",
-    min: 0,
-    max: 5,
+    eventId: eventIds[1],
+    min: 1,
+    max: 2,
   },
   {
-    id: "01HB64JAPW4Q0XR46MK831NTB2",
     createdAt: new Date("2023-02-25 11:03:49.289+00"),
     updatedAt: new Date("2023-02-25 11:03:49.289+00"),
     start: new Date("2023-06-18 15:00:00+00"),
     end: new Date("2023-06-19 15:00:00+00"),
     deregisterDeadline: new Date("2023-06-20 15:00:00+00"),
     limit: 20,
-    eventId: "01HB64TWZK1N8ABMH8JAE12101",
-    min: 0,
-    max: 5,
+    eventId: eventIds[1],
+    min: 2,
+    max: 3,
   },
 ]

--- a/tools/migrator/src/fixtures/attendance.ts
+++ b/tools/migrator/src/fixtures/attendance.ts
@@ -1,8 +1,8 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
-import { type ResultIds } from "../fixture"
+import { type InsertedIds } from "../fixture"
 
-export const getAttendanceFixtures: (eventIds: ResultIds["event"]) => Insertable<Database["attendance"]>[] = (
+export const getAttendanceFixtures: (eventIds: InsertedIds["event"]) => Insertable<Database["attendance"]>[] = (
   eventIds
 ) => [
   {

--- a/tools/migrator/src/fixtures/attendee.ts
+++ b/tools/migrator/src/fixtures/attendee.ts
@@ -1,10 +1,10 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
-import { type ResultIds } from "../fixture"
+import { type InsertedIds } from "../fixture"
 
 export const getAttendeeFixtures: (
-  attendanceIds: ResultIds["attendance"],
-  userIds: ResultIds["owUser"]
+  attendanceIds: InsertedIds["attendance"],
+  userIds: InsertedIds["owUser"]
 ) => Insertable<Database["attendee"]>[] = (attendanceIds, userIds) => [
   {
     createdAt: new Date("2023-02-22 13:30:04.713+00"),

--- a/tools/migrator/src/fixtures/attendee.ts
+++ b/tools/migrator/src/fixtures/attendee.ts
@@ -1,46 +1,51 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
+import { type ResultIds } from "../fixture"
 
-export const attendees: Insertable<Database["attendee"]>[] = [
-  {
-    id: "01HB64JAPWNDTA2PXF0BK6YTAE",
-    createdAt: new Date("2023-02-22 13:30:04.713+00"),
-    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-    userId: "01HB64XF7WZZZZZZZZZZZZZZZZ",
-    attendanceId: "01HB64JAPWJBMZN3HN6RF5GPVF",
-    extrasChoices: JSON.stringify([
-      {
-        id: "1",
-        choice: "1",
-      },
-      {
-        id: "2",
-        choice: "3",
-      },
-    ]),
-  },
-  {
-    id: "01HB64JAPXD30K1WYK53HYFXR2",
-    createdAt: new Date("2023-02-22 13:30:04.713+00"),
-    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-    userId: "01HB64XF7WXBPGVQKFKFGJBH4D",
-    attendanceId: "01HB64JAPWJBMZN3HN6RF5GPVF",
-    extrasChoices: JSON.stringify([
-      {
-        id: "1",
-        choice: "2",
-      },
-      {
-        id: "2",
-        choice: "3",
-      },
-    ]),
-  },
-  {
-    id: "01HB64JAPW4Q0XR46MK831NTB2",
-    createdAt: new Date("2023-02-22 13:30:04.713+00"),
-    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-    userId: "01HB64XF7WZZZZZZZZZZZZZZZZ",
-    attendanceId: "01HB64JAPW4Q0XR46MK831NTB2",
-  },
-]
+export const getAttendeeFixtures: (
+  attendanceIds: ResultIds["attendance"],
+  userIds: ResultIds["owUser"]
+) => Insertable<Database["attendee"]>[] = (attendanceIds, userIds) => {
+  console.log("attendanceIds", attendanceIds, "userIds", userIds)
+  return [
+    {
+      createdAt: new Date("2023-02-22 13:30:04.713+00"),
+      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+      userId: userIds[0],
+      attendanceId: attendanceIds[0],
+      extrasChoices: JSON.stringify([
+        {
+          id: "1",
+          choice: "1",
+        },
+        {
+          id: "2",
+          choice: "3",
+        },
+      ]),
+    },
+    {
+      createdAt: new Date("2023-02-22 13:30:04.713+00"),
+      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+      userId: userIds[1],
+      attendanceId: attendanceIds[0],
+      extrasChoices: JSON.stringify([
+        {
+          id: "1",
+          choice: "2",
+        },
+        {
+          id: "2",
+          choice: "3",
+        },
+      ]),
+    },
+    {
+      id: "01HB64JAPW4Q0XR46MK831NTB2",
+      createdAt: new Date("2023-02-22 13:30:04.713+00"),
+      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+      userId: userIds[2],
+      attendanceId: attendanceIds[0],
+    },
+  ]
+}

--- a/tools/migrator/src/fixtures/attendee.ts
+++ b/tools/migrator/src/fixtures/attendee.ts
@@ -5,47 +5,44 @@ import { type ResultIds } from "../fixture"
 export const getAttendeeFixtures: (
   attendanceIds: ResultIds["attendance"],
   userIds: ResultIds["owUser"]
-) => Insertable<Database["attendee"]>[] = (attendanceIds, userIds) => {
-  console.log("attendanceIds", attendanceIds, "userIds", userIds)
-  return [
-    {
-      createdAt: new Date("2023-02-22 13:30:04.713+00"),
-      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-      userId: userIds[0],
-      attendanceId: attendanceIds[0],
-      extrasChoices: JSON.stringify([
-        {
-          id: "1",
-          choice: "1",
-        },
-        {
-          id: "2",
-          choice: "3",
-        },
-      ]),
-    },
-    {
-      createdAt: new Date("2023-02-22 13:30:04.713+00"),
-      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-      userId: userIds[1],
-      attendanceId: attendanceIds[0],
-      extrasChoices: JSON.stringify([
-        {
-          id: "1",
-          choice: "2",
-        },
-        {
-          id: "2",
-          choice: "3",
-        },
-      ]),
-    },
-    {
-      id: "01HB64JAPW4Q0XR46MK831NTB2",
-      createdAt: new Date("2023-02-22 13:30:04.713+00"),
-      updatedAt: new Date("2023-02-22 13:30:04.713+00"),
-      userId: userIds[2],
-      attendanceId: attendanceIds[0],
-    },
-  ]
-}
+) => Insertable<Database["attendee"]>[] = (attendanceIds, userIds) => [
+  {
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: userIds[0],
+    attendanceId: attendanceIds[0],
+    extrasChoices: JSON.stringify([
+      {
+        id: "1",
+        choice: "1",
+      },
+      {
+        id: "2",
+        choice: "3",
+      },
+    ]),
+  },
+  {
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: userIds[1],
+    attendanceId: attendanceIds[0],
+    extrasChoices: JSON.stringify([
+      {
+        id: "1",
+        choice: "2",
+      },
+      {
+        id: "2",
+        choice: "3",
+      },
+    ]),
+  },
+  {
+    id: "01HB64JAPW4Q0XR46MK831NTB2",
+    createdAt: new Date("2023-02-22 13:30:04.713+00"),
+    updatedAt: new Date("2023-02-22 13:30:04.713+00"),
+    userId: userIds[2],
+    attendanceId: attendanceIds[0],
+  },
+]

--- a/tools/migrator/src/fixtures/committee-organizer.ts
+++ b/tools/migrator/src/fixtures/committee-organizer.ts
@@ -1,10 +1,10 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
-import { type ResultIds } from "../fixture"
+import { type InsertedIds } from "../fixture"
 
 export const getEventCommitteeFixtures: (
-  eventIds: ResultIds["event"],
-  committeeIds: ResultIds["committee"]
+  eventIds: InsertedIds["event"],
+  committeeIds: InsertedIds["committee"]
 ) => Insertable<Database["eventCommittee"]>[] = (eventIds, committeeIds) => [
   {
     eventId: eventIds[0],

--- a/tools/migrator/src/fixtures/committee-organizer.ts
+++ b/tools/migrator/src/fixtures/committee-organizer.ts
@@ -1,17 +1,21 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
+import { type ResultIds } from "../fixture"
 
-export const eventCommittees: Insertable<Database["eventCommittee"]>[] = [
+export const getEventCommitteeFixtures: (
+  eventIds: ResultIds["event"],
+  committeeIds: ResultIds["committee"]
+) => Insertable<Database["eventCommittee"]>[] = (eventIds, committeeIds) => [
   {
-    eventId: "01HB64TWZK1C5YK5J7VGNZPDGW",
-    committeeId: "01HB64JAPVE9RXE19JX2BXSNJX",
+    eventId: eventIds[0],
+    committeeId: committeeIds[0],
   },
   {
-    eventId: "01HB64TWZK1N8ABMH8JAE12101",
-    committeeId: "01HB64JAPVVHCWQAWQGFATVZXZ",
+    eventId: eventIds[0],
+    committeeId: committeeIds[1],
   },
   {
-    eventId: "01HB64TWZK1N8ABMH8JAE12101",
-    committeeId: "01HB64JAPW4FP1BJV0NTQSBF19",
+    eventId: eventIds[1],
+    committeeId: committeeIds[0],
   },
 ]

--- a/tools/migrator/src/fixtures/committee.ts
+++ b/tools/migrator/src/fixtures/committee.ts
@@ -3,7 +3,6 @@ import { type Insertable } from "kysely"
 
 export const getCommitteeFixtures: () => Insertable<Database["committee"]>[] = () => [
   {
-    id: "01HB64JAPVE9RXE19JX2BXSNJX",
     createdAt: new Date("2023-02-22 13:30:04.713+00"),
     name: "Dotkom",
     description:
@@ -13,7 +12,6 @@ export const getCommitteeFixtures: () => Insertable<Database["committee"]>[] = (
       "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/0990ab67-0f5b-4c4d-95f1-50a5293335a5.png",
   },
   {
-    id: "01HB64JAPVVHCWQAWQGFATVZXZ",
     createdAt: new Date("2023-02-23 11:03:49.289+00"),
     name: "Bedkom",
     description:
@@ -23,7 +21,6 @@ export const getCommitteeFixtures: () => Insertable<Database["committee"]>[] = (
       "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/974b88bd-de01-4b59-856f-f53d9bb600a0.png",
   },
   {
-    id: "01HB64JAPW4FP1BJV0NTQSBF19",
     createdAt: new Date("2023-02-25 11:03:49.289+00"),
     name: "Arrkom",
     description:
@@ -33,7 +30,6 @@ export const getCommitteeFixtures: () => Insertable<Database["committee"]>[] = (
       "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/xs/0954f3de-da25-44eb-b3a9-7dbba7e23f25.png",
   },
   {
-    id: "01HB64JAPW06HQ00VE2GZ4NFQ4",
     createdAt: new Date("2023-02-15 11:03:49.289+00"),
     name: "Hovedstyret",
     email: "hovedstyret@online.ntnu.no",

--- a/tools/migrator/src/fixtures/committee.ts
+++ b/tools/migrator/src/fixtures/committee.ts
@@ -1,7 +1,7 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const committees: Insertable<Database["committee"]>[] = [
+export const getCommitteeFixtures: () => Insertable<Database["committee"]>[] = () => [
   {
     id: "01HB64JAPVE9RXE19JX2BXSNJX",
     createdAt: new Date("2023-02-22 13:30:04.713+00"),

--- a/tools/migrator/src/fixtures/company.ts
+++ b/tools/migrator/src/fixtures/company.ts
@@ -1,9 +1,9 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const companies: Insertable<Database["company"]>[] = [
+// export const companies: Insertable<Database["company"]>[] = [
+export const getCompanyFixtures: () => Insertable<Database["company"]>[] = () => [
   {
-    id: "01HB64JAPXRPX1XSD2SMWYNGQ9",
     createdAt: new Date("2023-02-28 17:23:45.329666+00"),
     name: "Bekk",
     description: "Et konsulentselskap som forøvrig er hovedsponsor for Online Linjeforening",
@@ -16,7 +16,6 @@ export const companies: Insertable<Database["company"]>[] = [
       "https://onlineweb4-prod.s3.eu-north-1.amazonaws.com/media/images/responsive/md/6a826628-9ebf-426e-9966-625513779427.png",
   },
   {
-    id: "01HB64TWZJD1F83E5XNB96NF2R",
     createdAt: new Date("2023-03-01 14:50:38.564678+00"),
     name: "Junior Consulting",
     description: "Et konsulentselskap drevet av erfaringssultne studenter",

--- a/tools/migrator/src/fixtures/event-company.ts
+++ b/tools/migrator/src/fixtures/event-company.ts
@@ -1,10 +1,10 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
-import { type ResultIds } from "../fixture"
+import { type InsertedIds } from "../fixture"
 
 export const getEventCompany: (
-  event_ids: ResultIds["event"],
-  company_ids: ResultIds["company"]
+  event_ids: InsertedIds["event"],
+  company_ids: InsertedIds["company"]
 ) => Insertable<Database["eventCompany"]>[] = (event_ids, company_ids) => [
   {
     eventId: event_ids[0],

--- a/tools/migrator/src/fixtures/event-company.ts
+++ b/tools/migrator/src/fixtures/event-company.ts
@@ -1,17 +1,21 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
+import { type ResultIds } from "../fixture"
 
-export const eventCompany: Insertable<Database["eventCompany"]>[] = [
+export const getEventCompany: (
+  event_ids: ResultIds["event"],
+  company_ids: ResultIds["company"]
+) => Insertable<Database["eventCompany"]>[] = (event_ids, company_ids) => [
   {
-    eventId: "01HB64TWZK1C5YK5J7VGNZPDGW",
-    companyId: "01HB64JAPXRPX1XSD2SMWYNGQ9",
+    eventId: event_ids[0],
+    companyId: company_ids[0],
   },
   {
-    eventId: "01HB64TWZK1N8ABMH8JAE12101",
-    companyId: "01HB64JAPXRPX1XSD2SMWYNGQ9",
+    eventId: event_ids[0],
+    companyId: company_ids[1],
   },
   {
-    eventId: "01HB64TWZK1N8ABMH8JAE12101",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    eventId: event_ids[1],
+    companyId: company_ids[1],
   },
 ]

--- a/tools/migrator/src/fixtures/event.ts
+++ b/tools/migrator/src/fixtures/event.ts
@@ -1,9 +1,8 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const events: Insertable<Database["event"]>[] = [
+export const getEventFixtures: () => Insertable<Database["event"]>[] = () => [
   {
-    id: "01HB64TWZK1C5YK5J7VGNZPDGW",
     createdAt: new Date("2023-02-22 13:30:04.713+00"),
     updatedAt: new Date("2023-02-22 13:30:04.713+00"),
     title: "Kurs i å lage fixtures",
@@ -58,7 +57,6 @@ export const events: Insertable<Database["event"]>[] = [
     ]),
   },
   {
-    id: "01HB64TWZK1N8ABMH8JAE12101",
     createdAt: new Date("2023-02-23 11:03:49.289+00"),
     updatedAt: new Date("2023-02-23 11:03:49.289+00"),
     title: "Åre 2024",

--- a/tools/migrator/src/fixtures/job-listing.ts
+++ b/tools/migrator/src/fixtures/job-listing.ts
@@ -1,5 +1,6 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
+import { type ResultIds } from "../fixture"
 
 const employments = {
   fulltime: "Fulltid",
@@ -8,10 +9,13 @@ const employments = {
   other: "Annet",
 } as const
 
-export const jobListings: Insertable<Database["jobListing"]>[] = [
+// export const jobListings: Insertable<Database["jobListing"]>[] = [
+export const getJobListingFixtures: (companyId: ResultIds["company"]) => Insertable<Database["jobListing"]>[] = (
+  companyIds
+) => [
   {
     id: "01HD77R4Y4S3WJ44NZ8029VP4P",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Job at Bekk",
     ingress: "Join us at Bekk!",
     description: "Et konsulentselskap som forøvrig er hovedsponsor for Online Linjeforening",
@@ -26,7 +30,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y764E5Q5DY9YTT9ZF6",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[1],
     title: "Job at Junior Consulting",
     ingress: "Become a consultant at Junior Consulting!",
     description: "Et konsulentselskap drevet av erfaringssultne studenter",
@@ -41,7 +45,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y7RHCCQ5SYN31CVFRG",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[1],
     title: "Software engineer - summer intern",
     ingress:
       "Er du på utkikk etter sommerjobb innenfor edtech-sektoren? Kateter har oppnådd stor suksess ved å tilby Gløsinger kurs i utfordrende fag til en billig penge.",
@@ -58,7 +62,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y7XW6S2VBTPBJWMTN0",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Produktutvikler",
     ingress:
       "Brenner du for å skape noe nytt, og få ting til å skje? Vi er et team på seks personer med mål om å utvikle revolusjonerende teknologi for kunder over hele verden, og ser etter deg som ønsker å være med på reisen fremover.",
@@ -75,7 +79,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y9HFYK1NJV8SKSPKN3",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Energisommerjobb 2024: Vil du være med å forme fremtiden?",
     ingress:
       "Nå kan du prøve deg som forsker for en sommer hos SINTEF, et av Europas største uavhengige forskningsinstitutt!",
@@ -92,7 +96,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y9D8FJ8WHBY6GF67AW",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Sommerjobb i Sticos",
     ingress:
       "I perioden juni - august søker vi studenter til sommerjobb. Du får også anledning til å ta 3-4 uker ferie i juli.",
@@ -109,7 +113,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4Y998QA09CMCAJKGSD7",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Sommeren er best hos Avinor – bli med å utvikle fremtidens luftfart!",
     ingress:
       "Kunne du tenke deg en sommer der du er med og bidrar til å gjøre en liten forskjell i verden og samtidig gi deg selv en flying start på egen karriere? Avinors sommerprogram 2024 er klar for din søknad. Velkommen til oss!",
@@ -126,7 +130,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YAYQAR9V47DA5X1Q7C",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Norkart Sommer Internship 2024",
     ingress:
       "I Norkart er du med på å digitalisere Norge – ikke i teorien – men i virkeligheten. Vi er en markedsledende system- og dataleverandør innenfor stat, kommune og næringsliv - noe som gjør at våre løsninger påvirker hverdagen til svært mange personer.",
@@ -143,7 +147,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YAW54151ZE3ABZVGSX",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Software Engineering Summer Internship",
     ingress: "Are you our new Software Engineering Intern?",
     description:
@@ -159,7 +163,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YAQXGEH10C4XTT8J5K",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Associate Solutions Engineer - Norway",
     ingress: "Are You Our New Associate Solution Engineer?",
     description:
@@ -175,7 +179,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YA5CA0QYF0PEBGZNGZ",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Graduate Software Engineer - Norway",
     ingress: "Are You Our New Graduate Software Engineer?",
     description:
@@ -191,7 +195,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YAZN6ABDPB17K52NAH",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Form din fremtid gjennom internship i Deloitte Consulting",
     ingress:
       "Er du student og ønsker kompetanseheving og verdifull praksis for fremtiden? Da vil vi oppfordre deg til å søke internship hos oss i Consulting!",
@@ -208,7 +212,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YAMPR4PG0GSYBM9Y32",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Summer Internship 2024 - AI and Product Development",
     ingress:
       "Aneo is a renewable energy company with headquarters in Trondheim, established in 2022 by TrønderEnergi and HitecVision. Aneo invests heavily in wind power, solar power, electrification and energy efficiency in the Nordic region.",
@@ -225,7 +229,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YA6AH85A2EZ0BJP4MN",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Nyutdannet innen IT høsten 2024 og vil jobbe med Software Development?",
     ingress:
       "Ønsker du å bli en del av et felleskap med unge og engasjerte talenter som vil bygge en spennende karriere innen IT? Da er Ignite-programmet til Capgemini det perfekte starten for deg!",
@@ -243,7 +247,7 @@ export const jobListings: Insertable<Database["jobListing"]>[] = [
   },
   {
     id: "01HD77R4YCTMJ7XPRHCEDQ616B",
-    companyId: "01HB64TWZJD1F83E5XNB96NF2R",
+    companyId: companyIds[0],
     title: "Kickstart karrieren som konsulent i twoday",
     ingress:
       "I twoday kan du starte karrieren som fast ansatt sammen med en håndplukket gjeng.\r\nMålet er å få deg raskt ut på prosjekt – parallelt med spennede kurs, fagkvelder, reiser\r\nog mye sosialt.",

--- a/tools/migrator/src/fixtures/job-listing.ts
+++ b/tools/migrator/src/fixtures/job-listing.ts
@@ -1,6 +1,6 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
-import { type ResultIds } from "../fixture"
+import { type InsertedIds } from "../fixture"
 
 const employments = {
   fulltime: "Fulltid",
@@ -10,11 +10,10 @@ const employments = {
 } as const
 
 // export const jobListings: Insertable<Database["jobListing"]>[] = [
-export const getJobListingFixtures: (companyId: ResultIds["company"]) => Insertable<Database["jobListing"]>[] = (
+export const getJobListingFixtures: (companyId: InsertedIds["company"]) => Insertable<Database["jobListing"]>[] = (
   companyIds
 ) => [
   {
-    id: "01HD77R4Y4S3WJ44NZ8029VP4P",
     companyId: companyIds[0],
     title: "Job at Bekk",
     ingress: "Join us at Bekk!",
@@ -29,7 +28,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     deadlineAsap: false, // Placeholder value
   },
   {
-    id: "01HD77R4Y764E5Q5DY9YTT9ZF6",
     companyId: companyIds[1],
     title: "Job at Junior Consulting",
     ingress: "Become a consultant at Junior Consulting!",
@@ -44,7 +42,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     deadlineAsap: false, // Placeholder value
   },
   {
-    id: "01HD77R4Y7RHCCQ5SYN31CVFRG",
     companyId: companyIds[1],
     title: "Software engineer - summer intern",
     ingress:
@@ -61,7 +58,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4Y7XW6S2VBTPBJWMTN0",
     companyId: companyIds[0],
     title: "Produktutvikler",
     ingress:
@@ -78,7 +74,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.parttime,
   },
   {
-    id: "01HD77R4Y9HFYK1NJV8SKSPKN3",
     companyId: companyIds[0],
     title: "Energisommerjobb 2024: Vil du være med å forme fremtiden?",
     ingress:
@@ -95,7 +90,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4Y9D8FJ8WHBY6GF67AW",
     companyId: companyIds[0],
     title: "Sommerjobb i Sticos",
     ingress:
@@ -112,7 +106,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4Y998QA09CMCAJKGSD7",
     companyId: companyIds[0],
     title: "Sommeren er best hos Avinor – bli med å utvikle fremtidens luftfart!",
     ingress:
@@ -129,7 +122,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4YAYQAR9V47DA5X1Q7C",
     companyId: companyIds[0],
     title: "Norkart Sommer Internship 2024",
     ingress:
@@ -146,7 +138,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4YAW54151ZE3ABZVGSX",
     companyId: companyIds[0],
     title: "Software Engineering Summer Internship",
     ingress: "Are you our new Software Engineering Intern?",
@@ -162,7 +153,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4YAQXGEH10C4XTT8J5K",
     companyId: companyIds[0],
     title: "Associate Solutions Engineer - Norway",
     ingress: "Are You Our New Associate Solution Engineer?",
@@ -178,7 +168,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.fulltime,
   },
   {
-    id: "01HD77R4YA5CA0QYF0PEBGZNGZ",
     companyId: companyIds[0],
     title: "Graduate Software Engineer - Norway",
     ingress: "Are You Our New Graduate Software Engineer?",
@@ -194,7 +183,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.fulltime,
   },
   {
-    id: "01HD77R4YAZN6ABDPB17K52NAH",
     companyId: companyIds[0],
     title: "Form din fremtid gjennom internship i Deloitte Consulting",
     ingress:
@@ -211,7 +199,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4YAMPR4PG0GSYBM9Y32",
     companyId: companyIds[0],
     title: "Summer Internship 2024 - AI and Product Development",
     ingress:
@@ -228,7 +215,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.internship,
   },
   {
-    id: "01HD77R4YA6AH85A2EZ0BJP4MN",
     companyId: companyIds[0],
     title: "Nyutdannet innen IT høsten 2024 og vil jobbe med Software Development?",
     ingress:
@@ -246,7 +232,6 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
     employment: employments.fulltime,
   },
   {
-    id: "01HD77R4YCTMJ7XPRHCEDQ616B",
     companyId: companyIds[0],
     title: "Kickstart karrieren som konsulent i twoday",
     ingress:
@@ -264,29 +249,32 @@ export const getJobListingFixtures: (companyId: ResultIds["company"]) => Inserta
   },
 ]
 
-export const jobListingLocations: Insertable<Database["jobListingLocation"]>[] = [
-  { name: "Fredrikstad", id: "01HD99TC1RF2DBYKBTJZDN35GG" },
-  { name: "Tromsø", id: "01HD99TC1T89TQ76VSW1PWQ6BQ" },
-  { name: "Bodø", id: "01HD99TC1TSFA62739TJ21KDMV" },
-  { name: "Oslo", id: "01HD99TC1T9DFGM6APVQ6FV8HM" },
-  { name: "Trondheim", id: "01HD99TC1THMR30405QJ9ZVYE8" },
+export const getJobListingLocationFixtures: () => Insertable<Database["jobListingLocation"]>[] = () => [
+  { name: "Fredrikstad" },
+  { name: "Tromsø" },
+  { name: "Bodø" },
+  { name: "Oslo" },
+  { name: "Trondheim" },
 ]
 
-export const jobListingLocationLinks: Insertable<Database["jobListingLocationLink"]>[] = [
+export const getJobListingLocationLinkFixtures: (
+  jobListingIds: string[],
+  locationIds: string[]
+) => Insertable<Database["jobListingLocationLink"]>[] = (jobListingIds, locationIds) => [
   {
-    jobListingId: "01HD77R4Y4S3WJ44NZ8029VP4P",
-    locationId: "01HD99TC1T9DFGM6APVQ6FV8HM",
+    jobListingId: jobListingIds[0],
+    locationId: locationIds[0],
   },
   {
-    jobListingId: "01HD77R4Y4S3WJ44NZ8029VP4P",
-    locationId: "01HD99TC1THMR30405QJ9ZVYE8",
+    jobListingId: jobListingIds[0],
+    locationId: locationIds[1],
   },
   {
-    jobListingId: "01HD77R4Y4S3WJ44NZ8029VP4P",
-    locationId: "01HD99TC1T89TQ76VSW1PWQ6BQ",
+    jobListingId: jobListingIds[0],
+    locationId: locationIds[1],
   },
   {
-    jobListingId: "01HD77R4Y764E5Q5DY9YTT9ZF6",
-    locationId: "01HD99TC1THMR30405QJ9ZVYE8",
+    jobListingId: jobListingIds[0],
+    locationId: locationIds[1],
   },
 ]

--- a/tools/migrator/src/fixtures/mark.ts
+++ b/tools/migrator/src/fixtures/mark.ts
@@ -1,9 +1,8 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const marks: Insertable<Database["mark"]>[] = [
+export const getMarkFixtures: () => Insertable<Database["mark"]>[] = () => [
   {
-    id: "01HB64TWZK96KY3GRDFDABDSC6",
     updatedAt: new Date("2023-01-25 19:58:43.138389+00"),
     title: "a",
     createdAt: new Date("2023-01-25 19:58:43.138389+00"),
@@ -12,7 +11,6 @@ export const marks: Insertable<Database["mark"]>[] = [
     duration: 20,
   },
   {
-    id: "01HB64TWZKDFXAG4HX3CQNE6BX",
     updatedAt: new Date("2023-01-25 20:05:31.034217+00"),
     title: "a",
     createdAt: new Date("2023-01-25 20:05:31.034217+00"),

--- a/tools/migrator/src/fixtures/offline.ts
+++ b/tools/migrator/src/fixtures/offline.ts
@@ -1,16 +1,14 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const offlines: Insertable<Database["offline"]>[] = [
+export const getOfflineFixtures: () => Insertable<Database["offline"]>[] = () => [
   {
-    id: "01HD77R4Y4S3WJ44NZ8029VP4P",
     title: "Offline #1",
     published: new Date("2023-10-09T10:00:00+02:00"),
     fileUrl: null,
     imageUrl: null,
   },
   {
-    id: "01HD77R4Y4S3WJ44NZ8029VP4C",
     title: "Offline #2",
     published: new Date("2023-10-09T10:00:00+02:00"),
     fileUrl: null,

--- a/tools/migrator/src/fixtures/personal-mark.ts
+++ b/tools/migrator/src/fixtures/personal-mark.ts
@@ -1,9 +1,12 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const personalMarks: Insertable<Database["personalMark"]>[] = [
+export const getPersonalMarkFixtures: (
+  markIds: string[],
+  userIds: string[]
+) => Insertable<Database["personalMark"]>[] = (markIds, userIds) => [
   {
-    markId: "01HB64TWZK96KY3GRDFDABDSC6",
-    userId: "01HB64XF7WXBPGVQKFKFGJBH4D",
+    markId: markIds[0],
+    userId: userIds[0],
   },
 ]

--- a/tools/migrator/src/fixtures/product-payment-provider.ts
+++ b/tools/migrator/src/fixtures/product-payment-provider.ts
@@ -1,14 +1,16 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const productPaymentProviders: Insertable<Database["productPaymentProvider"]>[] = [
+export const getProductPaymentProviderFixtures: (
+  productIds: string[]
+) => Insertable<Database["productPaymentProvider"]>[] = (productIds) => [
   {
-    productId: "01HB64TWZMXJEXKB3M7RQ705E5",
+    productId: productIds[0],
     paymentProvider: "STRIPE",
     paymentProviderId: "pk_test_t3JLACvjcDHrHyEQEkQYm3Hz",
   },
   {
-    productId: "01HB64TWZM3GN9R4DEYK0Q6RZG",
+    productId: productIds[1],
     paymentProvider: "STRIPE",
     paymentProviderId: "pk_test_t3JLACvjcDHrHyEQEkQYm3Hz",
   },

--- a/tools/migrator/src/fixtures/product.ts
+++ b/tools/migrator/src/fixtures/product.ts
@@ -1,9 +1,8 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const products: Insertable<Database["product"]>[] = [
+export const getProductFixtures: () => Insertable<Database["product"]>[] = () => [
   {
-    id: "01HB64TWZMXJEXKB3M7RQ705E5",
     createdAt: new Date("2023-04-29 21:20:15.229179+00"),
     updatedAt: new Date("2023-04-29 21:20:15.229179+00"),
     type: "EVENT",
@@ -14,7 +13,6 @@ export const products: Insertable<Database["product"]>[] = [
     refundRequiresApproval: true,
   },
   {
-    id: "01HB64TWZM3GN9R4DEYK0Q6RZG",
     createdAt: new Date("2023-04-29 21:20:15.229179+00"),
     updatedAt: new Date("2023-04-29 21:20:15.229179+00"),
     type: "EVENT",

--- a/tools/migrator/src/fixtures/user.ts
+++ b/tools/migrator/src/fixtures/user.ts
@@ -1,21 +1,18 @@
 import { type Database } from "@dotkomonline/db"
 import { type Insertable } from "kysely"
 
-export const users: Insertable<Database["owUser"]>[] = [
+export const getUserFixtures: () => Insertable<Database["owUser"]>[] = () => [
   {
     auth0Sub: "auth0|4dd4698d-c376-4e5e-b5fb-4db9bf6cd417", // brage.baugerod@online.ntnu.no
-    id: "01HB64XF7WXBPGVQKFKFGJBH4D",
     createdAt: new Date("2023-04-30 19:22:17.627253+00"),
     studyYear: 3,
   },
   {
     auth0Sub: "auth0|7f6e0389-b49f-4bbc-b401-505f4b53fb3c", // njal.sorland@online.ntnu.no
-    id: "11HB64XF7WXBPGVQKFKFGJBH4D",
     createdAt: new Date("2023-08-11 21:22:17.627253+00"),
     studyYear: 5,
   },
   {
-    id: "01HB64XF7WZZZZZZZZZZZZZZZZ",
     createdAt: new Date("2023-04-30 21:22:17.627253+00"),
     auth0Sub: "auth0|dddddddd-c376-4e5e-b5fb-4db9bf6cd417",
     studyYear: 0,


### PR DESCRIPTION
**Background**
I was creating new fixtures due to some changes that needed to be made to the database schema. I found it very annoying to generate the ulids manually, seeing that the ulids should be absolutely ordered based on insert time. Ended up rewriting such that the ids are generated by the database. 

**Changes**
- Use functions to generate fixtures instead of hard-coded objects so that you can inject FK-IDs from previous fixtures
- some helper functions to make the code a bit neater