### PR TITLE
Remove Vercel logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ pnpm dev
 
 Please see the [developer guide](CONTRIBUTING.md) for information on how to get started with development.
 
-<a href="https://vercel.com?utm_source=[team-name]&utm_campaign=oss" width="150" height="30">
-    <img src="https://images.ctfassets.net/e5382hct74si/78Olo8EZRdUlcDUFQvnzG7/fa4cdb6dc04c40fceac194134788a0e2/1618983297-powered-by-vercel.svg" alt="Vercel">
-</a>
-
 ## License
 
 Licensed under the MIT license.


### PR DESCRIPTION
We are not sponsored by them so there is no contractual obligation to
have their logo mark anywhere