### PR TITLE
Fix incorrect redirect uris for vengeful vineyard

### DIFF
--- a/infra/auth0/main.tf
+++ b/infra/auth0/main.tf
@@ -159,13 +159,16 @@ resource "auth0_client" "vengeful_vineyard_frontend" {
     "stg" = [
       "https://staging.vinstraff.no",
       "https://staging.vinstraff.no/docs/oauth2-redirect",
+      "http://localhost:3000",
+      "http://localhost:8000",
+      "http://localhost:8000/docs/oauth2-redirect",
     ]
     "prd" = [
       "https://vinstraff.no",
       "https://vinstraff.no/docs/oauth2-redirect",
       "http://localhost:3000",
       "http://localhost:8000",
-      "http://localhost:3000/docs/oauth2-redirect",
+      "http://localhost:8000/docs/oauth2-redirect",
     ]
   }[terraform.workspace]
   grant_types                   = ["authorization_code", "refresh_token"]


### PR DESCRIPTION
## Changelog

- Fixed `/docs` redirect uri for production environment
- Added localhost to staging environment redirect uris
