### PR TITLE
Decrease to max 1MB attachments compressed

### DIFF
--- a/apps/kvittering-frontend/src/components/ui/file-upload.tsx
+++ b/apps/kvittering-frontend/src/components/ui/file-upload.tsx
@@ -192,7 +192,7 @@ export const FileUploader = forwardRef<
 				}
 
 				// MAX 5 MB file
-				const maxSizeMB = 2;
+				const maxSizeMB = 1;
 
 				for (const file of files) {
 					try {


### PR DESCRIPTION
Max size of email is 10MB.
