### PR TITLE
Enable automerge for patch and minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/", 
+      "automerge": true
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
         "/^@dotkomonline//"


### PR DESCRIPTION
We do this at work and I think it's pretty nice. Helps keep the maintenance burden down. And we have a low risk application, so I think it's worth the occasional problematic merge

The matchCurrentVersion setting above is a rule to exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time according to the SemVer spec.

