### PR TITLE
Add helpful log if the fetch call to the trpc server fails

### DIFF
--- a/apps/dashboard/src/utils/trpc.ts
+++ b/apps/dashboard/src/utils/trpc.ts
@@ -24,10 +24,18 @@ export const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
     httpBatchLink({
       url: `${getBaseUrl()}/api/trpc`,
       async fetch(url, options) {
-        return fetch(url, {
-          ...options,
-          credentials: "include",
-        })
+        try {
+          const result = await fetch(url, {
+            ...options,
+            credentials: "include",
+          })
+          return result
+        } catch (e) {
+          console.error(
+            "The fetch call to the TRPC api failed, the TRPC server may be down! Check if the TRPC server is up and running"
+          )
+          throw e
+        }
       },
     }),
   ],


### PR DESCRIPTION
I have found it pretty confusing to debug issues where the root issue has been that the trpc server has not been responding. I.e. if you forget to run `web` now that it is hosted through that app. Maybe this helps someone that goes into the same trap of not running the trpc server.

Without this, all you get is "TypeError: failed to fetch". But for someone that's not a pro in trpc and how it works, it can be pretty confusing