### PR TITLE
Set minimum node version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.12.2
+          node-version: 22.14.0
           cache: 'pnpm'
  
       - name: Install dependencies

--- a/apps/brevduen/Dockerfile
+++ b/apps/brevduen/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:20 AS builder
+FROM public.ecr.aws/lambda/nodejs:22 AS builder
 
 WORKDIR /usr/app
 COPY apps ./apps
@@ -9,7 +9,7 @@ RUN npm i -g pnpm@9.15.5 --ignore-scripts
 RUN pnpm install --frozen-lockfile --ignore-scripts
 RUN pnpm build:brevduen
 
-FROM public.ecr.aws/lambda/nodejs:20 AS runner
+FROM public.ecr.aws/lambda/nodejs:22 AS runner
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "workspaces": ["packages/*", "apps/*"],
   "packageManager": "pnpm@9.15.5",
   "engines": {
-    "node": ">=20.12.2",
+    "node": ">=22.0.0",
     "pnpm": ">=9.15.5"
   },
   "devDependencies": {


### PR DESCRIPTION
We are using --experimental-strip-types for rpc, and the nvmrc has been
at 22 for a long time. 22 is also the active version right now