### PR TITLE
Rewrite code to conform to erasableSyntaxOnly

### DIFF
--- a/apps/invoicification/src/app/form-schema.ts
+++ b/apps/invoicification/src/app/form-schema.ts
@@ -1,19 +1,19 @@
 import { z } from "zod"
 
-export enum InvoiceRelation {
-  COMPANY_PRESENTATION = "Bedriftspresentasjon",
-  COURSE_EVENT = "Kurs",
-  OFFLINE_ADVERTISEMENT = "Annonse i Offline",
-  JOB_LISTING = "Jobbannonse",
-  EXCURSION_PARTICIPATION = "ITEX",
-  OTHER = "Annet",
-}
+export const InvoiceRelation = {
+  COMPANY_PRESENTATION: "Bedriftspresentasjon",
+  COURSE_EVENT: "Kurs",
+  OFFLINE_ADVERTISEMENT: "Annonse i Offline",
+  JOB_LISTING: "Jobbannonse",
+  EXCURSION_PARTICIPATION: "ITEX",
+  OTHER: "Annet",
+} as const
 
-export enum DeliveryMethod {
-  EMAIL = "E-post",
-  POST = "Post",
-  EHF = "EHF",
-}
+export const DeliveryMethod = {
+  EMAIL: "E-post",
+  POST: "Post",
+  EHF: "EHF",
+} as const
 
 export const formSchema = z.object({
   companyName: z.string().min(1, "Bedriftsnavnet kan ikke være tomt"),

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -18,6 +18,8 @@
     "skipLibCheck": true,
     "stripInternal": true,
 
-    "noEmit": true
+    "noEmit": true,
+
+    "erasableSyntaxOnly": true
   }
 }

