### PR TITLE
Make event types not nullable

### DIFF
--- a/packages/db/src/db.generated.d.ts
+++ b/packages/db/src/db.generated.d.ts
@@ -110,7 +110,7 @@ export interface Event {
   status: EventStatus
   subtitle: string | null
   title: string
-  type: EventType | null
+  type: EventType
   updatedAt: Generated<Timestamp>
   waitlist: string | null
 }

--- a/packages/db/src/migrations/0026_no_null_event_types.js
+++ b/packages/db/src/migrations/0026_no_null_event_types.js
@@ -1,0 +1,17 @@
+import { sql } from "kysely"
+
+/** @param db {import('kysely').Kysely} */
+export async function up(db) {
+  await db.schema
+    .alterTable("event")
+    .alterColumn("type", (col) => col.setNotNull())
+    .execute()
+}
+
+/** @param db {import('kysely').Kysely} */
+export async function down(db) {
+  await db.schema
+    .alterTable("event")
+    .alterColumn("type", (col) => col.dropNotNull())
+    .execute()
+}


### PR DESCRIPTION
This fixes a bug where you are allowed to insert events with event type null into the database, which then crashes when trying to retrieve them. 