### PR TITLE
Move sentry dsn and slack webhook url to environment variables

### DIFF
--- a/apps/kvittering-frontend/src/lib/alert.ts
+++ b/apps/kvittering-frontend/src/lib/alert.ts
@@ -1,10 +1,5 @@
-// curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' https://hooks.slack.com/services/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
-
-const slackWebhookUrl =
-	"https://hooks.slack.com/services/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";
-
 export function alertFormSubmission(message: string) {
-	fetch(slackWebhookUrl, {
+	fetch(import.meta.env.VITE_SLACK_ALERT_WEBHOOK_URL, {
 		method: "POST",
 		body: JSON.stringify({ text: message }),
 	});

--- a/apps/kvittering-frontend/src/main.tsx
+++ b/apps/kvittering-frontend/src/main.tsx
@@ -7,9 +7,7 @@ import * as Sentry from "@sentry/react";
 const IS_PRODUCTION = import.meta.env.MODE === "production";
 
 Sentry.init({
-	dsn: IS_PRODUCTION
-		? import.meta.env.VITE_SENTRY_DSN
-		: undefined,
+	dsn: IS_PRODUCTION ? import.meta.env.VITE_SENTRY_DSN : undefined,
 	integrations: [
 		Sentry.replayIntegration({
 			unblock: [".sentry-unblock, [data-sentry-unblock]"],

--- a/apps/kvittering-frontend/src/main.tsx
+++ b/apps/kvittering-frontend/src/main.tsx
@@ -8,7 +8,7 @@ const IS_PRODUCTION = import.meta.env.MODE === "production";
 
 Sentry.init({
 	dsn: IS_PRODUCTION
-		? "https://ce333be780ecceb0975d83342bacedba@o93837.ingest.us.sentry.io/4508931842048000"
+		? import.meta.env.VITE_SENTRY_DSN
 		: undefined,
 	integrations: [
 		Sentry.replayIntegration({


### PR DESCRIPTION
Moved hardcoded API keys to environment variables for improved security

This PR replaces hardcoded API keys with environment variables:
- Replaced the Slack webhook URL with `import.meta.env.VITE_SLACK_ALERT_WEBHOOK_URL`
- Replaced the Sentry DSN with `import.meta.env.VITE_SENTRY_DSN`

These changes enhance security by removing sensitive credentials from the codebase and make the application more configurable across different environments.