### PR TITLE
Increase maximum file upload limit from 5 to 20

### DIFF
--- a/apps/kvittering-frontend/src/components/receipt-form.tsx
+++ b/apps/kvittering-frontend/src/components/receipt-form.tsx
@@ -150,7 +150,7 @@ export default function ReceiptForm() {
 	const [pdfUrl, setPdfUrl] = useState<string | null>(null);
 
 	const dropZoneConfig = {
-		maxFiles: 5,
+		maxFiles: 20,
 		maxSize: 1024 * 1024 * 50,
 		multiple: true,
 	};


### PR DESCRIPTION
Increased the maximum number of files allowed in the receipt form dropzone from 5 to 20, while maintaining the same file size limit of 50MB per file.