### PR TITLE
Replace text inputs with file inputs for image uploads

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/company/write-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/company/write-form.tsx
@@ -1,5 +1,5 @@
 import { type CompanyWrite, CompanyWriteSchema } from "@dotkomonline/types"
-import { createSelectInput, createTextInput, createTextareaInput, useFormBuilder } from "../../form"
+import { createFileInput, createSelectInput, createTextInput, createTextareaInput, useFormBuilder } from "../../form"
 
 const COMPANY_FORM_DEFAULT_VALUES: Partial<CompanyWrite> = {
   type: "CONSULTING",
@@ -65,8 +65,9 @@ export const useCompanyWriteForm = ({
         label: "Lokasjon",
         placeholder: "Oslo",
       }),
-      image: createTextInput({
-        label: "Bildelenke til logo",
+      image: createFileInput({
+        label: "Bilde",
+        placeholder: "Last opp",
       }),
     },
   })

--- a/apps/dashboard/src/app/(dashboard)/group/write-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/group/write-form.tsx
@@ -1,5 +1,5 @@
 import { type GroupWrite, GroupWriteSchema } from "@dotkomonline/types"
-import { createSelectInput, createTextInput, createTextareaInput, useFormBuilder } from "../../form"
+import { createFileInput, createSelectInput, createTextInput, createTextareaInput, useFormBuilder } from "../../form"
 
 const GROUP_FORM_DEFAULT_VALUES: Partial<GroupWrite> = {}
 
@@ -43,8 +43,9 @@ export const useGroupWriteForm = ({
         withAsterisk: true,
         required: true,
       }),
-      image: createTextInput({
-        label: "Bilde-url",
+      image: createFileInput({
+        label: "Bilde",
+        placeholder: "Last opp",
       }),
       type: createSelectInput({
         label: "Type",

--- a/apps/dashboard/src/app/(dashboard)/interest-group/write-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/interest-group/write-form.tsx
@@ -1,5 +1,11 @@
 import { type InterestGroupWrite, InterestGroupWriteSchema } from "@dotkomonline/types"
-import { createCheckboxInput, createFileInput, createTextInput, createTextareaInput, useFormBuilder } from "src/app/form"
+import {
+  createCheckboxInput,
+  createFileInput,
+  createTextInput,
+  createTextareaInput,
+  useFormBuilder,
+} from "src/app/form"
 
 const INTEREST_GROUP_FORM_DEFAULT_VALUES: Partial<InterestGroupWrite> = {}
 

--- a/apps/dashboard/src/app/(dashboard)/interest-group/write-form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/interest-group/write-form.tsx
@@ -1,5 +1,5 @@
 import { type InterestGroupWrite, InterestGroupWriteSchema } from "@dotkomonline/types"
-import { createCheckboxInput, createTextInput, createTextareaInput, useFormBuilder } from "src/app/form"
+import { createCheckboxInput, createFileInput, createTextInput, createTextareaInput, useFormBuilder } from "src/app/form"
 
 const INTEREST_GROUP_FORM_DEFAULT_VALUES: Partial<InterestGroupWrite> = {}
 
@@ -37,8 +37,9 @@ export const useInterestGroupWriteForm = ({
         withAsterisk: false,
         rows: 5,
       }),
-      image: createTextInput({
-        label: "Bilde-url",
+      image: createFileInput({
+        label: "Bilde",
+        placeholder: "Last opp",
       }),
       joinInfo: createTextareaInput({
         label: "Hvordan bli med",


### PR DESCRIPTION
# Replace text inputs with file inputs for image uploads

This PR updates the image input fields in the write forms for companies, groups, and interest groups. Instead of using text inputs where users would need to provide image URLs, we now use file inputs that allow direct file uploads.

Changes include:
- Importing `createFileInput` in all three form files
- Replacing `createTextInput` with `createFileInput` for image fields
- Updating labels and adding appropriate placeholders for the upload fields

This change improves the user experience by allowing direct file uploads rather than requiring users to provide image URLs manually.