### PR TITLE
Update CloudFront distribution ID in production deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -195,4 +195,4 @@ jobs:
             --exclude "*.svg" \
             --region "eu-north-1"
       - name: Invalidate CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id E60JFQ13PM11R --paths '/*'
+        run: aws cloudfront create-invalidation --distribution-id E3J930LEDCHBY3 --paths '/*'


### PR DESCRIPTION
Updated CloudFront distribution ID in the production deployment workflow from E60JFQ13PM11R to E3J930LEDCHBY3. This change ensures cache invalidation operations target the correct distribution during deployments.