### PR TITLE
Improve logging package config

### DIFF
--- a/packages/core/src/modules/external/auth0-synchronization-service.ts
+++ b/packages/core/src/modules/external/auth0-synchronization-service.ts
@@ -27,7 +27,6 @@ export class Auth0SynchronizationServiceImpl implements Auth0SynchronizationServ
   ) {}
 
   private async synchronizeUser(auth0Subject: string) {
-    this.logger.log("info", "Synchronizing user with Auth0", { userId: auth0Subject })
     const auth0User = await this.auth0Repository.getBySubject(auth0Subject)
 
     if (auth0User === null) {
@@ -37,8 +36,6 @@ export class Auth0SynchronizationServiceImpl implements Auth0SynchronizationServ
     const user = await this.userService.getUserBySubject(auth0Subject)
 
     if (user === undefined) {
-      this.logger.log("info", "User does not exist in local db, creating user", { userId: auth0Subject })
-
       const userData: UserWrite = {
         auth0Sub: auth0User.subject,
         studyYear: -1,
@@ -74,6 +71,7 @@ export class Auth0SynchronizationServiceImpl implements Auth0SynchronizationServ
 
     const userShouldBeSynced = user.lastSyncedAt < oneDayAgo
     if (userShouldBeSynced) {
+      this.logger.info("Syncing user from Auth0: %s", auth0Sub)
       return this.synchronizeUser(user.auth0Sub)
     }
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@dotkomonline/env": "workspace:*",
-    "winston": "^3.11.0"
+    "winston": "^3.13.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.4"

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,17 +1,45 @@
 import winston, { format } from "winston"
 export type { Logger } from "winston"
 
+interface Message {
+  level: string
+  message: string
+  timestamp: string
+  path: string
+}
+
+function padWithColor(str: string, desiredLength: number) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: <explanation>
+  const ansiEscapeCodes = /\x1b\[[0-9;]*m/g // Regex to match ANSI escape codes
+  const visibleLength = str.replace(ansiEscapeCodes, "").length // Length of string without ANSI codes
+  const paddingLength = desiredLength - visibleLength // Calculate how much padding is needed
+  return str + " ".repeat(paddingLength) // Pad the string with spaces
+}
+
+const formatMessage = ({ level, message, timestamp, path }: Message) => {
+  const levelPadded = padWithColor(level, 7)
+  const dim = "\x1b[2m"
+  const reset = "\x1b[0m"
+  return `${levelPadded}[${timestamp}] ${message} ${dim}(${path})${reset}`
+}
+
 export const getLogger = (path: string) =>
   winston.createLogger({
-    level: "info",
-    silent: process.env.NODE_ENV === "test",
-    format: format.json(),
+    level: "silly",
     transports: [
       new winston.transports.Console({
         format: format.combine(
+          format.splat(),
           format.colorize(),
           format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-          format.printf((msg) => `${msg.level} [${msg.timestamp}] ${msg.message} (${path})`)
+          format.printf((msg) =>
+            formatMessage({
+              level: msg.level,
+              message: msg.message,
+              timestamp: msg.timestamp,
+              path,
+            })
+          )
         ),
       }),
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,8 +819,8 @@ importers:
         specifier: workspace:*
         version: link:../env
       winston:
-        specifier: ^3.11.0
-        version: 3.11.0
+        specifier: ^3.13.0
+        version: 3.13.0
     devDependencies:
       '@biomejs/biome':
         specifier: 1.6.4
@@ -12411,17 +12411,17 @@ packages:
       string-width: 5.1.2
     dev: true
 
-  /winston-transport@4.5.0:
-    resolution: {integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==}
-    engines: {node: '>= 6.4.0'}
+  /winston-transport@4.7.0:
+    resolution: {integrity: sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==}
+    engines: {node: '>= 12.0.0'}
     dependencies:
       logform: 2.5.1
       readable-stream: 3.6.2
       triple-beam: 1.4.1
     dev: false
 
-  /winston@3.11.0:
-    resolution: {integrity: sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==}
+  /winston@3.13.0:
+    resolution: {integrity: sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       '@colors/colors': 1.6.0
@@ -12434,7 +12434,7 @@ packages:
       safe-stable-stringify: 2.4.3
       stack-trace: 0.0.10
       triple-beam: 1.4.1
-      winston-transport: 4.5.0
+      winston-transport: 4.7.0
     dev: false
 
   /wrap-ansi@6.2.0:

--- a/tools/migrator/src/index.ts
+++ b/tools/migrator/src/index.ts
@@ -65,7 +65,7 @@ program
             .join("\n")}`
         )
       } else {
-        logger.warn(res)
+        logger.warn("%O", res)
       }
     }
 
@@ -77,7 +77,7 @@ program
     if (res.error) {
       console.dir(res.error, { depth: null })
       logger.warn("Error while running migrations:")
-      logger.warn(JSON.stringify(res.error))
+      logger.warn("%O", JSON.stringify(res.error))
       process.exit(1)
     }
 


### PR DESCRIPTION
Previously it was not possible to log out objects using the winston logger. This adds support for this using interpolation in the message. It also adds some padding to the `info` part such that messages start from the same column.

Example console output
```ts
  const logger = getLogger("service a")

  logger.error("error message")
  logger.warn("warn message")
  logger.info("info message")
  logger.http("http message")
  logger.verbose("verbose message")
  logger.debug("debug message")
  logger.silly("silly message")

  console.log("")

  logger.info("test info message from service a")
  logger.info("message with metadata2 %o", { message: "John Doe", id: 123 })

  const error = new Error("Something failed!")
  logger.error("hello world %O", error)
  ```
New
<img width="1056" alt="image" src="https://github.com/dotkom/monoweb/assets/55615149/206c66c6-be5e-449c-ae25-ab7ec66a7dd9">

Old (set to only showing info and more serious):
<img width="888" alt="image" src="https://github.com/dotkom/monoweb/assets/55615149/94c4c6f0-b870-4118-b4ba-450e5efe7b84">

