### PR TITLE
Use subject claim from access token in sign-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,46 @@ jobs:
           aws-region: eu-north-1
           role-to-assume: arn:aws:iam::891459268445:role/MonowebStagingDashboardCIRole
       - uses: aws-actions/amazon-ecr-login@v2
+      # Dashboard requires build-time secrets from Doppler
+      - uses: actions/github-script@v6
+        id: get-oidc-token
+        with:
+          script: |
+            const id_token = await core.getIDToken()
+            core.setOutput('oidc_token', id_token)
+      - uses: dopplerhq/cli-action@v2
+      # Identity comes from the configured doppler account identity
+      # (see last step https://docs.doppler.com/docs/service-account-identities#configure-the-identity)
+      - run: |
+          doppler oidc login \
+            --api-host https://api.doppler.com \
+            --scope=. \
+            --identity=8f25d2a1-28b9-4f2a-8fb3-115b10f456b2 \
+            --token=${{ steps.get-oidc-token.outputs.oidc_token }}
+      - run: doppler setup -p monoweb-dashboard -c staging
+      # Configure build arguments
+      - run: |
+          OAUTH_CLIENT_ID=$(doppler secrets get OAUTH_CLIENT_ID --json | jq -r '.OAUTH_CLIENT_ID.computed')
+          OAUTH_CLIENT_SECRET=$(doppler secrets get OAUTH_CLIENT_SECRET --json | jq -r '.OAUTH_CLIENT_SECRET.computed')
+          OAUTH_ISSUER=$(doppler secrets get OAUTH_ISSUER --json | jq -r '.OAUTH_ISSUER.computed')
+          AUTH_SECRET=$(doppler secrets get AUTH_SECRET --json | jq -r '.AUTH_SECRET.computed')
+          NEXT_PUBLIC_ORIGIN=$(doppler secrets get NEXT_PUBLIC_ORIGIN --json | jq -r '.NEXT_PUBLIC_ORIGIN.computed')
+          RPC_HOST=$(doppler secrets get RPC_HOST --json | jq -r '.RPC_HOST.computed')
+
+          echo "::add-mask::$OAUTH_CLIENT_ID"
+          echo "::add-mask::$OAUTH_CLIENT_SECRET"
+          echo "::add-mask::$OAUTH_ISSUER"
+          echo "::add-mask::$AUTH_SECRET"
+          echo "::add-mask::$NEXT_PUBLIC_ORIGIN"
+          echo "::add-mask::$RPC_HOST"
+
+          echo BUILD_ARG_OAUTH_CLIENT_ID="$OAUTH_CLIENT_ID" >> $GITHUB_OUTPUT
+          echo BUILD_ARG_OAUTH_CLIENT_SECRET="$OAUTH_CLIENT_SECRET" >> $GITHUB_OUTPUT
+          echo BUILD_ARG_OAUTH_ISSUER="$OAUTH_ISSUER" >> $GITHUB_OUTPUT
+          echo BUILD_ARG_AUTH_SECRET="$AUTH_SECRET" >> $GITHUB_OUTPUT
+          echo BUILD_ARG_NEXT_PUBLIC_ORIGIN="$NEXT_PUBLIC_ORIGIN" >> $GITHUB_OUTPUT
+          echo BUILD_ARG_RPC_HOST="$RPC_HOST" >> $GITHUB_OUTPUT
+        id: set-build-args
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
@@ -155,6 +195,13 @@ jobs:
           file: apps/dashboard/Dockerfile
           tags: 891459268445.dkr.ecr.eu-north-1.amazonaws.com/monoweb/staging/dashboard:latest
           push: ${{ env.GH_IS_DEPLOYING_STAGING }}
+          build-args: |
+            OAUTH_CLIENT_ID=${{ steps.set-build-args.outputs.BUILD_ARG_OAUTH_CLIENT_ID }}
+            OAUTH_CLIENT_SECRET=${{ steps.set-build-args.outputs.BUILD_ARG_OAUTH_CLIENT_SECRET }}
+            OAUTH_ISSUER=${{ steps.set-build-args.outputs.BUILD_ARG_OAUTH_ISSUER }}
+            AUTH_SECRET=${{ steps.set-build-args.outputs.BUILD_ARG_AUTH_SECRET }}
+            NEXT_PUBLIC_ORIGIN=${{ steps.set-build-args.outputs.BUILD_ARG_NEXT_PUBLIC_ORIGIN }}
+            RPC_HOST=${{ steps.set-build-args.outputs.BUILD_ARG_RPC_HOST }}
       - uses: actions/github-script@v7
         if: env.GH_IS_DEPLOYING_STAGING
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,12 +281,12 @@ jobs:
       - run: doppler setup -p monoweb-web -c staging
       # Configure build arguments
       - run: |
