### PR TITLE
Add optional AUTH_URL variable

### DIFF
--- a/apps/dashboard/src/env.ts
+++ b/apps/dashboard/src/env.ts
@@ -9,6 +9,7 @@ export const env = createEnvironment(
     // Behind a proxy (e.g AWS ALB) the Host header will be the proxy's host, so
     // we tell AuthJs to trust the X-Forwarded-Host header instead.
     AUTH_TRUST_HOST: variable.optional(),
+    AUTH_URL: variable.optional(),
     NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3002"),
     RPC_HOST: variable,
   },

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -9,6 +9,7 @@ export const env = createEnvironment(
     // Behind a proxy (e.g AWS ALB) the Host header will be the proxy's host, so
     // we tell AuthJs to trust the X-Forwarded-Host header instead.
     AUTH_TRUST_HOST: variable.optional(),
+    AUTH_URL: variable.optional(),
     NEXT_PUBLIC_ORIGIN: variable.default("http://localhost:3000"),
     RPC_HOST: variable,
     SIGNING_KEY: variable,


### PR DESCRIPTION
When deployed behind ALB we need this variable, otherwise authjs thinks
we are going back to localhost:3000