### PR TITLE
Setup alerting about errors in frontend until stuff has stabilized

### DIFF
--- a/apps/kvittering-frontend/src/components/receipt-form.tsx
+++ b/apps/kvittering-frontend/src/components/receipt-form.tsx
@@ -34,6 +34,7 @@ import { useForm } from "react-hook-form";
 import useFormPersist from "react-hook-form-persist";
 import { toast } from "sonner";
 import * as z from "zod";
+import { alertFormSubmission } from "../lib/alert";
 import type { ApiFormData } from "../lib/api";
 
 const formSchema = z
@@ -211,7 +212,9 @@ export default function ReceiptForm() {
 	}
 
 	async function onSubmit(values: z.infer<typeof formSchema>) {
-		console.log("onSubmit", values);
+		alertFormSubmission(
+			`${values.name} har sendt inn kvitteringsskjema med ${values.attachments.length} filer`,
+		);
 		try {
 			const formData: ApiFormData = {
 				full_name: values.name,
@@ -234,7 +237,12 @@ export default function ReceiptForm() {
 			const pdfUrlPromise = toast.promise(generatePdf(formData), {
 				loading: "Genererer PDF...",
 				success: "PDF generert",
-				error: "Feil ved generering av PDF",
+				error: () => {
+					alertFormSubmission(
+						`${values.name} har feilet ved generering av PDF`,
+					);
+					return "Feil ved generering av PDF";
+				},
 			});
 
 			const pdfUrl = await pdfUrlPromise.unwrap();
@@ -244,7 +252,12 @@ export default function ReceiptForm() {
 			const emailPromise = toast.promise(sendEmail(pdfUrl, formData), {
 				loading: "Sender email til Bankkom...",
 				success: "Email sendt til Bankkom",
-				error: "Feil ved sending av email",
+				error: () => {
+					alertFormSubmission(
+						`${values.name} har feilet ved sending av email til Bankkom`,
+					);
+					return "Feil ved sending av email til Bankkom";
+				},
 			});
 
 			console.log("emailPromise", emailPromise);

--- a/apps/kvittering-frontend/src/components/ui/file-upload.tsx
+++ b/apps/kvittering-frontend/src/components/ui/file-upload.tsx
@@ -22,6 +22,7 @@ import {
 	useDropzone,
 } from "react-dropzone";
 import { toast } from "sonner";
+import { alertFormSubmission } from "../../lib/alert";
 import { compressImageWithLibrary } from "../../lib/compress-img";
 import { convertPdfToLongImage } from "../../lib/convert-pdf-to-image";
 import { uploadFileToS3 } from "../../lib/upload-s3";
@@ -206,7 +207,12 @@ export const FileUploader = forwardRef<
 								{
 									loading: "Konverterer PDF til bilde...",
 									success: "PDF konvertert til bilde",
-									error: "Feil ved konvertering av PDF. Prøv igjen!",
+									error: () => {
+										alertFormSubmission(
+											"Feil ved konvertering av PDF til bilde",
+										);
+										return "Feil ved konvertering av PDF. Prøv igjen!";
+									},
 								},
 							);
 
@@ -232,7 +238,10 @@ export const FileUploader = forwardRef<
 							{
 								loading: "Komprimerer bilde...",
 								success: "Bilde komprimert",
-								error: "Feil ved komprimering. Prøv igjen!",
+								error: () => {
+									alertFormSubmission("Feil ved komprimering");
+									return "Feil ved komprimering. Prøv igjen!";
+								},
 							},
 						);
 
@@ -251,7 +260,10 @@ export const FileUploader = forwardRef<
 							{
 								loading: "Laster opp fil...",
 								success: `${file.name} ble lastet opp`,
-								error: "Feil ved opplasting. Prøv igjen!",
+								error: () => {
+									alertFormSubmission("Feil ved opplasting");
+									return "Feil ved opplasting. Prøv igjen!";
+								},
 							},
 						);
 

--- a/apps/kvittering-frontend/src/lib/alert.ts
+++ b/apps/kvittering-frontend/src/lib/alert.ts
@@ -1,0 +1,11 @@
+// curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' https://hooks.slack.com/services/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
+
+const slackWebhookUrl =
+	"https://hooks.slack.com/services/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";
+
+export function alertFormSubmission(message: string) {
+	fetch(slackWebhookUrl, {
+		method: "POST",
+		body: JSON.stringify({ text: message }),
+	});
+}


### PR DESCRIPTION
# Add Slack notifications for form submissions and errors

This PR adds Slack notifications for important events in the receipt form submission process. A new `alertFormSubmission` function sends messages to a `tmp-kvittering-submissions` Slack webhook when:

1. A user submits the receipt form (including their name and number of attachments)
2. PDF generation fails
3. Email sending fails
4. PDF to image conversion fails
5. Image compression fails
6. File upload fails

These notifications will help track form submissions and quickly identify when users encounter errors during the process.