### PR TITLE
Propose introducing codeowners for GitHub reviewer assignent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,54 @@
+# Code owner file for Monoweb.
+#
+# We don't take this very seriously, but they are really useful for making
+# GitHub auto-assign reviewers to PRs. It makes it easier for contributors to
+# get pull requests reviewed.
+#
+# Another goal is also that people who have more experience with certain parts
+# of the codebase get the responsibility to review patches that touch these
+# parts.
+
+
+# Until we have more defined responsibilities, I'll take ownership of code that
+# is not covered by other, because I know every part of the codebase well.
+*                     @junlarsen
+
+
+# Pipelines and automation
+.github               @junlarsen
+*.Dockerfile          @junlarsen
+docker-compose.yml    @junlarsen
+
+
+# Main applications
+apps/brevduen         @junlarsen
+apps/dashboard        @henrikskog
+apps/rpc              @junlarsen
+apps/invoicification  @junlarsen
+apps/rif              @junlarsen
+apps/web              @jotjern
+
+
+# Libraries and packages
+packages/auth         @junlarsen @jotjern
+packages/config
+packages/core         @junlarsen @jotjern @henrikskog @terbau
+packages/db           @jotjern
+packages/email
+packages/environment  @junlarsen
+packages/gateway-trpc @junlarsen @jotjern @henrikskog @terbau
+packages/logger       @junlarsen
+packages/proxy-nextjs @junlarsen
+packages/tsconfig
+packages/types
+packages/ui           @brage-andreas @madsbarnes
+packages/utils        @brage-andreas
+
+
+# Tools
+tools/migrator        @jotjern @junlarsen
+tools/shell           @henrikskog
+
+
+# Infrastructure located in the monorepo
+infra/auth0           @henrikhorluck @jotjern

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ packages/logger       @junlarsen
 packages/proxy-nextjs @junlarsen
 packages/tsconfig
 packages/types
-packages/ui           @brage-andreas @madsbarnes
+packages/ui           @brage-andreas @madsab
 packages/utils        @brage-andreas
 
 


### PR DESCRIPTION
This introduces (and suggests some codeowners to begin with) that we use GitHub codeowners feature for auto-assigning reviewers to pull requests.

Historically speaking we haven't been the best at reviewing eachother's patches, so having GitHub autoassign *somebody* means contributors don't need to consider who to ask, and it's easier for people who wrote the code to see and follow updates.

I don't intend to take the name "codeowners" very seriously. It's just so GitHub can auto-assign reviewers.

This list is incomplete now, but I've proposed some initial codeowners for code I know people have worked a lot on. This also doesn't prevent others from chiming in on PRs, but it should hopefully help us forget about PRs.
