### PR TITLE
Do not rely on GitHub secrets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,36 +7,10 @@ on:
     types: [opened, synchronize]
   merge_group:
 
-env:
-  DASHBOARD_AUTH0_CLIENT_ID: ${{ secrets.DASHBOARD_AUTH0_CLIENT_ID }}
-  DASHBOARD_AUTH0_CLIENT_SECRET: ${{ secrets.DASHBOARD_AUTH0_CLIENT_SECRET }}
-  DASHBOARD_AUTH0_ISSUER: ${{ secrets.DASHBOARD_AUTH0_ISSUER }}
-  WEB_AUTH0_CLIENT_ID: ${{ secrets.WEB_AUTH0_CLIENT_ID }}
-  WEB_AUTH0_CLIENT_SECRET: ${{ secrets.WEB_AUTH0_CLIENT_SECRET }}
-  WEB_AUTH0_ISSUER: ${{ secrets.WEB_AUTH0_ISSUER }}
-  DATABASE_URL: ${{ secrets.DATABASE_URL }}
-  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-  AWS_REGION: ${{ secrets.AWS_REGION }}
-  TRIKOM_STRIPE_PUBLIC_KEY: ${{ secrets.TRIKOM_STRIPE_PUBLIC_KEY }}
-  TRIKOM_STRIPE_SECRET_KEY: ${{ secrets.TRIKOM_STRIPE_SECRET_KEY }}
-  TRIKOM_STRIPE_WEBHOOK_SECRET: ${{ secrets.TRIKOM_STRIPE_WEBHOOK_SECRET }}
-  FAGKOM_STRIPE_PUBLIC_KEY: ${{ secrets.FAGKOM_STRIPE_PUBLIC_KEY }}
-  FAGKOM_STRIPE_SECRET_KEY: ${{ secrets.FAGKOM_STRIPE_SECRET_KEY }}
-  FAGKOM_STRIPE_WEBHOOK_SECRET: ${{ secrets.FAGKOM_STRIPE_WEBHOOK_SECRET }}
-  S3_BUCKET_MONOWEB: ${{ secrets.S3_BUCKET_MONOWEB }}
-  GTX_AUTH0_CLIENT_ID: ${{ secrets.GTX_AUTH0_CLIENT_ID }}
-  GTX_AUTH0_CLIENT_SECRET: ${{ secrets.GTX_AUTH0_CLIENT_SECRET }}
-  GTX_AUTH0_ISSUER: ${{ secrets.GTX_AUTH0_ISSUER }}
-  RPC_HOST: ${{ secrets.RPC_HOST }}
-  RPC_ALLOWED_ORIGINS: ${{ secrets.RPC_ALLOWED_ORIGINS }}
-
 jobs:
   build:
     name: Build and Test
     timeout-minutes: 15
-    # env:
-    #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-    #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -72,9 +46,6 @@ jobs:
         run: pnpm lint-check
 
       - name: Build
-        # TODO: Building Next.js apps that do server-side fetching doesn't have the
-        #       right variables at the moment. This is easily fixable but I don't
-        #       have the capacity right now.
         run: |
           pnpm run -F @dotkomonline/brevduen \
             -F @dotkomonline/invoicification \


### PR DESCRIPTION
We shouldn't require any production data or any credentials to run the tests or build the apps.
