### PR TITLE
Improve performance in integration tests

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,9 +35,9 @@
     "@dotkomonline/types": "workspace:*",
     "@testcontainers/postgresql": "^10.7.1",
     "@types/node": "^18.18.13",
-    "@vitest/ui": "^0.34.6",
+    "@vitest/ui": "^1.3.1",
     "testcontainers": "^10.7.1",
     "typescript": "^5.2.2",
-    "vitest": "^0.34.6"
+    "vitest": "^1.3.1"
   }
 }

--- a/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
+++ b/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it, expect } from "vitest"
+import { beforeAll, afterEach, beforeEach, describe, it, expect } from "vitest"
 import { createEnvironment } from "@dotkomonline/env"
 import { Database, createKysely } from "@dotkomonline/db"
 import { type Company } from "@dotkomonline/types"
@@ -12,15 +12,24 @@ import {
   InvalidStartDateError,
 } from "../job-listing-service"
 import { Kysely } from "kysely"
+import { buildDbUrl, setupTestDB } from "../../../../vitest-integration.setup"
 
 describe("job-listings", () => {
   let core: ServiceLayer
   let company: Company
   let db: Kysely<Database>
+  const dbName = "joblisting"
 
   beforeEach(async () => {
     const env = createEnvironment()
-    db = createKysely(env)
+    await setupTestDB(env, dbName)
+
+    const testDbURL = buildDbUrl(dbName)
+    db = createKysely({
+      ...env,
+      DATABASE_URL: testDbURL,
+    })
+
     core = await createServiceLayer({ db })
     company = await core.companyService.createCompany(getCompanyMock())
   })

--- a/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
+++ b/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
@@ -1,9 +1,11 @@
-import { beforeAll, afterEach, beforeEach, describe, it, expect } from "vitest"
+import { Database } from "@dotkomonline/db"
 import { createEnvironment } from "@dotkomonline/env"
-import { Database, createKysely } from "@dotkomonline/db"
 import { type Company } from "@dotkomonline/types"
 import { addDays, addMinutes, subDays } from "date-fns"
+import { Kysely } from "kysely"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { getCompanyMock, getJobListingMock } from "../../../../mock"
+import { getTestDb, setupTestDB } from "../../../../vitest-integration.setup"
 import { createServiceLayer, type ServiceLayer } from "../../core"
 import {
   InvalidDeadlineError,
@@ -11,8 +13,6 @@ import {
   InvalidLocationError,
   InvalidStartDateError,
 } from "../job-listing-service"
-import { Kysely } from "kysely"
-import { buildDbUrl, setupTestDB } from "../../../../vitest-integration.setup"
 
 describe("job-listings", () => {
   let core: ServiceLayer
@@ -24,11 +24,7 @@ describe("job-listings", () => {
     const env = createEnvironment()
     await setupTestDB(env, dbName)
 
-    const testDbURL = buildDbUrl(dbName)
-    db = createKysely({
-      ...env,
-      DATABASE_URL: testDbURL,
-    })
+    db = getTestDb(env, dbName)
 
     core = await createServiceLayer({ db })
     company = await core.companyService.createCompany(getCompanyMock())

--- a/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
+++ b/packages/core/src/modules/job-listing/__test__/job-listing.e2e-spec.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, it, expect } from "vitest"
+import { afterEach, beforeEach, describe, it, expect } from "vitest"
 import { createEnvironment } from "@dotkomonline/env"
-import { createKysely } from "@dotkomonline/db"
+import { Database, createKysely } from "@dotkomonline/db"
 import { type Company } from "@dotkomonline/types"
 import { addDays, addMinutes, subDays } from "date-fns"
 import { getCompanyMock, getJobListingMock } from "../../../../mock"
@@ -11,16 +11,22 @@ import {
   InvalidLocationError,
   InvalidStartDateError,
 } from "../job-listing-service"
+import { Kysely } from "kysely"
 
 describe("job-listings", () => {
   let core: ServiceLayer
   let company: Company
+  let db: Kysely<Database>
 
   beforeEach(async () => {
     const env = createEnvironment()
-    const db = createKysely(env)
+    db = createKysely(env)
     core = await createServiceLayer({ db })
     company = await core.companyService.createCompany(getCompanyMock())
+  })
+
+  afterEach(async () => {
+    await db.destroy()
   })
 
   it("can create new job listings", async () => {

--- a/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
+++ b/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
@@ -36,10 +36,6 @@ describe("users", () => {
     await db.destroy()
   })
 
-  afterEach(async () => {
-    await db.destroy()
-  })
-
   it("can create new users", async () => {
     const none = await core.userService.getAllUsers(100)
     expect(none).toHaveLength(0)

--- a/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
+++ b/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
@@ -1,11 +1,9 @@
-import { Database } from "@dotkomonline/db"
 import { createEnvironment } from "@dotkomonline/env"
 import { UserWrite } from "@dotkomonline/types"
 import crypto from "crypto"
-import { Kysely } from "kysely"
 import { ulid } from "ulid"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { getTestDb, setupTestDB } from "../../../../vitest-integration.setup"
+import { CleanupFunction, createServiceLayerForTesting } from "../../../../vitest-integration.setup"
 import { createServiceLayer, type ServiceLayer } from "../../core"
 
 const fakeUser = (subject?: string): UserWrite => ({
@@ -20,20 +18,17 @@ const fakeUser = (subject?: string): UserWrite => ({
 
 describe("users", () => {
   let core: ServiceLayer
-  let db: Kysely<Database>
-  const dbName = "user"
+  let cleanup: CleanupFunction
 
   beforeEach(async () => {
     const env = createEnvironment()
-    await setupTestDB(env, dbName)
-
-    db = getTestDb(env, dbName)
-
-    core = await createServiceLayer({ db })
+    const context = await createServiceLayerForTesting(env, "user")
+    cleanup = context.cleanup
+    core = await createServiceLayer({ db: context.kysely })
   })
 
   afterEach(async () => {
-    await db.destroy()
+    await cleanup()
   })
 
   it("can create new users", async () => {

--- a/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
+++ b/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
@@ -1,12 +1,12 @@
-import crypto from "crypto"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { ulid } from "ulid"
+import { Database } from "@dotkomonline/db"
 import { createEnvironment } from "@dotkomonline/env"
-import { Database, createKysely } from "@dotkomonline/db"
-import { createServiceLayer, type ServiceLayer } from "../../core"
 import { UserWrite } from "@dotkomonline/types"
+import crypto from "crypto"
 import { Kysely } from "kysely"
-import { buildDbUrl, setupTestDB } from "../../../../vitest-integration.setup"
+import { ulid } from "ulid"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { getTestDb, setupTestDB } from "../../../../vitest-integration.setup"
+import { createServiceLayer, type ServiceLayer } from "../../core"
 
 const fakeUser = (subject?: string): UserWrite => ({
   auth0Sub: subject ?? crypto.randomUUID(),
@@ -27,11 +27,7 @@ describe("users", () => {
     const env = createEnvironment()
     await setupTestDB(env, dbName)
 
-    const testDbURL = buildDbUrl(dbName)
-    db = createKysely({
-      ...env,
-      DATABASE_URL: testDbURL,
-    })
+    db = getTestDb(env, dbName)
 
     core = await createServiceLayer({ db })
   })

--- a/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
+++ b/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
@@ -1,10 +1,11 @@
 import crypto from "crypto"
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { ulid } from "ulid"
 import { createEnvironment } from "@dotkomonline/env"
-import { createKysely } from "@dotkomonline/db"
+import { Database, createKysely } from "@dotkomonline/db"
 import { createServiceLayer, type ServiceLayer } from "../../core"
 import { UserWrite } from "@dotkomonline/types"
+import { Kysely } from "kysely"
 
 const fakeUser = (subject?: string): UserWrite => ({
   auth0Sub: subject ?? crypto.randomUUID(),
@@ -18,11 +19,16 @@ const fakeUser = (subject?: string): UserWrite => ({
 
 describe("users", () => {
   let core: ServiceLayer
+  let db: Kysely<Database>
 
   beforeEach(async () => {
     const env = createEnvironment()
-    const db = createKysely(env)
+    db = createKysely(env)
     core = await createServiceLayer({ db })
+  })
+
+  afterEach(async () => {
+    await db.destroy()
   })
 
   it("can create new users", async () => {

--- a/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
+++ b/packages/core/src/modules/user/__test__/user-service.e2e-spec.ts
@@ -6,6 +6,7 @@ import { Database, createKysely } from "@dotkomonline/db"
 import { createServiceLayer, type ServiceLayer } from "../../core"
 import { UserWrite } from "@dotkomonline/types"
 import { Kysely } from "kysely"
+import { buildDbUrl, setupTestDB } from "../../../../vitest-integration.setup"
 
 const fakeUser = (subject?: string): UserWrite => ({
   auth0Sub: subject ?? crypto.randomUUID(),
@@ -20,11 +21,23 @@ const fakeUser = (subject?: string): UserWrite => ({
 describe("users", () => {
   let core: ServiceLayer
   let db: Kysely<Database>
+  const dbName = "user"
 
   beforeEach(async () => {
     const env = createEnvironment()
-    db = createKysely(env)
+    await setupTestDB(env, dbName)
+
+    const testDbURL = buildDbUrl(dbName)
+    db = createKysely({
+      ...env,
+      DATABASE_URL: testDbURL,
+    })
+
     core = await createServiceLayer({ db })
+  })
+
+  afterEach(async () => {
+    await db.destroy()
   })
 
   afterEach(async () => {

--- a/packages/core/vitest-integration.config.ts
+++ b/packages/core/vitest-integration.config.ts
@@ -14,11 +14,5 @@ export default defineConfig({
     include: ["**/*.e2e-spec.ts"],
     mockReset: true,
     setupFiles: ["./vitest-integration.setup.ts"],
-    poolOptions: {
-      threads: {
-        maxThreads: 1,
-        minThreads: 1,
-      },
-    },
   },
 })

--- a/packages/core/vitest-integration.config.ts
+++ b/packages/core/vitest-integration.config.ts
@@ -12,8 +12,13 @@ export default defineConfig({
   test: {
     exclude: defaultExclude.concat("**/*.spec.ts"),
     include: ["**/*.e2e-spec.ts"],
-    threads: false,
     mockReset: true,
     setupFiles: ["./vitest-integration.setup.ts"],
+    poolOptions: {
+      threads: {
+        maxThreads: 1,
+        minThreads: 1,
+      },
+    },
   },
 })

--- a/packages/core/vitest-integration.setup.ts
+++ b/packages/core/vitest-integration.setup.ts
@@ -2,66 +2,76 @@ import { beforeEach, beforeAll, afterEach } from "vitest"
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
 import { createMigrator, createKysely, Database } from "@dotkomonline/db"
 import { Environment, createEnvironment } from "@dotkomonline/env"
-import { exec } from "child_process"
-import { Kysely } from "kysely"
-import util from "util"
+import { sql } from "kysely"
 
-const promiseExec = util.promisify(exec)
+// Configuration settings for the database container
+const testDBConfig = {
+  password: "local",
+  username: "local",
+  database: "main",
+  imageName: "public.ecr.aws/z5h0l8j6/dotkom/pgx-ulid:0.1.3",
+}
 
-const password = "local"
-const username = "local"
-const database = "main"
-
-const containers: StartedPostgreSqlContainer[] = []
-
+// Used globally for all tests
 let container: StartedPostgreSqlContainer
-let kysely: Kysely<Database>
-let env: Environment
 
-beforeAll(async () => {
-  container = await new PostgreSqlContainer("public.ecr.aws/z5h0l8j6/dotkom/pgx-ulid:0.1.3")
+async function setupDatabaseContainer() {
+  const container = await new PostgreSqlContainer(testDBConfig.imageName)
     .withExposedPorts(5432)
-    .withUsername(username)
-    .withPassword(password)
-    .withDatabase(database)
+    .withUsername(testDBConfig.username)
+    .withPassword(testDBConfig.password)
+    .withDatabase(testDBConfig.database)
+    .withReuse()
     .start()
 
-  containers.push(container)
   process.env.DATABASE_URL = container.getConnectionUri()
+  return container
+}
+
+async function runMigrations(env: Environment) {
+  const kysely = createKysely(env)
+  const migrator = createMigrator(kysely, new URL("node_modules/@dotkomonline/db/src/migrations", import.meta.url))
+  await migrator.migrateToLatest().catch(console.warn)
+  await kysely.destroy()
+}
+
+async function resetTestDatabase(container: StartedPostgreSqlContainer, env: Environment) {
+  try {
+
+  // Create client for the default database and use it to drop and recreate the test database
+  const dbString = container.getConnectionUri().replace("/main", "/postgres")
+  const kysely = createKysely({
+    ...env,
+    DATABASE_URL: dbString,
+  })
+
+  const deleteQuery = sql`drop database if exists ${sql.ref(testDBConfig.database)}`.compile(kysely)
+  const createQuery = sql`create database ${sql.ref(testDBConfig.database)}`.compile(kysely)
+
+  await kysely.executeQuery(deleteQuery)
+  await kysely.executeQuery(createQuery)
+
+  await kysely.destroy()
+
+  } catch (e) {
+    console.error(e)
+}
+}
+
+beforeAll(async () => {
+  container = await setupDatabaseContainer()
 }, 30000)
 
 beforeEach(async () => {
-  env = createEnvironment()
-  kysely = createKysely(env)
-  const migrator = createMigrator(kysely, new URL("node_modules/@dotkomonline/db/src/migrations", import.meta.url))
-  const result = await migrator.migrateToLatest()
-  if (result.error) {
-    console.warn(`Error running migrations in test: ${result.error}`)
-  }
-  await kysely.destroy()
+  const env = createEnvironment()
+  await runMigrations(env)
 })
 
 afterEach(async () => {
-  try {
-    const command = `echo "drop database ${database}; create database ${database};" | PGPASSWORD=${password} psql -h ${container.getHost()} -p ${container.getMappedPort(
-      5432
-    )} -U ${username} -d postgres`
-
-    const { stderr, stdout } = await promiseExec(command)
-
-    if (stderr) {
-      console.error(`Error running command: ${stderr}`)
-      return
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Error running command: ${error.message}`)
-      return
-    }
-  }
+  const env = createEnvironment()
+  await resetTestDatabase(container, env)
 })
 
-
 process.on("beforeExit", async () => {
-  await Promise.all(containers.map(async (container) => container.stop()))
+  // await container.stop()
 })

--- a/packages/core/vitest-integration.setup.ts
+++ b/packages/core/vitest-integration.setup.ts
@@ -1,27 +1,66 @@
-import { beforeEach } from "vitest"
+import { beforeEach, beforeAll, afterEach } from "vitest"
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
-import { createMigrator, createKysely } from "@dotkomonline/db"
-import { createEnvironment } from "@dotkomonline/env"
+import { createMigrator, createKysely, Database } from "@dotkomonline/db"
+import { Environment, createEnvironment } from "@dotkomonline/env"
+import { exec } from "child_process"
+import { Kysely } from "kysely"
+import util from "util"
+
+const promiseExec = util.promisify(exec)
+
+const password = "local"
+const username = "local"
+const database = "main"
 
 const containers: StartedPostgreSqlContainer[] = []
 
-beforeEach(async () => {
-  const container = await new PostgreSqlContainer("public.ecr.aws/z5h0l8j6/dotkom/pgx-ulid:0.1.3")
+let container: StartedPostgreSqlContainer
+let kysely: Kysely<Database>
+let env: Environment
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("public.ecr.aws/z5h0l8j6/dotkom/pgx-ulid:0.1.3")
     .withExposedPorts(5432)
-    .withUsername("local")
-    .withPassword("local")
-    .withDatabase("main")
+    .withUsername(username)
+    .withPassword(password)
+    .withDatabase(database)
     .start()
+
+  containers.push(container)
   process.env.DATABASE_URL = container.getConnectionUri()
-  const env = createEnvironment()
-  const kysely = createKysely(env)
+}, 30000)
+
+beforeEach(async () => {
+  env = createEnvironment()
+  kysely = createKysely(env)
   const migrator = createMigrator(kysely, new URL("node_modules/@dotkomonline/db/src/migrations", import.meta.url))
   const result = await migrator.migrateToLatest()
   if (result.error) {
     console.warn(`Error running migrations in test: ${result.error}`)
   }
-  containers.push(container)
+  await kysely.destroy()
 })
+
+afterEach(async () => {
+  try {
+    const command = `echo "drop database ${database}; create database ${database};" | PGPASSWORD=${password} psql -h ${container.getHost()} -p ${container.getMappedPort(
+      5432
+    )} -U ${username} -d postgres`
+
+    const { stderr, stdout } = await promiseExec(command)
+
+    if (stderr) {
+      console.error(`Error running command: ${stderr}`)
+      return
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Error running command: ${error.message}`)
+      return
+    }
+  }
+})
+
 
 process.on("beforeExit", async () => {
   await Promise.all(containers.map(async (container) => container.stop()))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,8 +653,8 @@ importers:
         specifier: ^18.18.13
         version: 18.18.13
       '@vitest/ui':
-        specifier: ^0.34.6
-        version: 0.34.6(vitest@0.34.6)
+        specifier: ^1.3.1
+        version: 1.3.1(vitest@1.3.1)
       testcontainers:
         specifier: ^10.7.1
         version: 10.7.1
@@ -662,8 +662,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/ui@0.34.6)
+        specifier: ^1.3.1
+        version: 1.3.1(@types/node@18.18.13)(@vitest/ui@1.3.1)
 
   packages/db:
     dependencies:
@@ -3147,6 +3147,13 @@ packages:
       '@sinclair/typebox': 0.27.8
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -3696,6 +3703,10 @@ packages:
 
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
+  /@polka/url@1.0.0-next.25:
+    resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
     dev: true
 
   /@portabletext/react@3.0.11(react@18.2.0):
@@ -6589,26 +6600,56 @@ packages:
       chai: 4.3.10
     dev: true
 
+  /@vitest/expect@1.3.1:
+    resolution: {integrity: sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==}
+    dependencies:
+      '@vitest/spy': 1.3.1
+      '@vitest/utils': 1.3.1
+      chai: 4.3.10
+    dev: true
+
   /@vitest/runner@0.34.6:
     resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
     dependencies:
       '@vitest/utils': 0.34.6
       p-limit: 4.0.0
-      pathe: 1.1.1
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/runner@1.3.1:
+    resolution: {integrity: sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==}
+    dependencies:
+      '@vitest/utils': 1.3.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
     dev: true
 
   /@vitest/snapshot@0.34.6:
     resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
     dependencies:
       magic-string: 0.30.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pretty-format: 29.6.2
+    dev: true
+
+  /@vitest/snapshot@1.3.1:
+    resolution: {integrity: sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==}
+    dependencies:
+      magic-string: 0.30.8
+      pathe: 1.1.2
+      pretty-format: 29.7.0
     dev: true
 
   /@vitest/spy@0.34.6:
     resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
     dependencies:
       tinyspy: 2.1.1
+    dev: true
+
+  /@vitest/spy@1.3.1:
+    resolution: {integrity: sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==}
+    dependencies:
+      tinyspy: 2.2.1
     dev: true
 
   /@vitest/ui@0.34.6(vitest@0.34.6):
@@ -6626,12 +6667,36 @@ packages:
       vitest: 0.34.6(@vitest/ui@0.34.6)
     dev: true
 
+  /@vitest/ui@1.3.1(vitest@1.3.1):
+    resolution: {integrity: sha512-2UrFLJ62c/eJGPHcclstMKlAR7E1WB1ITe1isuowEPJJHi3HfqofvsUqQ1cGrEF7kitG1DJuwURUA3HLDtQkXA==}
+    peerDependencies:
+      vitest: 1.3.1
+    dependencies:
+      '@vitest/utils': 1.3.1
+      fast-glob: 3.3.2
+      fflate: 0.8.2
+      flatted: 3.3.1
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vitest: 1.3.1(@types/node@18.18.13)(@vitest/ui@1.3.1)
+    dev: true
+
   /@vitest/utils@0.34.6:
     resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
     dependencies:
       diff-sequences: 29.4.3
       loupe: 2.3.6
       pretty-format: 29.6.2
+    dev: true
+
+  /@vitest/utils@1.3.1:
+    resolution: {integrity: sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
     dev: true
 
   /abab@2.0.6:
@@ -6667,10 +6732,21 @@ packages:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
 
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
 
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -7779,6 +7855,11 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
   /diff@3.5.0:
     resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
     engines: {node: '>=0.3.1'}
@@ -8261,6 +8342,21 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: true
+
   /exif-component@1.0.1:
     resolution: {integrity: sha512-FXnmK9yJYTa3V3G7DE9BRjUJ0pwXMICAxfbsAuKPTuSlFzMZhQbcvvwx0I8ofNJHxz3tfjze+whxcGpfklAWOQ==}
     dev: false
@@ -8335,6 +8431,10 @@ packages:
     resolution: {integrity: sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg==}
     dev: true
 
+  /fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+    dev: true
+
   /figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -8380,6 +8480,10 @@ packages:
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
+
+  /flatted@3.3.1:
+    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
   /flush-write-stream@2.0.0:
@@ -8617,6 +8721,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: true
+
   /get-tsconfig@4.7.2:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
     dependencies:
@@ -8722,7 +8831,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -9148,6 +9257,11 @@ packages:
     engines: {node: '>=14.18.0'}
     dev: true
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: true
+
   /humanize-list@1.0.1:
     resolution: {integrity: sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA==}
     dev: false
@@ -9511,6 +9625,10 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-tokens@8.0.3:
+    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
+    dev: true
+
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -9797,6 +9915,14 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /local-pkg@0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.6.1
+      pkg-types: 1.0.3
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -9889,6 +10015,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -9902,6 +10034,13 @@ packages:
 
   /magic-string@0.30.2:
     resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magic-string@0.30.8:
+    resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -10584,9 +10723,18 @@ packages:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
     dependencies:
       acorn: 8.10.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.2.0
+    dev: true
+
+  /mlly@1.6.1:
+    resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.0.3
+      ufo: 1.4.0
     dev: true
 
   /mnemonist@0.39.5:
@@ -10605,6 +10753,11 @@ packages:
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
     dev: true
 
@@ -11020,6 +11173,13 @@ packages:
       yocto-queue: 1.0.0
     dev: true
 
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -11172,6 +11332,10 @@ packages:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
     dev: true
 
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -11316,7 +11480,7 @@ packages:
     dependencies:
       jsonc-parser: 3.2.0
       mlly: 1.4.0
-      pathe: 1.1.1
+      pathe: 1.1.2
     dev: true
 
   /pluralize-esm@9.0.5:
@@ -11569,6 +11733,15 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/schemas': 29.6.0
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -12556,6 +12729,11 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
@@ -12572,6 +12750,15 @@ packages:
     dependencies:
       '@polka/url': 1.0.0-next.21
       mrmime: 1.0.1
+      totalist: 3.0.1
+    dev: true
+
+  /sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.25
+      mrmime: 2.0.0
       totalist: 3.0.1
     dev: true
 
@@ -12743,6 +12930,10 @@ packages:
     resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
     dev: true
 
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+    dev: true
+
   /stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
     dependencies:
@@ -12850,6 +13041,12 @@ packages:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
       acorn: 8.10.0
+    dev: true
+
+  /strip-literal@2.0.0:
+    resolution: {integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==}
+    dependencies:
+      js-tokens: 8.0.3
     dev: true
 
   /stripe@13.11.0:
@@ -13172,13 +13369,27 @@ packages:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
+  /tinybench@2.6.0:
+    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+    dev: true
+
   /tinypool@0.7.0:
     resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
     dev: true
 
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /tinyspy@2.1.1:
     resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -13584,6 +13795,10 @@ packages:
     resolution: {integrity: sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==}
     dev: true
 
+  /ufo@1.4.0:
+    resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
+    dev: true
+
   /ulid@2.3.0:
     resolution: {integrity: sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==}
     hasBin: true
@@ -13931,9 +14146,30 @@ packages:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.4.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
       vite: 4.5.0(@types/node@18.18.13)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@1.3.1(@types/node@18.18.13):
+    resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.0.7(@types/node@18.18.13)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -14124,6 +14360,63 @@ packages:
       tinypool: 0.7.0
       vite: 4.4.11(@types/node@18.18.13)
       vite-node: 0.34.6(@types/node@18.18.13)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.3.1(@types/node@18.18.13)(@vitest/ui@1.3.1):
+    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.3.1
+      '@vitest/ui': 1.3.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.18.13
+      '@vitest/expect': 1.3.1
+      '@vitest/runner': 1.3.1
+      '@vitest/snapshot': 1.3.1
+      '@vitest/spy': 1.3.1
+      '@vitest/ui': 1.3.1(vitest@1.3.1)
+      '@vitest/utils': 1.3.1
+      acorn-walk: 8.3.2
+      chai: 4.3.10
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.8
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.0.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.7(@types/node@18.18.13)
+      vite-node: 1.3.1(@types/node@18.18.13)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Set up _one_ container at the start of running tests. Instead of starting new containers for each test, do this:

```
beforeEach(async () => {
  const env = createEnvironment()
  await runMigrations(env)
})

afterEach(async () => {
  const env = createEnvironment()
  await resetTestDatabase(container, env)
})
```

**Note**:
I added the `withReuse()` option to the `PostgreSqlContainer`. I __think__ this should run fine in ci but I'm not 100% sure.

### Benchmarks

**Before:**
```
 ✓ src/modules/user/__test__/user-service.e2e-spec.ts (4) 35020ms
   ✓ users (4) 35020ms
     ✓ can create new users 9889ms
     ✓ will not allow two users the same subject 8424ms
     ✓ will find users by their user id 8364ms
     ✓ can update users given their id 8342ms
```

**After:**
Without reusing container
```
✓ src/modules/user/__test__/user-service.e2e-spec.ts (4) 13469ms
   ✓ users (4) 4478ms
     ✓ can create new users 1239ms
     ✓ will not allow two users the same subject 1089ms
     ✓ will find users by their user id 1084ms
     ✓ can update users given their id 1064ms
```

    
With reusing container
```
 ✓ src/modules/user/__test__/user-service.e2e-spec.ts (4) 4924ms
   ✓ users (4) 4098ms
     ✓ can create new users 838ms
     ✓ will not allow two users the same subject 1098ms
     ✓ will find users by their user id 1105ms
     ✓ can update users given their id 1056ms
```