### PR TITLE
fix: Publish job listing

### DIFF
--- a/apps/dashboard/src/modules/job-listing/modals/create-job-listing-modal.tsx
+++ b/apps/dashboard/src/modules/job-listing/modals/create-job-listing-modal.tsx
@@ -8,7 +8,8 @@ export const CreateJobListingModal: FC<ContextModalProps> = ({ context, id }) =>
   const create = useCreateJobListingMutation()
   const FormComponent = useJobListingWriteForm({
     onSubmit: (data) => {
-      create.mutate(data)
+      const createdAt = new Date();
+      create.mutate({...data, createdAt})
       close()
     },
   })

--- a/packages/types/src/job-listing.ts
+++ b/packages/types/src/job-listing.ts
@@ -26,7 +26,7 @@ export const JobListingWriteSchema = JobListingSchema.partial({
   .extend({
     companyId: z.string().ulid(),
   })
-  .strict()
+  .partial()
 
 export type JobListing = z.infer<typeof JobListingSchema>
 export type JobListingId = JobListing["id"]


### PR DESCRIPTION
Tok alt for lang tid å finne buggen haha
Fixing where the job listing wont be published since it asks for createdAt date.

Reason for switching to .partial() is so that we can get the zod error messages. It keeps the same flow with not publishing if fields is not filled