### PR TITLE
Add NTNU-username to app_metadata when using Feide login

### DIFF
--- a/infra/auth0/js/fetchUserProfile.js
+++ b/infra/auth0/js/fetchUserProfile.js
@@ -28,8 +28,6 @@ async function fetchUserProfile(accessToken, ctx, callback) {
     email: openid_userinfo.email,
     email_verified: openid_userinfo.email_verified,
     name: openid_userinfo.name,
-    app_metadata: {
-      ntnuUsername: ntnu_username,
-    }
+    app_metadata: { ntnu_username }
   });
 }

--- a/infra/auth0/js/fetchUserProfile.js
+++ b/infra/auth0/js/fetchUserProfile.js
@@ -1,32 +1,35 @@
-function fetchUserProfile(accessToken, ctx, callback) {
-    // this is run every time a user logs in
-    request.get(
-      {
-        url: 'https://auth.dataporten.no/openid/userinfo',
-        headers: {
-          'Authorization': 'Bearer ' + accessToken,
-        }
-      },
-      (err, resp, body) => {
-        if (err) {
-          return callback(err);
-        }
-        if (resp.statusCode !== 200) {
-          return callback(new Error(body));
-        }
-        let bodyParsed;
-        try {
-          bodyParsed = JSON.parse(body);
-        } catch (jsonError) {
-          return callback(new Error(body));
-        }
-        const profile = {
-          user_id: bodyParsed.sub,
-          email: bodyParsed.email,
-          "email_verified": bodyParsed.email_verified,
-          "name": bodyParsed.name,
-        };
-        callback(null, profile);
-      }
-    );
+async function fetchUserProfile(accessToken, ctx, callback) {
+  const headers = {"Authorization": `Bearer ${accessToken}`};
+
+  // https://docs.feide.no/reference/apis/userinfo.html
+  const openid_userinfo_response = await fetch("https://auth.dataporten.no/openid/userinfo", { headers });
+
+  if (!openid_userinfo_response.ok) {
+    return callback(new Error("Failed to fetch user profile"));
+  }
+
+  const openid_userinfo = await openid_userinfo_response.json();
+
+  // https://docs.feide.no/reference/apis/attributes_feide/extended_userinfo.html
+  const extended_userinfo_response = await fetch("https://api.dataporten.no/userinfo/v1/userinfo", { headers });
+
+  if (!extended_userinfo_response.ok) {
+    return callback(new Error("Failed to fetch user profile"));
+  }
+
+  const extended_userinfo = await extended_userinfo_response.json();
+
+  // Always a single string according to
+  // https://docs.feide.no/reference/apis/attributes_feide/available_attributes.html#required-attributes
+  const ntnu_username = extended_userinfo.uid[0];
+
+  callback(null, {
+    user_id: openid_userinfo.sub,
+    email: openid_userinfo.email,
+    email_verified: openid_userinfo.email_verified,
+    name: openid_userinfo.name,
+    app_metadata: {
+      ntnuUsername: ntnu_username,
     }
+  });
+}


### PR DESCRIPTION
The aim of this pull request is to add ntnu username to the data fetched from the feide api when logging in via feide. This will at a later point be used to connect onlineweb auth0-accounts to feide auth0 accounts. 

This is implemented by:

* Refactoring the script to use fetch instead of request (to avoid excessive nesting by using async)
* Getting the "extended userinfo" in addition to the openid userinfo. [Documentation here](https://docs.feide.no/reference/apis/attributes_feide/extended_userinfo.html#extended-userinfo)
* Putting the NTNU-username from the abovementioned API into the app_metadata