### PR TITLE
Turn off retry and refetch on window focus during development

### DIFF
--- a/apps/dashboard/src/app/QueryProvider.tsx
+++ b/apps/dashboard/src/app/QueryProvider.tsx
@@ -10,7 +10,7 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry: process.env.NODE_ENV === "production" ? 3 : 0,
+            retry: process.env.NODE_ENV === "production" ? 3 : 0
           },
         },
       })

--- a/apps/dashboard/src/app/QueryProvider.tsx
+++ b/apps/dashboard/src/app/QueryProvider.tsx
@@ -5,7 +5,17 @@ import { type PropsWithChildren, useState } from "react"
 import { trpc, trpcConfig } from "../utils/trpc"
 
 export const QueryProvider = ({ children }: PropsWithChildren) => {
-  const [queryClient] = useState(() => new QueryClient())
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: process.env.NODE_ENV === "production" ? 3 : false,
+            refetchOnWindowFocus: process.env.NODE_ENV === "production",
+          },
+        },
+      })
+  )
   const [trpcClient] = useState(() => trpc.createClient(trpcConfig))
 
   return (

--- a/apps/dashboard/src/app/QueryProvider.tsx
+++ b/apps/dashboard/src/app/QueryProvider.tsx
@@ -10,7 +10,7 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry: process.env.NODE_ENV === "production" ? 3 : 0
+            retry: process.env.NODE_ENV === "production" ? 3 : 0,
           },
         },
       })

--- a/apps/dashboard/src/app/QueryProvider.tsx
+++ b/apps/dashboard/src/app/QueryProvider.tsx
@@ -10,8 +10,7 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry: process.env.NODE_ENV === "production" ? 3 : false,
-            refetchOnWindowFocus: process.env.NODE_ENV === "production",
+            retry: process.env.NODE_ENV === "production" ? 3 : 0,
           },
         },
       })


### PR DESCRIPTION
I think having request retries and window refetching makes little sense during development. 