### PR TITLE
Add tRPC client and events component to splash-2025

### DIFF
--- a/apps/splash-2025/package.json
+++ b/apps/splash-2025/package.json
@@ -16,6 +16,11 @@
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
 		"tailwindcss-animate": "^1.0.7",
+		"@dotkomonline/gateway-trpc": "workspace:*",
+		"@tanstack/react-query": "^5.67.2",
+		"superjson": "^2.0.0",
+		"@trpc/tanstack-react-query": "11.0.0-rc.828",
+		"@trpc/client": "11.0.0-rc.828",
 		"zod": "^3.22.4"
 	},
 	"devDependencies": {

--- a/apps/splash-2025/src/App.tsx
+++ b/apps/splash-2025/src/App.tsx
@@ -1,5 +1,8 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { Cloud } from "./components/cloud";
+import { Events } from "./components/events";
 import { Header } from "./components/header";
+import { queryClient } from "./lib/trpc";
 
 function App() {
 	return (
@@ -9,6 +12,9 @@ function App() {
 			<main>
 				Team onboarding ftw 1
 				<Cloud />
+				<QueryClientProvider client={queryClient}>
+					<Events />
+				</QueryClientProvider>
 			</main>
 		</div>
 	);

--- a/apps/splash-2025/src/components/events.tsx
+++ b/apps/splash-2025/src/components/events.tsx
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "../lib/trpc";
+
+export const Events = () => {
+	const { data, ...query } = useQuery(trpc.event.all.queryOptions());
+
+	if (data === undefined || query.isLoading) {
+		return <div>Loading...</div>;
+	}
+
+	console.log(data);
+	return (
+		<div className="w-full bg-white h-[500px] p-4 overflow-y-auto">
+			{data.map((event) => (
+				// show nice formatted json
+				<pre key={event.id}>{JSON.stringify(event, null, 2)}</pre>
+			))}
+		</div>
+	);
+};

--- a/apps/splash-2025/src/lib/trpc.ts
+++ b/apps/splash-2025/src/lib/trpc.ts
@@ -1,0 +1,22 @@
+import type { AppRouter } from "@dotkomonline/gateway-trpc";
+import { QueryClient } from "@tanstack/react-query";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
+import SuperJSON from "superjson";
+
+// https://trpc.io/docs/client/tanstack-react-query/setup
+export const queryClient = new QueryClient();
+const trpcClient = createTRPCClient<AppRouter>({
+	links: [
+		httpBatchLink({
+			url: "http://localhost:4444/api/trpc",
+			transformer: SuperJSON,
+		}),
+	],
+});
+
+export const trpc: ReturnType<typeof createTRPCOptionsProxy<AppRouter>> =
+	createTRPCOptionsProxy<AppRouter>({
+		client: trpcClient,
+		queryClient,
+	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,18 @@ importers:
 
   apps/splash-2025:
     dependencies:
+      '@dotkomonline/gateway-trpc':
+        specifier: workspace:*
+        version: link:../../packages/gateway-trpc
+      '@tanstack/react-query':
+        specifier: ^5.67.2
+        version: 5.67.3(react@19.0.0)
+      '@trpc/client':
+        specifier: 11.0.0-rc.828
+        version: 11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/tanstack-react-query':
+        specifier: 11.0.0-rc.828
+        version: 11.0.0-rc.828(@tanstack/react-query@5.67.3(react@19.0.0))(@trpc/client@11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -548,6 +560,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      superjson:
+        specifier: ^2.0.0
+        version: 2.2.2
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)


### PR DESCRIPTION
# Add Events Component with tRPC Integration

This PR adds a new Events component to the Splash 2025 app that fetches and displays event data using tRPC. The implementation includes:

- Added tRPC client configuration with TanStack Query integration
- Created a new Events component that displays fetched event data
- Set up necessary dependencies including @dotkomonline/gateway-trpc, TanStack React Query, and tRPC packages
- Integrated the Events component into the main App component with proper QueryClientProvider setup

The Events component currently displays the raw JSON data for all events, with a loading state while data is being fetched.