### PR TITLE
Copy full turbo prune tree in Docker builds

### DIFF
--- a/apps/brevduen/Dockerfile
+++ b/apps/brevduen/Dockerfile
@@ -16,10 +16,8 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY --from=builder /app/out/json .
-
-RUN pnpm install --ignore-scripts
 COPY --from=builder /app/out/full .
+RUN pnpm install --ignore-scripts
 
 RUN pnpm run -F @dotkomonline/emails build
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -27,8 +27,7 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 --ignore-scripts
-COPY --from=builder /app/out/json .
-COPY --from=builder /app/out/full/packages/db/prisma/schema.prisma packages/db/prisma/schema.prisma
+COPY --from=builder /app/out/full .
 RUN pnpm install --ignore-scripts
 
 # Generate prisma types

--- a/apps/invoicification/Dockerfile
+++ b/apps/invoicification/Dockerfile
@@ -16,9 +16,8 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY --from=builder /app/out/json .
-RUN pnpm install --ignore-scripts
 COPY --from=builder /app/out/full .
+RUN pnpm install --ignore-scripts
 RUN turbo run build --filter @dotkomonline/invoicification
 
 FROM base AS runner

--- a/apps/rif/Dockerfile
+++ b/apps/rif/Dockerfile
@@ -16,9 +16,8 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY --from=builder /app/out/json .
-RUN pnpm install --ignore-scripts
 COPY --from=builder /app/out/full .
+RUN pnpm install --ignore-scripts
 RUN turbo run build --filter @dotkomonline/rif
 
 FROM base AS runner

--- a/apps/rpc/Dockerfile
+++ b/apps/rpc/Dockerfile
@@ -16,9 +16,7 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY --from=builder /app/out/json .
-COPY --from=builder /app/out/full/packages/db/prisma/schema.prisma packages/db/prisma/schema.prisma
-
+COPY --from=builder /app/out/full .
 RUN pnpm install --ignore-scripts
 RUN pnpm generate
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -27,8 +27,7 @@ WORKDIR /app
 ENV DOCKER_BUILD=1
 
 RUN npm install -g pnpm@9.15.5 --ignore-scripts
-COPY --from=builder /app/out/json .
-COPY --from=builder /app/out/full/packages/db/prisma/schema.prisma packages/db/prisma/schema.prisma
+COPY --from=builder /app/out/full .
 RUN pnpm install --ignore-scripts
 
 # Generate prisma types


### PR DESCRIPTION
Fixes MONO-369

The JSON-prune tree from `turbo prune` causes the lockfile to point to
files that don't exist, rendering the entire lockfile broken and pnpm
having to build a fresh lock. This means the pnpm-lock.yaml we have in
root is not used at all, and this can lead to build differences.

When building with the full pruned tree this no longer happens.