### PR TITLE
Add S3 upload feature toggle with test mode fallback

### DIFF
--- a/apps/dashboard/src/env.ts
+++ b/apps/dashboard/src/env.ts
@@ -12,6 +12,7 @@ export const env = createEnvironment(
     NEXT_PUBLIC_ORIGIN: variable,
     NEXT_PUBLIC_RPC_HOST: variable,
     NEXT_PUBLIC_SENTRY_DSN: variable.optional(),
+    S3_UPLOAD_ENABLED: variable,
   },
   {
     env: {
@@ -19,7 +20,12 @@ export const env = createEnvironment(
       NEXT_PUBLIC_ORIGIN: process.env.NEXT_PUBLIC_ORIGIN,
       NEXT_PUBLIC_RPC_HOST: process.env.NEXT_PUBLIC_RPC_HOST,
       NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+    // Feature toggle for uploading files to S3
+    // Defaulted to false.
+    S3_UPLOAD_ENABLED: process.env.S3_UPLOAD_ENABLED ?? "false", 
     },
+
     // Dashboard should also validate env at build time
     skipValidation: false,
   }

--- a/apps/dashboard/src/modules/offline/modals/create-offline-modal.tsx
+++ b/apps/dashboard/src/modules/offline/modals/create-offline-modal.tsx
@@ -8,7 +8,6 @@ import { useS3UploadFile } from "../use-s3-upload-file"
 export const CreateOfflineModal: FC<ContextModalProps> = ({ context, id }) => {
   const close = () => context.closeModal(id)
   const create = useCreateOfflineMutation()
-  const upload = useS3UploadFile()
 
   const FormComponent = useOfflineWriteForm({
     onSubmit: async (data) => {

--- a/apps/dashboard/src/modules/offline/use-s3-upload-file.ts
+++ b/apps/dashboard/src/modules/offline/use-s3-upload-file.ts
@@ -1,17 +1,35 @@
-import { uploadFileToS3PresignedUrl } from "../../s3"
-import { useTRPC } from "../../trpc"
+import { env } from "../../env";
+import { uploadFileToS3PresignedUrl } from "../../s3";
+import { useTRPC } from "../../trpc";
+import { notifications } from "@mantine/notifications";
+import { useMutation } from "@tanstack/react-query";
 
-import { useMutation } from "@tanstack/react-query"
+const TEST_MODE_IMG_URL = "https://s3.eu-north-1.amazonaws.com/cdn.online.ntnu.no/img1.jpeg"
 
 export const useS3UploadFile = () => {
-  const trpc = useTRPC()
-  const presignedPostMut = useMutation(trpc.offline.createPresignedPost.mutationOptions())
+  const trpc = useTRPC();
+  const presignedPostMut = useMutation(
+    trpc.offline.createPresignedPost.mutationOptions()
+  );
 
   return async (file: File) => {
-    const presignedPost = await presignedPostMut.mutateAsync({
-      filename: `${file.name}`,
-      mimeType: file.type,
-    })
-    return await uploadFileToS3PresignedUrl(file, presignedPost.fields, presignedPost.url)
-  }
-}
+    if (env.S3_UPLOAD_ENABLED === "true") {
+      const presignedPost = await presignedPostMut.mutateAsync({
+        filename: `${file.name}`,
+        mimeType: file.type,
+      });
+      return await uploadFileToS3PresignedUrl(
+        file,
+        presignedPost.fields,
+        presignedPost.url
+      );
+    }
+
+    notifications.show({
+      title: "You're in test mode",
+      message:
+        "Returning url of already uploaded file. See S3_UPLOAD_ENABLED env variable to turn on S3 upload.",
+    });
+    return TEST_MODE_IMG_URL
+  };
+};

--- a/packages/gateway-trpc/src/modules/offline/offline-router.ts
+++ b/packages/gateway-trpc/src/modules/offline/offline-router.ts
@@ -23,4 +23,13 @@ export const offlineRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => ctx.offlineService.createPresignedPost(input.filename, input.mimeType)),
+    uploadFileToServer: protectedProcedure
+    .input(
+      z.object({
+        filename: z.string(),
+        mimeType: z.string(),
+        file: z.instanceof(File),
+      })
+    )
+    .mutation(async ({ input, ctx }) => ctx.offlineService.createPresignedPost(input.filename, input.mimeType)),
 })


### PR DESCRIPTION
# Add S3 Upload Feature Toggle

This PR introduces a feature toggle for S3 file uploads. When disabled, the system will use a test image URL instead of attempting to upload files to S3.

Key changes:
- Added `S3_UPLOAD_ENABLED` environment variable (defaults to "false")
- Modified `useS3UploadFile` hook to check the feature toggle before attempting uploads
- Added a notification to inform users when in test mode
- Added a constant test image URL for development purposes
- Added a new `uploadFileToServer` procedure to the offline router

This change allows developers to work without needing S3 credentials while maintaining the full upload functionality in production.