-          OAUTH_CLIENT_ID=$(doppler secrets get OAUTH_CLIENT_ID --json | jq '.OAUTH_CLIENT_ID.computed')
-          OAUTH_CLIENT_SECRET=$(doppler secrets get OAUTH_CLIENT_SECRET --json | jq '.OAUTH_CLIENT_SECRET.computed')
-          OAUTH_ISSUER=$(doppler secrets get OAUTH_ISSUER --json | jq '.OAUTH_ISSUER.computed')
-          AUTH_SECRET=$(doppler secrets get AUTH_SECRET --json | jq '.AUTH_SECRET.computed')
-          NEXT_PUBLIC_ORIGIN=$(doppler secrets get NEXT_PUBLIC_ORIGIN --json | jq '.NEXT_PUBLIC_ORIGIN.computed')
-          RPC_HOST=$(doppler secrets get RPC_HOST --json | jq '.RPC_HOST.computed')
+          OAUTH_CLIENT_ID=$(doppler secrets get OAUTH_CLIENT_ID --json | jq -r '.OAUTH_CLIENT_ID.computed')
+          OAUTH_CLIENT_SECRET=$(doppler secrets get OAUTH_CLIENT_SECRET --json | jq -r '.OAUTH_CLIENT_SECRET.computed')
+          OAUTH_ISSUER=$(doppler secrets get OAUTH_ISSUER --json | jq -r '.OAUTH_ISSUER.computed')
+          AUTH_SECRET=$(doppler secrets get AUTH_SECRET --json | jq -r '.AUTH_SECRET.computed')
+          NEXT_PUBLIC_ORIGIN=$(doppler secrets get NEXT_PUBLIC_ORIGIN --json | jq -r '.NEXT_PUBLIC_ORIGIN.computed')
+          RPC_HOST=$(doppler secrets get RPC_HOST --json | jq -r '.RPC_HOST.computed')
 
           echo "::add-mask::$OAUTH_CLIENT_ID"
           echo "::add-mask::$OAUTH_CLIENT_SECRET"

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,5 +1,16 @@
 FROM node:22-alpine AS base
 
+# Next.js evaluates a lot of code at build-time for things like SSG and SSR. For this reason, we need some of the
+# runtime variables to be available at build-time.
+#
+# These build arguments loosely mirror the src/env.ts file
+ARG OAUTH_CLIENT_ID
+ARG OAUTH_CLIENT_SECRET
+ARG OAUTH_ISSUER
+ARG AUTH_SECRET
+ARG NEXT_PUBLIC_ORIGIN
+ARG RPC_HOST
+
 FROM base AS builder
 WORKDIR /app
 
@@ -15,16 +26,25 @@ WORKDIR /app
 
 ENV DOCKER_BUILD=1
 
-RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
+RUN npm install -g pnpm@9.15.5 --ignore-scripts
 COPY --from=builder /app/out/json .
 COPY --from=builder /app/out/full/packages/db/prisma/schema.prisma packages/db/prisma/schema.prisma
+RUN pnpm install --ignore-scripts
 
-# Must enable scripts here for Prisma codegen to build
-RUN apk update && apk add --no-cache python3 gcc g++ make
-RUN pnpm install
+# Generate prisma types
+WORKDIR /app/packages/db
+RUN pnpm run generate
+WORKDIR /app
+
+ENV OAUTH_CLIENT_ID ${OAUTH_CLIENT_ID}
+ENV OAUTH_CLIENT_SECRET ${OAUTH_CLIENT_SECRET}
+ENV OAUTH_ISSUER ${OAUTH_ISSUER}
+ENV AUTH_SECRET ${AUTH_SECRET}
+ENV NEXT_PUBLIC_ORIGIN ${NEXT_PUBLIC_ORIGIN}
+ENV RPC_HOST ${RPC_HOST}
 
 COPY --from=builder /app/out/full .
-RUN turbo run build --filter @dotkomonline/dashboard
+RUN pnpm run --filter @dotkomonline/dashboard build
 
 FROM base AS runner
 WORKDIR /app

--- a/apps/dashboard/src/env.ts
+++ b/apps/dashboard/src/env.ts
@@ -6,6 +6,9 @@ export const env = createEnvironment(
     OAUTH_CLIENT_SECRET: variable,
     OAUTH_ISSUER: variable,
     AUTH_SECRET: variable,
+    // Behind a proxy (e.g AWS ALB) the Host header will be the proxy's host, so
+    // we tell AuthJs to trust the X-Forwarded-Host header instead.
+    AUTH_TRUST_HOST: variable.optional(),
     NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3002"),
     RPC_HOST: variable,
   },

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 
 ENV DOCKER_BUILD=1
 
-RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
+RUN npm install -g pnpm@9.15.5 --ignore-scripts
 COPY --from=builder /app/out/json .
 COPY --from=builder /app/out/full/packages/db/prisma/schema.prisma packages/db/prisma/schema.prisma
 RUN pnpm install --ignore-scripts
@@ -45,7 +45,7 @@ ENV AUTH_SECRET ${AUTH_SECRET}
 ENV NEXT_PUBLIC_ORIGIN ${NEXT_PUBLIC_ORIGIN}
 ENV RPC_HOST ${RPC_HOST}
 
-RUN turbo run build --filter @dotkomonline/web
+RUN pnpm run --filter @dotkomonline/web build
 
 FROM base AS runner
 WORKDIR /app

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -6,7 +6,7 @@ export const env = createEnvironment(
     OAUTH_CLIENT_SECRET: variable,
     OAUTH_ISSUER: variable,
     AUTH_SECRET: variable,
-    // Behind a proxy (e.g AWS ELB) the Host header will be the proxy's host, so
+    // Behind a proxy (e.g AWS ALB) the Host header will be the proxy's host, so
     // we tell AuthJs to trust the X-Forwarded-Host header instead.
     AUTH_TRUST_HOST: variable.optional(),
     NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3000"),

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,7 @@
     "@auth/core": "^0.37.2",
     "@dotkomonline/types": "workspace:*",
     "@trpc/client": "11.0.0-rc.828",
+    "jose": "^6.0.0",
     "superjson": "^2.0.0",
     "next": "^15.1.6",
     "next-auth": "5.0.0-beta.25",

--- a/packages/environment/src/index.mjs
+++ b/packages/environment/src/index.mjs
@@ -17,7 +17,9 @@ export function createEnvironment(variables, env = process.env) {
   const environment = schema.safeParse(env)
   const skipValidation = process.env.DOCKER_BUILD === "1" || process.env.CI !== undefined
   if (skipValidation) {
-    return environment.data ?? {}
+    // If we did successfully parse, we might as well return them. Otherwise, we're just going to hand the raw
+    // environment variables back.
+    return environment.data ?? env
   }
   if (!environment.success) {
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -769,6 +769,9 @@ importers:
       '@trpc/client':
         specifier: 11.0.0-rc.828
         version: 11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)
+      jose:
+        specifier: ^6.0.0
+        version: 6.0.10
       next:
         specifier: ^15.1.6
         version: 15.2.2(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/turbo.json
+++ b/turbo.json
@@ -3,16 +3,12 @@
   "globalEnv": [
     "S3_BUCKET_MONOWEB",
     "NODE_ENV",
-    "WEB_AUTH0_CLIENT_ID",
-    "WEB_AUTH0_CLIENT_SECRET",
-    "WEB_AUTH0_ISSUER",
-    "DASHBOARD_AUTH0_CLIENT_ID",
-    "DASHBOARD_AUTH0_CLIENT_SECRET",
-    "DASHBOARD_AUTH0_ISSUER",
+    "OAUTH_CLIENT_ID",
+    "OAUTH_CLIENT_SECRET",
+    "OAUTH_ISSUER",
     "AUTH_SECRET",
+    "AUTH_TRUST_HOST",
     "DATABASE_URL",
-    "VERCEL_URL",
-    "PORT",
     "FAGKOM_STRIPE_PUBLIC_KEY",
     "FAGKOM_STRIPE_SECRET_KEY",
     "FAGKOM_STRIPE_WEBHOOK_SECRET",
@@ -24,11 +20,6 @@
     "AWS_ACCESS_KEY_ID",
     "EMAIL_TOKEN",
     "EMAIL_ENDPOINT",
-    "INTEREST_FORM_SERVICE_ACCOUNT",
-    "INTEREST_FORM_SPREADSHEET_ID",
-    "GTX_AUTH0_CLIENT_ID",
-    "GTX_AUTH0_CLIENT_SECRET",
-    "GTX_AUTH0_ISSUER",
     "RPC_ALLOWED_ORIGINS",
     "RPC_HOST"
   ],
@@ -36,13 +27,6 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["**/dist"]
-    },
-    "build:prod": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**"]
-    },
-    "build:storybook": {
-      "outputs": ["storybook-static/**"]
     },
     "type-check": {
       "outputs": []


### PR DESCRIPTION
`token.sub` gives you the provider sub. If the user logs in via FEIDE,
this field becomes the FEIDE sub - not the Auth0 one. This change uses
the access token to derive the Auth0 sub.