### PR TITLE
Don't reset invoicification form when submitting

### DIFF
--- a/apps/invoicification/src/app/page.tsx
+++ b/apps/invoicification/src/app/page.tsx
@@ -19,9 +19,8 @@ export default function Page() {
     },
   })
   const dispatch = useSubmitMutation()
-  const onSubmit = (data: FormSchema) => {
+  const onSubmit = async (data: FormSchema) => {
     dispatch.mutate(data)
-    form.reset()
   }
 
   return (

--- a/apps/invoicification/src/app/page.tsx
+++ b/apps/invoicification/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
     },
   })
   const dispatch = useSubmitMutation()
-  const onSubmit = async (data: FormSchema) => {
+  const onSubmit = (data: FormSchema) => {
     dispatch.mutate(data)
   }
 


### PR DESCRIPTION
Bekk representative was complaining that when you click submit on the form seemingly all the form values disappear, making it seem like an empty form was submitted. This PR removes the form reset on submit. Since we redirect on success anyways, it is not necessary to reset the form when successfull, and if the submit fails it is also IMO better to keep the values. 