--- a/packages/core/src/modules/article/article-repository.ts
+++ b/packages/core/src/modules/article/article-repository.ts
@@ -12,7 +12,11 @@ export interface ArticleRepository {
 }
 
 export class ArticleRepositoryImpl implements ArticleRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(input: ArticleWrite): Promise<Article> {
     return await this.db.article.create({ data: input })

--- a/packages/core/src/modules/article/article-service.ts
+++ b/packages/core/src/modules/article/article-service.ts
@@ -18,11 +18,19 @@ export interface ArticleService {
 }
 
 export class ArticleServiceImpl implements ArticleService {
+  private readonly articleRepository: ArticleRepository
+  private readonly articleTagRepository: ArticleTagRepository
+  private readonly articleTagLinkRepository: ArticleTagLinkRepository
+
   constructor(
-    private readonly articleRepository: ArticleRepository,
-    private readonly articleTagRepository: ArticleTagRepository,
-    private readonly articleTagLinkRepository: ArticleTagLinkRepository
-  ) {}
+    articleRepository: ArticleRepository,
+    articleTagRepository: ArticleTagRepository,
+    articleTagLinkRepository: ArticleTagLinkRepository
+  ) {
+    this.articleRepository = articleRepository
+    this.articleTagRepository = articleTagRepository
+    this.articleTagLinkRepository = articleTagLinkRepository
+  }
 
   async create(input: ArticleWrite): Promise<Article> {
     return await this.articleRepository.create(input)

--- a/packages/core/src/modules/article/article-tag-link-repository.ts
+++ b/packages/core/src/modules/article/article-tag-link-repository.ts
@@ -7,7 +7,11 @@ export interface ArticleTagLinkRepository {
 }
 
 export class ArticleTagLinkRepositoryImpl implements ArticleTagLinkRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async add(articleId: ArticleId, tagName: ArticleTagName): Promise<void> {
     await this.db.articleTagLink.create({ data: { articleId, tagName } })

--- a/packages/core/src/modules/article/article-tag-repository.ts
+++ b/packages/core/src/modules/article/article-tag-repository.ts
@@ -9,7 +9,11 @@ export interface ArticleTagRepository {
 }
 
 export class ArticleTagRepositoryImpl implements ArticleTagRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getAll(): Promise<ArticleTag[]> {
     return await this.db.articleTag.findMany()

--- a/packages/core/src/modules/attendance/attendance-pool-repository.ts
+++ b/packages/core/src/modules/attendance/attendance-pool-repository.ts
@@ -20,7 +20,11 @@ export interface AttendancePoolRepository {
 }
 
 export class AttendancePoolRepositoryImpl implements AttendancePoolRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async get(id: AttendancePoolId) {
     const poolData = await this.db.attendancePool.findUnique({

--- a/packages/core/src/modules/attendance/attendance-pool-service.ts
+++ b/packages/core/src/modules/attendance/attendance-pool-service.ts
@@ -17,10 +17,13 @@ export interface AttendancePoolService {
 }
 
 export class AttendancePoolServiceImpl implements AttendancePoolService {
-  constructor(
-    private readonly attendancePoolRepository: AttendancePoolRepository,
-    private readonly attendeeService: AttendeeService
-  ) {}
+  private readonly attendancePoolRepository: AttendancePoolRepository
+  private readonly attendeeService: AttendeeService
+
+  constructor(attendancePoolRepository: AttendancePoolRepository, attendeeService: AttendeeService) {
+    this.attendancePoolRepository = attendancePoolRepository
+    this.attendeeService = attendeeService
+  }
 
   async getByAttendanceId(id: AttendanceId) {
     return this.attendancePoolRepository.getByAttendanceId(id)

--- a/packages/core/src/modules/attendance/attendance-repository.ts
+++ b/packages/core/src/modules/attendance/attendance-repository.ts
@@ -20,7 +20,11 @@ export interface AttendanceRepository {
 }
 
 export class AttendanceRepositoryImpl implements AttendanceRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getAll() {
     const attendances = await this.db.attendance.findMany({})

--- a/packages/core/src/modules/attendance/attendance-service.ts
+++ b/packages/core/src/modules/attendance/attendance-service.ts
@@ -34,13 +34,25 @@ export interface AttendanceService {
 }
 
 export class AttendanceServiceImpl implements AttendanceService {
+  private readonly attendanceRepository: AttendanceRepository
+  private readonly attendeeRepository: AttendeeRepository
+  private readonly waitlistAttendeeRepository: WaitlistAttendeRepository
+  private readonly attendancePoolRepository: AttendancePoolRepository
+  private readonly userService: UserService
+
   constructor(
-    private readonly attendanceRepository: AttendanceRepository,
-    private readonly attendeeRepository: AttendeeRepository,
-    private readonly waitlistAttendeeRepository: WaitlistAttendeRepository,
-    private readonly attendancePoolRepository: AttendancePoolRepository,
-    private readonly userService: UserService
-  ) {}
+    attendanceRepository: AttendanceRepository,
+    attendeeRepository: AttendeeRepository,
+    waitlistAttendeeRepository: WaitlistAttendeRepository,
+    attendancePoolRepository: AttendancePoolRepository,
+    userService: UserService
+  ) {
+    this.attendanceRepository = attendanceRepository
+    this.attendeeRepository = attendeeRepository
+    this.waitlistAttendeeRepository = waitlistAttendeeRepository
+    this.attendancePoolRepository = attendancePoolRepository
+    this.userService = userService
+  }
 
   async getExtrasResults(attendanceId: AttendanceId) {
     const attendance = await this.attendanceRepository.getById(attendanceId)

--- a/packages/core/src/modules/attendance/attendee-repository.ts
+++ b/packages/core/src/modules/attendance/attendee-repository.ts
@@ -23,7 +23,11 @@ export interface AttendeeRepository {
 }
 
 export class AttendeeRepositoryImpl implements AttendeeRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getByUserId(userId: UserId, attendanceId: AttendanceId) {
     const user = await this.db.attendee.findFirst({ where: { userId, attendanceId } })

--- a/packages/core/src/modules/attendance/attendee-service.ts
+++ b/packages/core/src/modules/attendance/attendee-service.ts
@@ -37,13 +37,25 @@ export interface AttendeeService {
 }
 
 export class AttendeeServiceImpl implements AttendeeService {
+  private readonly attendeeRepository: AttendeeRepository
+  private readonly attendancePoolRepository: AttendancePoolRepository
+  private readonly attendanceRespository: AttendanceRepository
+  private readonly userService: UserService
+  private readonly waitlistAttendeeService: WaitlistAttendeService
+
   constructor(
-    private readonly attendeeRepository: AttendeeRepository,
-    private readonly attendancePoolRepository: AttendancePoolRepository,
-    private readonly attendanceRespository: AttendanceRepository,
-    private readonly userService: UserService,
-    private readonly waitlistAttendeeService: WaitlistAttendeService
-  ) {}
+    attendeeRepository: AttendeeRepository,
+    attendancePoolRepository: AttendancePoolRepository,
+    attendanceRespository: AttendanceRepository,
+    userService: UserService,
+    waitlistAttendeeService: WaitlistAttendeService
+  ) {
+    this.attendeeRepository = attendeeRepository
+    this.attendancePoolRepository = attendancePoolRepository
+    this.attendanceRespository = attendanceRespository
+    this.userService = userService
+    this.waitlistAttendeeService = waitlistAttendeeService
+  }
 
   async create(obj: AttendeeWrite) {
     return this.attendeeRepository.create(obj)

--- a/packages/core/src/modules/attendance/waitlist-attendee-repository.ts
+++ b/packages/core/src/modules/attendance/waitlist-attendee-repository.ts
@@ -18,7 +18,11 @@ export interface WaitlistAttendeRepository {
 }
 
 export class WaitlistAttendeRepositoryImpl implements WaitlistAttendeRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: WaitlistAttendeeWrite): Promise<WaitlistAttendee> {
     return await this.db.waitlistAttendee.create({ data })

--- a/packages/core/src/modules/attendance/waitlist-attendee-service.ts
+++ b/packages/core/src/modules/attendance/waitlist-attendee-service.ts
@@ -11,11 +11,15 @@ export interface WaitlistAttendeService {
 }
 
 export class WaitlistAttendeServiceImpl implements WaitlistAttendeService {
+  private readonly waitlistAttendeeRepository: WaitlistAttendeRepository
+  private readonly attendancePoolRepository: AttendancePoolRepository
+
   constructor(
-    private readonly waitlistAttendeeRepository: WaitlistAttendeRepository,
-    private readonly attendancePoolRepository: AttendancePoolRepository
+    waitlistAttendeeRepository: WaitlistAttendeRepository,
+    attendancePoolRepository: AttendancePoolRepository
   ) {
     this.waitlistAttendeeRepository = waitlistAttendeeRepository
+    this.attendancePoolRepository = attendancePoolRepository
   }
 
   async create(obj: WaitlistAttendeeWrite): Promise<WaitlistAttendee> {

--- a/packages/core/src/modules/committee/committee-repository.ts
+++ b/packages/core/src/modules/committee/committee-repository.ts
@@ -9,7 +9,11 @@ export interface CommitteeRepository {
 }
 
 export class CommitteeRepositoryImpl implements CommitteeRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getById(id: CommitteeId) {
     return await this.db.committee.findUnique({ where: { id } })

--- a/packages/core/src/modules/committee/committee-service.ts
+++ b/packages/core/src/modules/committee/committee-service.ts
@@ -10,7 +10,11 @@ export interface CommitteeService {
 }
 
 export class CommitteeServiceImpl implements CommitteeService {
-  constructor(private readonly committeeRepository: CommitteeRepository) {}
+  private readonly committeeRepository: CommitteeRepository
+
+  constructor(committeeRepository: CommitteeRepository) {
+    this.committeeRepository = committeeRepository
+  }
 
   /**
    * Get a committee by its id

--- a/packages/core/src/modules/company/company-event-repository.ts
+++ b/packages/core/src/modules/company/company-event-repository.ts
@@ -6,7 +6,11 @@ export interface CompanyEventRepository {
 }
 
 export class CompanyEventRepositoryImpl implements CompanyEventRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getEventsByCompanyId(companyId: CompanyId) {
     return this.db.event.findMany({ where: { companies: { some: { companyId } } } })

--- a/packages/core/src/modules/company/company-event-service.ts
+++ b/packages/core/src/modules/company/company-event-service.ts
@@ -7,7 +7,11 @@ export interface CompanyEventService {
 }
 
 export class CompanyEventServiceImpl implements CompanyEventService {
-  constructor(private readonly companyEventRepository: CompanyEventRepository) {}
+  private readonly companyEventRepository: CompanyEventRepository
+
+  constructor(companyEventRepository: CompanyEventRepository) {
+    this.companyEventRepository = companyEventRepository
+  }
 
   async getEventsByCompanyId(company: CompanyId): Promise<Event[]> {
     return this.companyEventRepository.getEventsByCompanyId(company)

--- a/packages/core/src/modules/company/company-repository.ts
+++ b/packages/core/src/modules/company/company-repository.ts
@@ -10,7 +10,11 @@ export interface CompanyRepository {
 }
 
 export class CompanyRepositoryImpl implements CompanyRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getById(id: string): Promise<Company | null> {
     return await this.db.company.findUnique({ where: { id } })

--- a/packages/core/src/modules/company/company-service.ts
+++ b/packages/core/src/modules/company/company-service.ts
@@ -11,7 +11,11 @@ export interface CompanyService {
 }
 
 export class CompanyServiceImpl implements CompanyService {
-  constructor(private readonly companyRepository: CompanyRepository) {}
+  private readonly companyRepository: CompanyRepository
+
+  constructor(companyRepository: CompanyRepository) {
+    this.companyRepository = companyRepository
+  }
 
   /**
    * Get a company by its id

--- a/packages/core/src/modules/event/event-committee-repository.ts
+++ b/packages/core/src/modules/event/event-committee-repository.ts
@@ -9,7 +9,11 @@ export interface EventCommitteeRepository {
 }
 
 export class EventCommitteeRepositoryImpl implements EventCommitteeRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getAllEventCommittees(eventId: EventId): Promise<Committee[]> {
     const eventCommittees = await this.db.eventCommittee.findMany({

--- a/packages/core/src/modules/event/event-committee-service.ts
+++ b/packages/core/src/modules/event/event-committee-service.ts
@@ -8,7 +8,11 @@ export interface EventCommitteeService {
 }
 
 export class EventCommitteeServiceImpl implements EventCommitteeService {
-  constructor(private readonly committeeOrganizerRepository: EventCommitteeRepository) {}
+  private readonly committeeOrganizerRepository: EventCommitteeRepository
+
+  constructor(committeeOrganizerRepository: EventCommitteeRepository) {
+    this.committeeOrganizerRepository = committeeOrganizerRepository
+  }
 
   async getCommitteesForEvent(eventId: EventId): Promise<Committee[]> {
     const committees = await this.committeeOrganizerRepository.getAllCommittees(eventId)

--- a/packages/core/src/modules/event/event-company-repository.ts
+++ b/packages/core/src/modules/event/event-company-repository.ts
@@ -10,7 +10,11 @@ export interface EventCompanyRepository {
 }
 
 export class EventCompanyRepositoryImpl implements EventCompanyRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async createCompany(eventId: EventId, companyId: CompanyId) {
     await this.db.eventCompany.create({ data: { eventId, companyId } })

--- a/packages/core/src/modules/event/event-company-service.ts
+++ b/packages/core/src/modules/event/event-company-service.ts
@@ -8,7 +8,11 @@ export interface EventCompanyService {
 }
 
 export class EventCompanyServiceImpl implements EventCompanyService {
-  constructor(private readonly eventCompanyRepository: EventCompanyRepository) {}
+  private readonly eventCompanyRepository: EventCompanyRepository
+
+  constructor(eventCompanyRepository: EventCompanyRepository) {
+    this.eventCompanyRepository = eventCompanyRepository
+  }
 
   async createCompany(id: EventId, company: CompanyId) {
     const companies = await this.eventCompanyRepository.createCompany(id, company)

--- a/packages/core/src/modules/event/event-repository.ts
+++ b/packages/core/src/modules/event/event-repository.ts
@@ -13,7 +13,11 @@ export interface EventRepository {
 }
 
 export class EventRepositoryImpl implements EventRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async addAttendance(id: EventId, attendanceId: string) {
     return await this.db.event.update({ where: { id }, data: { attendanceId } })

--- a/packages/core/src/modules/event/event-service.ts
+++ b/packages/core/src/modules/event/event-service.ts
@@ -28,13 +28,25 @@ export interface EventService {
 }
 
 export class EventServiceImpl implements EventService {
+  private readonly eventRepository: EventRepository
+  private readonly attendanceService: AttendanceService
+  private readonly attendancePoolService: AttendancePoolService
+  private readonly eventCommitteeService: EventCommitteeService
+  private readonly eventCompanyService: EventCompanyService
+
   constructor(
-    private readonly eventRepository: EventRepository,
-    private readonly attendanceService: AttendanceService,
-    private readonly attendancePoolService: AttendancePoolService,
-    private readonly eventCommitteeService: EventCommitteeService,
-    private readonly eventCompanyService: EventCompanyService
-  ) {}
+    eventRepository: EventRepository,
+    attendanceService: AttendanceService,
+    attendancePoolService: AttendancePoolService,
+    eventCommitteeService: EventCommitteeService,
+    eventCompanyService: EventCompanyService
+  ) {
+    this.eventRepository = eventRepository
+    this.attendanceService = attendanceService
+    this.attendancePoolService = attendancePoolService
+    this.eventCommitteeService = eventCommitteeService
+    this.eventCompanyService = eventCompanyService
+  }
 
   async addAttendance(eventId: EventId, obj: AttendanceWrite) {
     const attendance = await this.attendanceService.create(obj)

--- a/packages/core/src/modules/external/s3-repository.ts
+++ b/packages/core/src/modules/external/s3-repository.ts
@@ -6,10 +6,13 @@ export interface S3Repository {
 }
 
 export class S3RepositoryImpl implements S3Repository {
-  public constructor(
-    private readonly s3Client: S3Client,
-    private readonly s3BucketName: string
-  ) {}
+  private readonly s3Client: S3Client
+  private readonly s3BucketName: string
+
+  public constructor(s3Client: S3Client, s3BucketName: string) {
+    this.s3Client = s3Client
+    this.s3BucketName = s3BucketName
+  }
 
   async createPresignedPost(key: string, mimeType: string, maxSizeMB: number): Promise<PresignedPost> {
     return _createPresignedPost(this.s3Client, {

--- a/packages/core/src/modules/interest-group/interest-group-repository.ts
+++ b/packages/core/src/modules/interest-group/interest-group-repository.ts
@@ -20,7 +20,11 @@ export interface InterestGroupRepository {
 }
 
 export class InterestGroupRepositoryImpl implements InterestGroupRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getById(id: InterestGroupId): Promise<InterestGroup | null> {
     return await this.db.interestGroup.findUnique({ where: { id } })

--- a/packages/core/src/modules/interest-group/interest-group-service.ts
+++ b/packages/core/src/modules/interest-group/interest-group-service.ts
@@ -20,7 +20,11 @@ export interface InterestGroupService {
 }
 
 export class InterestGroupServiceImpl implements InterestGroupService {
-  constructor(private readonly interestGroupRepository: InterestGroupRepository) {}
+  private readonly interestGroupRepository: InterestGroupRepository
+
+  constructor(interestGroupRepository: InterestGroupRepository) {
+    this.interestGroupRepository = interestGroupRepository
+  }
 
   async getById(id: InterestGroupId): Promise<InterestGroup | null> {
     return this.interestGroupRepository.getById(id)

--- a/packages/core/src/modules/job-listing/job-listing-repository.ts
+++ b/packages/core/src/modules/job-listing/job-listing-repository.ts
@@ -12,7 +12,11 @@ export interface JobListingRepository {
 }
 
 export class JobListingRepositoryImpl implements JobListingRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async createJobListing({ companyId, locations, ...rest }: JobListingWrite): Promise<JobListing> {
     const jobListing = await this.db.jobListing.create({

--- a/packages/core/src/modules/job-listing/job-listing-service.ts
+++ b/packages/core/src/modules/job-listing/job-listing-service.ts
@@ -15,7 +15,11 @@ export interface JobListingService {
 }
 
 export class JobListingServiceImpl implements JobListingService {
-  constructor(private readonly jobListingRepository: JobListingRepository) {}
+  private readonly jobListingRepository: JobListingRepository
+
+  constructor(jobListingRepository: JobListingRepository) {
+    this.jobListingRepository = jobListingRepository
+  }
 
   async getById(id: JobListingId): Promise<JobListing | null> {
     return await this.jobListingRepository.getById(id)

--- a/packages/core/src/modules/mark/mark-repository.ts
+++ b/packages/core/src/modules/mark/mark-repository.ts
@@ -10,7 +10,11 @@ export interface MarkRepository {
 }
 
 export class MarkRepositoryImpl implements MarkRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getById(id: MarkId): Promise<Mark | null> {
     return await this.db.mark.findUnique({ where: { id } })

--- a/packages/core/src/modules/mark/mark-service.ts
+++ b/packages/core/src/modules/mark/mark-service.ts
@@ -12,7 +12,11 @@ export interface MarkService {
 }
 
 export class MarkServiceImpl implements MarkService {
-  constructor(private readonly markRepository: MarkRepository) {}
+  private readonly markRepository: MarkRepository
+
+  constructor(markRepository: MarkRepository) {
+    this.markRepository = markRepository
+  }
 
   /**
    * Get a mark by its id

--- a/packages/core/src/modules/mark/personal-mark-repository.ts
+++ b/packages/core/src/modules/mark/personal-mark-repository.ts
@@ -12,7 +12,11 @@ export interface PersonalMarkRepository {
 }
 
 export class PersonalMarkRepositoryImpl implements PersonalMarkRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getAllByUserId(userId: UserId): Promise<PersonalMark[]> {
     return await this.db.personalMark.findMany({ where: { userId } })

--- a/packages/core/src/modules/mark/personal-mark-service.ts
+++ b/packages/core/src/modules/mark/personal-mark-service.ts
@@ -16,10 +16,13 @@ export interface PersonalMarkService {
 }
 
 export class PersonalMarkServiceImpl implements PersonalMarkService {
-  constructor(
-    private readonly personalMarkRepository: PersonalMarkRepository,
-    private readonly markService: MarkService
-  ) {}
+  private readonly personalMarkRepository: PersonalMarkRepository
+  private readonly markService: MarkService
+
+  constructor(personalMarkRepository: PersonalMarkRepository, markService: MarkService) {
+    this.personalMarkRepository = personalMarkRepository
+    this.markService = markService
+  }
 
   async getPersonalMarksForUserId(userId: UserId): Promise<PersonalMark[]> {
     const personalMarks = await this.personalMarkRepository.getAllByUserId(userId)

--- a/packages/core/src/modules/offline/offline-repository.ts
+++ b/packages/core/src/modules/offline/offline-repository.ts
@@ -10,7 +10,11 @@ export interface OfflineRepository {
 }
 
 export class OfflineRepositoryImpl implements OfflineRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: OfflineWrite): Promise<Offline> {
     return await this.db.offline.create({ data })

--- a/packages/core/src/modules/offline/offline-service.ts
+++ b/packages/core/src/modules/offline/offline-service.ts
@@ -14,10 +14,13 @@ export interface OfflineService {
 }
 
 export class OfflineServiceImpl implements OfflineService {
-  constructor(
-    private readonly offlineRepository: OfflineRepository,
-    private readonly s3Repository: S3Repository
-  ) {}
+  private readonly offlineRepository: OfflineRepository
+  private readonly s3Repository: S3Repository
+
+  constructor(offlineRepository: OfflineRepository, s3Repository: S3Repository) {
+    this.offlineRepository = offlineRepository
+    this.s3Repository = s3Repository
+  }
 
   /**
    * Get an offline by its id

--- a/packages/core/src/modules/payment/payment-repository.ts
+++ b/packages/core/src/modules/payment/payment-repository.ts
@@ -16,7 +16,11 @@ export interface PaymentRepository {
 }
 
 export class PaymentRepositoryImpl implements PaymentRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: PaymentWrite): Promise<Payment | null> {
     return await this.db.payment.create({ data })

--- a/packages/core/src/modules/payment/payment-service.ts
+++ b/packages/core/src/modules/payment/payment-service.ts
@@ -47,13 +47,25 @@ export interface PaymentService {
 }
 
 export class PaymentServiceImpl implements PaymentService {
+  private readonly paymentRepository: PaymentRepository
+  private readonly productRepository: ProductRepository
+  private readonly eventRepository: EventRepository
+  private readonly refundRequestRepository: RefundRequestRepository
+  private readonly stripeAccounts: Record<string, StripeAccount>
+
   constructor(
-    private readonly paymentRepository: PaymentRepository,
-    private readonly productRepository: ProductRepository,
-    private readonly eventRepository: EventRepository,
-    private readonly refundRequestRepository: RefundRequestRepository,
-    private readonly stripeAccounts: Record<string, StripeAccount>
-  ) {}
+    paymentRepository: PaymentRepository,
+    productRepository: ProductRepository,
+    eventRepository: EventRepository,
+    refundRequestRepository: RefundRequestRepository,
+    stripeAccounts: Record<string, StripeAccount>
+  ) {
+    this.paymentRepository = paymentRepository
+    this.productRepository = productRepository
+    this.eventRepository = eventRepository
+    this.refundRequestRepository = refundRequestRepository
+    this.stripeAccounts = stripeAccounts
+  }
 
   findStripeSdkByPublicKey(publicKey: string): Stripe | null {
     return Object.values(this.stripeAccounts).find((account) => account.publicKey === publicKey)?.stripe ?? null

--- a/packages/core/src/modules/payment/product-payment-provider-repository.ts
+++ b/packages/core/src/modules/payment/product-payment-provider-repository.ts
@@ -14,7 +14,11 @@ export interface ProductPaymentProviderRepository {
 }
 
 export class ProductPaymentProviderRepositoryImpl implements ProductPaymentProviderRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: ProductPaymentProviderWrite): Promise<ProductPaymentProvider | null> {
     return await this.db.productPaymentProvider.create({ data })

--- a/packages/core/src/modules/payment/product-payment-provider-service.ts
+++ b/packages/core/src/modules/payment/product-payment-provider-service.ts
@@ -14,7 +14,11 @@ export interface ProductPaymentProviderService {
 }
 
 export class ProductPaymentProviderServiceImpl implements ProductPaymentProviderService {
-  constructor(private readonly productPaymentProviderRepository: ProductPaymentProviderRepository) {}
+  private readonly productPaymentProviderRepository: ProductPaymentProviderRepository
+
+  constructor(productPaymentProviderRepository: ProductPaymentProviderRepository) {
+    this.productPaymentProviderRepository = productPaymentProviderRepository
+  }
 
   async addPaymentProvider(data: ProductPaymentProviderWrite): Promise<ProductPaymentProvider | null> {
     return await this.productPaymentProviderRepository.create(data)

--- a/packages/core/src/modules/payment/product-repository.ts
+++ b/packages/core/src/modules/payment/product-repository.ts
@@ -12,7 +12,11 @@ export interface ProductRepository {
 }
 
 export class ProductRepositoryImpl implements ProductRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: ProductWrite): Promise<Product> {
     return await this.db.product.create({ data, include: { paymentProviders: true } })

--- a/packages/core/src/modules/payment/product-service.ts
+++ b/packages/core/src/modules/payment/product-service.ts
@@ -10,7 +10,11 @@ export interface ProductService {
 }
 
 export class ProductServiceImpl implements ProductService {
-  constructor(private readonly productRepository: ProductRepository) {}
+  private readonly productRepository: ProductRepository
+
+  constructor(productRepository: ProductRepository) {
+    this.productRepository = productRepository
+  }
 
   async createProduct(productCreate: ProductWrite): Promise<Product> {
     const product = await this.productRepository.create(productCreate)

--- a/packages/core/src/modules/payment/refund-request-repository.ts
+++ b/packages/core/src/modules/payment/refund-request-repository.ts
@@ -12,7 +12,11 @@ export interface RefundRequestRepository {
 }
 
 export class RefundRequestRepositoryImpl implements RefundRequestRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async create(data: RefundRequestWrite): Promise<RefundRequest> {
     return await this.db.refundRequest.create({ data })

--- a/packages/core/src/modules/payment/refund-request-service.ts
+++ b/packages/core/src/modules/payment/refund-request-service.ts
@@ -20,12 +20,22 @@ export interface RefundRequestService {
 }
 
 export class RefundRequestServiceImpl implements RefundRequestService {
+  private readonly refundRequestRepository: RefundRequestRepository
+  private readonly paymentRepository: PaymentRepository
+  private readonly productRepository: ProductRepository
+  private readonly paymentService: PaymentService
+
   constructor(
-    private readonly refundRequestRepository: RefundRequestRepository,
-    private readonly paymentRepository: PaymentRepository,
-    private readonly productRepository: ProductRepository,
-    private readonly paymentService: PaymentService
-  ) {}
+    refundRequestRepository: RefundRequestRepository,
+    paymentRepository: PaymentRepository,
+    productRepository: ProductRepository,
+    paymentService: PaymentService
+  ) {
+    this.refundRequestRepository = refundRequestRepository
+    this.paymentRepository = paymentRepository
+    this.productRepository = productRepository
+    this.paymentService = paymentService
+  }
 
   /**
    * Create a refund request for a payment

--- a/packages/core/src/modules/user/notification-permissions-repository.ts
+++ b/packages/core/src/modules/user/notification-permissions-repository.ts
@@ -11,7 +11,11 @@ export interface NotificationPermissionsRepository {
 }
 
 export class NotificationPermissionsRepositoryImpl implements NotificationPermissionsRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getByUserId(userId: UserId): Promise<NotificationPermissions | null> {
     return await this.db.notificationPermissions.findUnique({ where: { userId } })

--- a/packages/core/src/modules/user/privacy-permissions-repository.ts
+++ b/packages/core/src/modules/user/privacy-permissions-repository.ts
@@ -8,7 +8,11 @@ export interface PrivacyPermissionsRepository {
 }
 
 export class PrivacyPermissionsRepositoryImpl implements PrivacyPermissionsRepository {
-  constructor(private readonly db: DBClient) {}
+  private readonly db: DBClient
+
+  constructor(db: DBClient) {
+    this.db = db
+  }
 
   async getByUserId(userId: UserId): Promise<PrivacyPermissions | null> {
     return await this.db.privacyPermissions.findUnique({ where: { userId } })

--- a/packages/core/src/modules/user/user-repository.ts
+++ b/packages/core/src/modules/user/user-repository.ts
@@ -71,10 +71,13 @@ const mapUserWriteToPatch = (data: Partial<UserWrite>): UserUpdate => {
 }
 
 export class UserRepositoryImpl implements UserRepository {
-  constructor(
-    private readonly client: ManagementClient,
-    private readonly db: DBClient
-  ) {}
+  private readonly client: ManagementClient
+  private readonly db: DBClient
+
+  constructor(client: ManagementClient, db: DBClient) {
+    this.client = client
+    this.db = db
+  }
 
   async create(data: Omit<User, "id">, password: string): Promise<User> {
     const response = await this.client.users.create(mapUserToAuth0UserCreate(data, password))

--- a/packages/core/src/modules/user/user-service.ts
+++ b/packages/core/src/modules/user/user-service.ts
@@ -25,11 +25,19 @@ export interface UserService {
 }
 
 export class UserServiceImpl implements UserService {
+  private readonly userRepository: UserRepository
+  private readonly privacyPermissionsRepository: PrivacyPermissionsRepository
+  private readonly notificationPermissionsRepository: NotificationPermissionsRepository
+
   constructor(
-    private readonly userRepository: UserRepository,
-    private readonly privacyPermissionsRepository: PrivacyPermissionsRepository,
-    private readonly notificationPermissionsRepository: NotificationPermissionsRepository
-  ) {}
+    userRepository: UserRepository,
+    privacyPermissionsRepository: PrivacyPermissionsRepository,
+    notificationPermissionsRepository: NotificationPermissionsRepository
+  ) {
+    this.userRepository = userRepository
+    this.privacyPermissionsRepository = privacyPermissionsRepository
+    this.notificationPermissionsRepository = notificationPermissionsRepository
+  }
 
   async registerAndGet(auth0Id: string) {
     return this.userRepository.registerAndGet(auth0Id)

--- a/packages/emails/src/emails/invoice-form-for-bedkom.tsx
+++ b/packages/emails/src/emails/invoice-form-for-bedkom.tsx
@@ -3,20 +3,20 @@ import { Tailwind } from "@react-email/tailwind"
 import { z } from "zod"
 import { type TemplateProps, createTemplate } from "../template"
 
-export enum InvoiceRelation {
-  COMPANY_PRESENTATION = "Bedriftspresentasjon",
-  COURSE_EVENT = "Kurs",
-  OFFLINE_ADVERTISEMENT = "Annonse i Offline",
-  JOB_LISTING = "Jobbannonse",
-  EXCURSION_PARTICIPATION = "ITEX",
-  OTHER = "Annet",
-}
+export const InvoiceRelation = {
+  COMPANY_PRESENTATION: "Bedriftspresentasjon",
+  COURSE_EVENT: "Kurs",
+  OFFLINE_ADVERTISEMENT: "Annonse i Offline",
+  JOB_LISTING: "Jobbannonse",
+  EXCURSION_PARTICIPATION: "ITEX",
+  OTHER: "Annet",
+} as const
 
-export enum DeliveryMethod {
-  EMAIL = "E-post",
-  POST = "Post",
-  EHF = "EHF",
-}
+export const DeliveryMethod = {
+  EMAIL: "E-post",
+  POST: "Post",
+  EHF: "EHF",
+} as const
 
 const Props = z.object({
   companyName: z.string().min(1, "Bedriftsnavnet kan ikke være tomt"),

--- a/packages/gateway-trpc/src/crypto.ts
+++ b/packages/gateway-trpc/src/crypto.ts
@@ -9,11 +9,12 @@ import {
 export class JwtService {
   private jwks: GetKeyFunction<JWTHeaderParameters, FlattenedJWSInput> | null = null
   private readonly jwksUrl: URL
+  private readonly issuer: string
+  private readonly audiences: string[]
 
-  public constructor(
-    private readonly issuer: string,
-    private readonly audiences: string[]
-  ) {
+  public constructor(issuer: string, audiences: string[]) {
+    this.issuer = issuer
+    this.audiences = audiences
     const issuerWithoutTrailingSlash = issuer.replace(/\/$/, "")
     this.jwksUrl = new URL(`${issuerWithoutTrailingSlash}/.well-known/jwks.json`)
   }


### PR DESCRIPTION
Makes it so all code is type-erasable (new option in TS 5.8)

This allows us to run RPC without tsx, building with tsup or any of that junk. It has a runtime loader to rewrite imports to have .ts extensions.