### PR TITLE
Add dev:core-web script for running core web services

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "turbo run test",
     "test:it": "turbo run test:it",
     "dev": "pnpm -rc --parallel -F @dotkomonline/ui -F @dotkomonline/web -F @dotkomonline/dashboard -F @dotkomonline/rpc -F @dotkomonline/invoicification -F @dotkomonline/rif exec doppler run --preserve-env pnpm run dev",
+    "dev:core-web": "pnpm -rc --parallel -F @dotkomonline/ui -F @dotkomonline/web -F @dotkomonline/dashboard -F @dotkomonline/rpc exec doppler run --preserve-env pnpm run dev",
     "prisma": "pnpm -F @dotkomonline/db prisma",
     "generate": "pnpm -F @dotkomonline/db generate",
     "migrate:dev": "pnpm -F @dotkomonline/db migrate",


### PR DESCRIPTION
Added a new script `dev:core-web` to run a subset of packages in development mode. This script runs the UI, web, dashboard, and RPC packages in parallel with Doppler environment variables, excluding the invoicification and rif packages that are included in the full `dev` script.