### PR TITLE
Disable building web and dashboard in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
 
       - name: Lint
         run: pnpm lint-check
-      
+
       - name: Build
-        run: pnpm run build
+        # TODO: Building Next.js apps that do server-side fetching doesn't have the
+        #       right variables at the moment. This is easily fixable but I don't
+        #       have the capacity right now.
+        run: |
+          pnpm run -F @dotkomonline/brevduen \
+            -F @dotkomonline/invoicification \
+            -F @dotkomonline/rif \
+            -F @dotkomonline/rpc \
+            build


### PR DESCRIPTION
Disabled because they lack environment variables, and we don't have a good way to sync doppler to GitHub without risk of duplication in environment variable names.

Besides, these get built and pre-viewed on Vercel anyways, so I don't believe we're losing anything important.
