### PR TITLE
Do not directly access client variables without createEnvironment

### DIFF
--- a/apps/dashboard/src/env.ts
+++ b/apps/dashboard/src/env.ts
@@ -1,11 +1,17 @@
 import { createEnvironment, variable } from "@dotkomonline/environment"
 
-export const env = createEnvironment({
-  OAUTH_CLIENT_ID: variable,
-  OAUTH_CLIENT_SECRET: variable,
-  OAUTH_ISSUER: variable,
-  NEXTAUTH_SECRET: variable,
-  NEXTAUTH_URL: variable.url(),
-  NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3002"),
-  RPC_HOST: variable,
-})
+export const env = createEnvironment(
+  {
+    OAUTH_CLIENT_ID: variable,
+    OAUTH_CLIENT_SECRET: variable,
+    OAUTH_ISSUER: variable,
+    NEXTAUTH_SECRET: variable,
+    NEXTAUTH_URL: variable.url(),
+    NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3002"),
+    RPC_HOST: variable,
+  },
+  {
+    ...process.env,
+    NEXT_PUBLIC_ORIGIN: process.env.NEXT_PUBLIC_ORIGIN,
+  }
+)

--- a/apps/dashboard/src/trpc.ts
+++ b/apps/dashboard/src/trpc.ts
@@ -10,8 +10,7 @@ export const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
   links: [
     loggerLink({
       enabled: (opts) =>
-        (process.env.NEXT_PUBLIC_ORIGIN ?? "").includes("localhost") ||
-        (opts.direction === "down" && opts.result instanceof Error),
+        (process.env.NEXT_PUBLIC_ORIGIN ?? '').includes("localhost") || (opts.direction === "down" && opts.result instanceof Error),
     }),
     httpBatchLink({
       url: `${process.env.NEXT_PUBLIC_ORIGIN}/api/trpc`,

--- a/apps/dashboard/src/trpc.ts
+++ b/apps/dashboard/src/trpc.ts
@@ -4,16 +4,17 @@ import type { AppRouter } from "@dotkomonline/gateway-trpc"
 import { type CreateTRPCClientOptions, httpBatchLink, loggerLink } from "@trpc/client"
 import { createTRPCReact } from "@trpc/react-query"
 import superjson from "superjson"
+import { env } from "./env"
 
 export const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
   transformer: superjson,
   links: [
     loggerLink({
       enabled: (opts) =>
-        (process.env.NEXT_PUBLIC_ORIGIN ?? '').includes("localhost") || (opts.direction === "down" && opts.result instanceof Error),
+        env.NEXT_PUBLIC_ORIGIN.includes("localhost") || (opts.direction === "down" && opts.result instanceof Error),
     }),
     httpBatchLink({
-      url: `${process.env.NEXT_PUBLIC_ORIGIN}/api/trpc`,
+      url: `${env.NEXT_PUBLIC_ORIGIN}/api/trpc`,
       async fetch(url, options) {
         try {
           const result = await fetch(url, {

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,11 +1,17 @@
 import { createEnvironment, variable } from "@dotkomonline/environment"
 
-export const env = createEnvironment({
-  OAUTH_CLIENT_ID: variable,
-  OAUTH_CLIENT_SECRET: variable,
-  OAUTH_ISSUER: variable,
-  NEXTAUTH_SECRET: variable,
-  NEXTAUTH_URL: variable.url(),
-  NEXT_PUBLIC_ORIGIN: variable,
-  RPC_HOST: variable,
-})
+export const env = createEnvironment(
+  {
+    OAUTH_CLIENT_ID: variable,
+    OAUTH_CLIENT_SECRET: variable,
+    OAUTH_ISSUER: variable,
+    NEXTAUTH_SECRET: variable,
+    NEXTAUTH_URL: variable.url(),
+    NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3000"),
+    RPC_HOST: variable,
+  },
+  {
+    ...process.env,
+    NEXT_PUBLIC_ORIGIN: process.env.NEXT_PUBLIC_ORIGIN,
+  }
+)

--- a/apps/web/src/utils/trpc/client.ts
+++ b/apps/web/src/utils/trpc/client.ts
@@ -1,4 +1,6 @@
 "use client"
+
+import { env } from "@/env"
 import type { AppRouter } from "@dotkomonline/gateway-trpc"
 import { type CreateTRPCClientOptions, httpBatchLink, loggerLink } from "@trpc/client"
 import { createTRPCReact } from "@trpc/react-query"
@@ -9,8 +11,7 @@ export const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
   links: [
     loggerLink({
       enabled: (opts) =>
-        (process.env.NEXT_PUBLIC_ORIGIN ?? "").includes("localhost") ||
-        (opts.direction === "down" && opts.result instanceof Error),
+        (process.env.NEXT_PUBLIC_ORIGIN ?? "").includes("localhost") || (opts.direction === "down" && opts.result instanceof Error),
     }),
     httpBatchLink({
       url: `${process.env.NEXT_PUBLIC_ORIGIN}/api/trpc`,

--- a/apps/web/src/utils/trpc/client.ts
+++ b/apps/web/src/utils/trpc/client.ts
@@ -11,10 +11,10 @@ export const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
   links: [
     loggerLink({
       enabled: (opts) =>
-        (process.env.NEXT_PUBLIC_ORIGIN ?? "").includes("localhost") || (opts.direction === "down" && opts.result instanceof Error),
+        env.NEXT_PUBLIC_ORIGIN === "development" || (opts.direction === "down" && opts.result instanceof Error),
     }),
     httpBatchLink({
-      url: `${process.env.NEXT_PUBLIC_ORIGIN}/api/trpc`,
+      url: `${env.NEXT_PUBLIC_ORIGIN}/api/trpc`,
       async fetch(url, options) {
         return fetch(url, {
           ...options,

--- a/packages/environment/src/index.mjs
+++ b/packages/environment/src/index.mjs
@@ -1,9 +1,5 @@
 import { z } from "zod"
 
-if (typeof window !== "undefined") {
-  throw new Error("The @dotkomonline/environment package should not be imported on the client side. Use process.env directly.");
-}
-
 /**
  * @template T
  * @param variables {Record<T, z.ZodString>}

--- a/packages/environment/src/index.mjs
+++ b/packages/environment/src/index.mjs
@@ -1,9 +1,7 @@
 import { z } from "zod"
 
 if (typeof window !== "undefined") {
-  throw new Error(
-    "The @dotkomonline/environment package should not be imported on the client side. Use process.env directly."
-  )
+  throw new Error("The @dotkomonline/environment package should not be imported on the client side. Use process.env directly.");
 }
 
 /**


### PR DESCRIPTION
Reverts two prior commits and passes the arguments as parameters to createEnvironment as intended.

This keeps the type safety that we intended for the environment package

cc @jotjern
