### PR TITLE
Add submitter's email to CC recipients in email sending

### DIFF
--- a/apps/kvittering-backend/src/server.py
+++ b/apps/kvittering-backend/src/server.py
@@ -207,7 +207,7 @@ def send_email():
         test_mode = body.get("test_mode", "false")
         sender_email = env.SENDER_EMAIL
         recipient_email = env.RECIPIENT_EMAIL
-        cc_recipient_emails = env.CC_RECIPIENT_EMAILS
+        cc_recipient_emails = env.CC_RECIPIENT_EMAILS + [form_data.email]
 
         if test_mode == "true":
             sender_email = env.TEST_SENDER_EMAIL


### PR DESCRIPTION
Added the user's email to the CC list when sending emails. This ensures that the person submitting the form receives a copy of the email, improving transparency and providing confirmation that their submission was processed.