### PR TITLE
Remove version field in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   db:
     container_name: ow_db


### PR DESCRIPTION
Docker renders it obsolete

![image](https://github.com/user-attachments/assets/f204f877-6e84-4e02-b34e-e8e937c1ab65)
