### PR TITLE
Emit warning if no certificate authority is provided

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "generate-types": "kysely-codegen --out-file ./src/db.generated.d.ts --camel-case --dialect postgres"
   },
   "dependencies": {
+    "@dotkomonline/logger": "workspace:*",
     "kysely": "^0.27.0",
     "pg": "^8.13.0"
   },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,8 +2,10 @@ import { CamelCasePlugin, Kysely, PostgresDialect } from "kysely"
 import pg, { type PoolConfig } from "pg"
 import type { DB } from "./db.generated"
 export type { DB as Database } from "./db.generated"
+import { getLogger } from "@dotkomonline/logger"
 
 export { createMigrator } from "./migrator"
+const logger = getLogger("@dotkomonline/db")
 
 export const createKysely = (url: string, certificateAuthority?: string) => {
   // If the caller has provided a certificate authority, we pass it down to
@@ -15,6 +17,15 @@ export const createKysely = (url: string, certificateAuthority?: string) => {
       rejectUnauthorized: true,
       ca: certificateAuthority,
     }
+  }
+
+  // If there are no certificates attached, we issue a warning so that it's easy
+  // to catch misconfigurations in non-local environments.
+  if (sslOptions === undefined) {
+    logger.warn(
+      "No certificate authority provided. This is required if you are connecting to staging/production databases."
+    )
+    logger.warn("- This configuration is only supported for local development.")
   }
 
   return new Kysely<DB>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@dotkomonline/logger':
+        specifier: workspace:*
+        version: link:../logger
       kysely:
         specifier: ^0.27.0
         version: 0.27.4


### PR DESCRIPTION
Makes it easier to identify if no certificate authority is provided.

Also gives a warning to local users that the config is only valid for local.
