### PR TITLE
Add admin authorization to API endpoints

### DIFF
--- a/apps/rpc/src/env.ts
+++ b/apps/rpc/src/env.ts
@@ -20,7 +20,9 @@ export const env = createEnvironment(
     // Sentry DSN should only be set in production
     SENTRY_DSN: variable.optional(),
 
-    // auth0 subs
+    // comma separated auth0 subs, e.g.
+    // "auth0|111111111111111111111111,auth0|222222222222222222222222"
+    // value "*" means all users are admins
     ADMIN_USERS: variable,
   },
   {

--- a/apps/rpc/src/env.ts
+++ b/apps/rpc/src/env.ts
@@ -19,6 +19,9 @@ export const env = createEnvironment(
     FAGKOM_STRIPE_WEBHOOK_SECRET: variable,
     // Sentry DSN should only be set in production
     SENTRY_DSN: variable.optional(),
+
+    // auth0 subs
+    ADMIN_USERS: variable,
   },
   {
     env: process.env,

--- a/apps/rpc/src/index.ts
+++ b/apps/rpc/src/index.ts
@@ -50,13 +50,17 @@ const prisma = createPrisma(env.DATABASE_URL)
 
 export async function createFastifyContext({ req }: CreateFastifyContextOptions) {
   const bearer = req.headers.authorization
+  const adminPrincipals = env.ADMIN_USERS.split(",").map((sub) => sub.trim())
+
   const context: Omit<CreateContextOptions, "principal"> = {
     s3Client,
     s3BucketName: env.AWS_S3_BUCKET,
     stripeAccounts,
     managementClient: auth0Client,
     db: prisma,
+    adminPrincipals,
   }
+
   if (bearer !== undefined) {
     const token = bearer.substring("Bearer ".length)
     const principal = await jwtService.verify(token)

--- a/packages/gateway-trpc/src/context.ts
+++ b/packages/gateway-trpc/src/context.ts
@@ -2,14 +2,19 @@ import { type ServiceLayerOptions, createServiceLayer } from "@dotkomonline/core
 import type { inferAsyncReturnType } from "@trpc/server"
 
 export type CreateContextOptions = {
+  // auth0 sub
   principal: string | null
+
+  // auth0 subs
+  adminPrincipals: string[]
 } & ServiceLayerOptions
 
-export const createContext = async ({ principal, ...opts }: CreateContextOptions) => {
+export const createContext = async ({ principal, adminPrincipals, ...opts }: CreateContextOptions) => {
   const services = await createServiceLayer(opts)
   return {
     ...services,
     principal,
+    adminPrincipals,
   }
 }
 

--- a/packages/gateway-trpc/src/modules/article/article-router.ts
+++ b/packages/gateway-trpc/src/modules/article/article-router.ts
@@ -1,13 +1,13 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { ArticleSchema, ArticleTagSchema, ArticleWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, publicProcedure, t } from "../../trpc"
+import { adminProcedure, publicProcedure, t } from "../../trpc"
 
 export const articleRouter = t.router({
-  create: protectedProcedure
+  create: adminProcedure
     .input(ArticleWriteSchema)
     .mutation(async ({ input, ctx }) => await ctx.articleService.create(input)),
-  edit: protectedProcedure
+  edit: adminProcedure
     .input(
       z.object({
         id: ArticleSchema.shape.id,
@@ -25,7 +25,7 @@ export const articleRouter = t.router({
     .input(ArticleSchema.shape.slug)
     .query(async ({ input, ctx }) => await ctx.articleService.getBySlug(input)),
   getTags: publicProcedure.query(async ({ ctx }) => await ctx.articleService.getTags()),
-  addTag: protectedProcedure
+  addTag: adminProcedure
     .input(
       z.object({
         id: ArticleSchema.shape.id,
@@ -33,7 +33,7 @@ export const articleRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => await ctx.articleService.addTag(input.id, input.tag)),
-  removeTag: protectedProcedure
+  removeTag: adminProcedure
     .input(
       z.object({
         id: ArticleSchema.shape.id,

--- a/packages/gateway-trpc/src/modules/company/company-router.ts
+++ b/packages/gateway-trpc/src/modules/company/company-router.ts
@@ -1,14 +1,14 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { CompanySchema, CompanyWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 import { companyEventRouter } from "./company-event-router"
 
 export const companyRouter = t.router({
-  create: t.procedure
+  create: adminProcedure
     .input(CompanyWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.companyService.createCompany(input)),
-  edit: protectedProcedure
+  edit: adminProcedure
     .input(
       z.object({
         id: CompanySchema.shape.id,

--- a/packages/gateway-trpc/src/modules/event/attendance-router.ts
+++ b/packages/gateway-trpc/src/modules/event/attendance-router.ts
@@ -8,7 +8,7 @@ import {
   UserSchema,
 } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, t } from "../../trpc"
 
 export const attendanceRouter = t.router({
   getAttendee: protectedProcedure
@@ -19,11 +19,11 @@ export const attendanceRouter = t.router({
       })
     )
     .query(async ({ input, ctx }) => ctx.attendeeService.getByUserId(input.userId, input.attendanceId)),
-  createPool: protectedProcedure
+  createPool: adminProcedure
     .input(AttendancePoolWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.attendanceService.createPool(input)),
 
-  updatePool: protectedProcedure
+  updatePool: adminProcedure
     .input(
       z.object({
         id: AttendancePoolSchema.shape.id,
@@ -32,7 +32,7 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input: { id, input }, ctx }) => ctx.attendanceService.updatePool(id, input)),
 
-  deletePool: protectedProcedure
+  deletePool: adminProcedure
     .input(
       z.object({
         id: AttendancePoolSchema.shape.id,
@@ -40,7 +40,7 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input, ctx }) => ctx.attendanceService.deletePool(input.id)),
 
-  adminRegisterForEvent: protectedProcedure
+  adminRegisterForEvent: adminProcedure
     .input(
       z.object({
         attendancePoolId: AttendancePoolSchema.shape.id,
@@ -59,9 +59,9 @@ export const attendanceRouter = t.router({
         attendanceId: AttendanceSchema.shape.id,
       })
     )
-    .mutation(async ({ input, ctx }) =>
-      ctx.attendeeService.registerForEvent(ctx.principal, input.attendanceId, input.attendancePoolId)
-    ),
+    .mutation(async ({ input, ctx }) => {
+      return ctx.attendeeService.registerForEvent(ctx.principal, input.attendanceId, input.attendancePoolId)
+    }),
 
   deregisterForEvent: protectedProcedure
     .input(
@@ -71,7 +71,7 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input, ctx }) => ctx.attendeeService.deregisterForEvent(ctx.principal, input.attendanceId)),
 
-  adminDeregisterForEvent: protectedProcedure
+  adminDeregisterForEvent: adminProcedure
     .input(
       z.object({
         id: AttendeeSchema.shape.id,
@@ -79,7 +79,7 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input, ctx }) => ctx.attendeeService.adminDeregisterForEvent(input.id)),
 
-  getSelectionsResults: protectedProcedure
+  getSelectionsResults: adminProcedure
     .input(
       z.object({
         attendanceId: AttendanceSchema.shape.id,
@@ -95,7 +95,8 @@ export const attendanceRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => await ctx.attendeeService.updateAttended(input.attended, input.id)),
-  handleQrCodeRegistration: protectedProcedure
+
+  handleQrCodeRegistration: adminProcedure
     .input(
       z.object({
         userId: UserSchema.shape.id,
@@ -103,10 +104,10 @@ export const attendanceRouter = t.router({
       })
     )
     .mutation(
-      async ({ input, ctx }) => await ctx.attendeeService.handleQrCodeRegistration(input.userId, input.attendanceId)
+      async ({ input, ctx }) => await ctx.attendeeService.handleQrCodeRegistration(ctx.principal, input.attendanceId)
     ),
 
-  updateSelectionResponses: protectedProcedure
+  updateSelectionResponses: adminProcedure
     .input(
       z.object({
         id: AttendeeSchema.shape.id,
@@ -115,7 +116,8 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input, ctx }) => await ctx.attendeeService.updateSelectionResponses(input.id, input.options)),
 
-  getAttendees: protectedProcedure
+  // currently only used by dashbaord, thus admin
+  getAttendees: adminProcedure
     .input(
       z.object({
         id: AttendanceSchema.shape.id,
@@ -123,7 +125,7 @@ export const attendanceRouter = t.router({
     )
     .query(async ({ input, ctx }) => ctx.attendeeService.getByAttendanceId(input.id)),
 
-  getAttendance: protectedProcedure
+  getAttendance: adminProcedure
     .input(
       z.object({
         id: AttendanceSchema.shape.id,
@@ -131,7 +133,7 @@ export const attendanceRouter = t.router({
     )
     .query(async ({ input, ctx }) => ctx.attendanceService.getById(input.id)),
 
-  updateAttendance: protectedProcedure
+  updateAttendance: adminProcedure
     .input(
       z.object({
         id: AttendanceSchema.shape.id,
@@ -139,7 +141,8 @@ export const attendanceRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => ctx.attendanceService.update(input.id, input.attendance)),
-  mergeAttendancePools: protectedProcedure
+
+  mergeAttendancePools: adminProcedure
     .input(
       z.object({
         attendanceId: AttendanceSchema.shape.id,
@@ -147,7 +150,7 @@ export const attendanceRouter = t.router({
     )
     .mutation(async ({ input, ctx }) => ctx.attendanceService.mergeAttendancePools(input.attendanceId)),
 
-  getSelectionResponseResults: protectedProcedure
+  getSelectionResponseResults: adminProcedure
     .input(
       z.object({
         attendanceId: AttendanceSchema.shape.id,

--- a/packages/gateway-trpc/src/modules/event/event-router.ts
+++ b/packages/gateway-trpc/src/modules/event/event-router.ts
@@ -12,15 +12,15 @@ import {
   UserSchema,
 } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, publicProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 import { attendanceRouter } from "./attendance-router"
 import { eventCompanyRouter } from "./event-company-router"
 
 export const eventRouter = t.router({
-  get: protectedProcedure.input(EventSchema.shape.id).query(async ({ input, ctx }) => {
+  get: adminProcedure.input(EventSchema.shape.id).query(async ({ input, ctx }) => {
     return ctx.eventService.getEventById(input)
   }),
-  create: protectedProcedure
+  create: adminProcedure
     .input(
       z.object({
         event: EventWriteSchema,
@@ -38,7 +38,7 @@ export const eventRouter = t.router({
         interestGroups,
       }
     }),
-  edit: protectedProcedure
+  edit: adminProcedure
     .input(
       z.object({
         id: EventSchema.shape.id,
@@ -50,7 +50,7 @@ export const eventRouter = t.router({
       return event
     }),
 
-  editWithGroups: protectedProcedure
+  editWithGroups: adminProcedure
     .input(
       z.object({
         id: EventSchema.shape.id,
@@ -67,7 +67,7 @@ export const eventRouter = t.router({
     }),
 
   // TODO: N+1 query, eventHostingGroupService and eventService should probably be merged
-  all: publicProcedure
+  all: adminProcedure
     .input(
       z
         .object({
@@ -95,7 +95,7 @@ export const eventRouter = t.router({
     }),
 
   // TODO: N+1 query, eventHostingGroupService and eventService should probably be merged
-  recommended: publicProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => {
+  recommended: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => {
     const events = await ctx.eventService.getEvents(input)
     const groups = events.map(async (e) => ctx.eventHostingGroupService.getHostingGroupsForEvent(e.id))
     const interestGroups = events.map(async (e) => ctx.interestGroupService.getAllByEventId(e.id))
@@ -113,24 +113,24 @@ export const eventRouter = t.router({
     }))
   }),
 
-  allByCompany: publicProcedure
+  allByCompany: adminProcedure
     .input(z.object({ id: CompanySchema.shape.id, paginate: PaginateInputSchema }))
     .query(async ({ input, ctx }) =>
       ctx.companyEventService.getEventsByCompanyId(input.id, input.paginate.take, input.paginate.cursor)
     ),
-  allByUserId: publicProcedure
+  allByUserId: adminProcedure
     .input(z.object({ id: UserSchema.shape.id }))
     .query(async ({ input, ctx }) => ctx.eventService.getEventsByUserAttending(input.id)),
-  allByGroup: publicProcedure
+  allByGroup: adminProcedure
     .input(z.object({ id: GroupSchema.shape.id, paginate: PaginateInputSchema }))
     .query(async ({ input, ctx }) => ctx.eventService.getEventsByGroupId(input.id, input.paginate)),
-  allByInterestGroup: publicProcedure
+  allByInterestGroup: adminProcedure
     .input(z.object({ id: InterestGroupSchema.shape.id, paginate: PaginateInputSchema }))
     .query(async ({ input, ctx }) => ctx.eventService.getEventsByInterestGroupId(input.id, input.paginate)),
-  getAttendanceEventDetail: publicProcedure
+  getAttendanceEventDetail: adminProcedure
     .input(EventSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.eventService.getAttendanceDetail(input)),
-  addAttendance: protectedProcedure
+  addAttendance: adminProcedure
     .input(
       z.object({
         values: AttendanceWriteSchema.partial(),

--- a/packages/gateway-trpc/src/modules/group/group-router.ts
+++ b/packages/gateway-trpc/src/modules/group/group-router.ts
@@ -1,19 +1,21 @@
 import { GroupMemberSchema, GroupMemberWriteSchema, GroupSchema, GroupWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, t } from "../../trpc"
 
 export const groupRouter = t.router({
-  create: t.procedure.input(GroupWriteSchema).mutation(async ({ input, ctx }) => ctx.groupService.createGroup(input)),
-  all: t.procedure.query(async ({ ctx }) => ctx.groupService.getGroups()),
-  allByType: t.procedure
+  create: adminProcedure
+    .input(GroupWriteSchema)
+    .mutation(async ({ input, ctx }) => ctx.groupService.createGroup(input)),
+  all: adminProcedure.query(async ({ ctx }) => ctx.groupService.getGroups()),
+  allByType: adminProcedure
     .input(GroupSchema.shape.type)
     .query(async ({ input, ctx }) => ctx.groupService.getGroupsByType(input)),
-  allIds: t.procedure.query(async ({ ctx }) => ctx.groupService.getAllGroupIds()),
-  allIdsByType: t.procedure
+  allIds: adminProcedure.query(async ({ ctx }) => ctx.groupService.getAllGroupIds()),
+  allIdsByType: adminProcedure
     .input(GroupSchema.shape.type)
     .query(async ({ input, ctx }) => ctx.groupService.getAllGroupIdsByType(input)),
-  get: t.procedure.input(GroupSchema.shape.id).query(async ({ input, ctx }) => ctx.groupService.getGroup(input)),
-  getByType: t.procedure
+  get: adminProcedure.input(GroupSchema.shape.id).query(async ({ input, ctx }) => ctx.groupService.getGroup(input)),
+  getByType: adminProcedure
     .input(z.object({ groupId: GroupSchema.shape.id, type: GroupSchema.shape.type }))
     .query(async ({ input, ctx }) => ctx.groupService.getGroupByType(input.groupId, input.type)),
   update: protectedProcedure
@@ -27,16 +29,16 @@ export const groupRouter = t.router({
   delete: protectedProcedure
     .input(GroupSchema.shape.id)
     .mutation(async ({ input, ctx }) => await ctx.groupService.deleteGroup(input)),
-  getMembers: t.procedure
+  getMembers: adminProcedure
     .input(GroupMemberSchema.shape.userId)
     .query(async ({ input, ctx }) => ctx.groupService.getMembers(input)),
-  allByMember: t.procedure
+  allByMember: adminProcedure
     .input(GroupMemberSchema.shape.userId)
     .query(async ({ input, ctx }) => ctx.groupService.getGroupsByMember(input)),
-  addMember: t.procedure
+  addMember: adminProcedure
     .input(GroupMemberWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.groupService.addMember(input)),
-  removeMember: protectedProcedure
+  removeMember: adminProcedure
     .input(z.object({ groupId: GroupMemberSchema.shape.groupId, userId: GroupMemberSchema.shape.userId }))
     .mutation(async ({ input, ctx }) => await ctx.groupService.removeMember(input.userId, input.groupId)),
 })

--- a/packages/gateway-trpc/src/modules/interest-group/interest-group-router.ts
+++ b/packages/gateway-trpc/src/modules/interest-group/interest-group-router.ts
@@ -1,16 +1,16 @@
 import { EventSchema, InterestGroupSchema, InterestGroupWriteSchema, UserSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, publicProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 
 export const interestGroupRouter = t.router({
-  create: protectedProcedure
+  create: adminProcedure
     .input(InterestGroupWriteSchema)
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.create(input)),
-  all: publicProcedure.query(async ({ ctx }) => await ctx.interestGroupService.getAll()),
-  get: publicProcedure
+  all: adminProcedure.query(async ({ ctx }) => await ctx.interestGroupService.getAll()),
+  get: adminProcedure
     .input(InterestGroupSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getById(input)),
-  update: protectedProcedure
+  update: adminProcedure
     .input(
       z.object({
         id: InterestGroupSchema.shape.id,
@@ -18,24 +18,24 @@ export const interestGroupRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.update(input.id, input.values)),
-  delete: protectedProcedure
+  delete: adminProcedure
     .input(InterestGroupSchema.shape.id)
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.delete(input)),
-  getByMember: publicProcedure
+  getByMember: adminProcedure
     .input(UserSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getByMember(input)),
-  getMembers: publicProcedure
+  getMembers: adminProcedure
     .input(InterestGroupSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getMembers(input)),
-  addMember: protectedProcedure
+  addMember: adminProcedure
     .input(z.object({ interestGroupId: InterestGroupSchema.shape.id, userId: UserSchema.shape.id }))
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.addMember(input.interestGroupId, input.userId)),
-  removeMember: protectedProcedure
+  removeMember: adminProcedure
     .input(z.object({ interestGroupId: InterestGroupSchema.shape.id, userId: UserSchema.shape.id }))
     .mutation(
       async ({ input, ctx }) => await ctx.interestGroupService.removeMember(input.interestGroupId, input.userId)
     ),
-  allByEventId: publicProcedure
+  allByEventId: adminProcedure
     .input(EventSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getAllByEventId(input)),
 })

--- a/packages/gateway-trpc/src/modules/job-listing/job-listing-router.ts
+++ b/packages/gateway-trpc/src/modules/job-listing/job-listing-router.ts
@@ -1,10 +1,10 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { JobListingSchema, JobListingWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, t } from "../../trpc"
 
 export const jobListingRouter = t.router({
-  create: t.procedure
+  create: adminProcedure
     .input(JobListingWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.jobListingService.create(input)),
   edit: protectedProcedure
@@ -15,12 +15,14 @@ export const jobListingRouter = t.router({
       })
     )
     .mutation(async ({ input: { id, input }, ctx }) => ctx.jobListingService.update(id, input)),
-  all: t.procedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.jobListingService.getAll(input)),
-  active: t.procedure
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.jobListingService.getAll(input)),
+  active: adminProcedure
     .input(PaginateInputSchema)
     .query(async ({ input, ctx }) => ctx.jobListingService.getActive(input)),
-  get: t.procedure
+  get: adminProcedure
     .input(JobListingSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.jobListingService.getById(input)),
-  getLocations: t.procedure.input(PaginateInputSchema).query(async ({ ctx }) => ctx.jobListingService.getLocations()),
+  getLocations: adminProcedure
+    .input(PaginateInputSchema)
+    .query(async ({ ctx }) => ctx.jobListingService.getLocations()),
 })

--- a/packages/gateway-trpc/src/modules/mark/mark-router.ts
+++ b/packages/gateway-trpc/src/modules/mark/mark-router.ts
@@ -1,20 +1,18 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { MarkSchema, MarkWriteSchema } from "@dotkomonline/types"
 import { t } from "../../trpc"
-import { protectedProcedure } from "./../../trpc"
+import { adminProcedure } from "./../../trpc"
 import { personalMarkRouter } from "./personal-mark-router"
 
 export const markRouter = t.router({
   personal: personalMarkRouter,
-  create: protectedProcedure
-    .input(MarkWriteSchema)
-    .mutation(async ({ input, ctx }) => ctx.markService.createMark(input)),
-  edit: protectedProcedure
+  create: adminProcedure.input(MarkWriteSchema).mutation(async ({ input, ctx }) => ctx.markService.createMark(input)),
+  edit: adminProcedure
     .input(MarkWriteSchema.required({ id: true }))
     .mutation(async ({ input: changes, ctx }) => ctx.markService.updateMark(changes.id, changes)),
-  all: protectedProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.markService.getMarks(input)),
-  get: protectedProcedure.input(MarkSchema.shape.id).query(async ({ input, ctx }) => ctx.markService.getMark(input)),
-  delete: protectedProcedure
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.markService.getMarks(input)),
+  get: adminProcedure.input(MarkSchema.shape.id).query(async ({ input, ctx }) => ctx.markService.getMark(input)),
+  delete: adminProcedure
     .input(MarkSchema.shape.id)
     .mutation(async ({ input, ctx }) => ctx.markService.deleteMark(input)),
 })

--- a/packages/gateway-trpc/src/modules/mark/personal-mark-router.ts
+++ b/packages/gateway-trpc/src/modules/mark/personal-mark-router.ts
@@ -1,27 +1,27 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { PersonalMarkSchema, UserSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 
 export const personalMarkRouter = t.router({
-  getByUser: protectedProcedure
+  getByUser: adminProcedure
     .input(z.object({ id: UserSchema.shape.id }))
     .query(async ({ input, ctx }) => ctx.personalMarkService.getPersonalMarksForUserId(input.id)),
-  getByMark: protectedProcedure
+  getByMark: adminProcedure
     .input(z.object({ id: PersonalMarkSchema.shape.markId, paginate: PaginateInputSchema }))
     .query(async ({ input, ctx }) => ctx.personalMarkService.getPersonalMarksByMarkId(input.id)),
-  addToUser: protectedProcedure
+  addToUser: adminProcedure
     .input(PersonalMarkSchema)
     .mutation(async ({ input, ctx }) => ctx.personalMarkService.addPersonalMarkToUserId(input.userId, input.markId)),
-  countUsersWithMark: protectedProcedure
+  countUsersWithMark: adminProcedure
     .input(z.object({ id: PersonalMarkSchema.shape.markId }))
     .query(async ({ input, ctx }) => ctx.personalMarkService.countUsersByMarkId(input.id)),
-  removeFromUser: protectedProcedure
+  removeFromUser: adminProcedure
     .input(PersonalMarkSchema)
     .mutation(async ({ input, ctx }) =>
       ctx.personalMarkService.removePersonalMarkFromUserId(input.userId, input.markId)
     ),
-  getExpiryDateForUser: protectedProcedure
+  getExpiryDateForUser: adminProcedure
     .input(UserSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.personalMarkService.getExpiryDateForUserId(input)),
 })

--- a/packages/gateway-trpc/src/modules/offline/offline-router.ts
+++ b/packages/gateway-trpc/src/modules/offline/offline-router.ts
@@ -1,11 +1,11 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { OfflineSchema, OfflineWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 
 export const offlineRouter = t.router({
-  create: t.procedure.input(OfflineWriteSchema).mutation(async ({ input, ctx }) => ctx.offlineService.create(input)),
-  edit: protectedProcedure
+  create: adminProcedure.input(OfflineWriteSchema).mutation(async ({ input, ctx }) => ctx.offlineService.create(input)),
+  edit: adminProcedure
     .input(
       z.object({
         id: OfflineSchema.shape.id,
@@ -13,9 +13,9 @@ export const offlineRouter = t.router({
       })
     )
     .mutation(async ({ input: changes, ctx }) => ctx.offlineService.update(changes.id, changes.input)),
-  all: t.procedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.offlineService.getAll(input)),
-  get: t.procedure.input(OfflineSchema.shape.id).query(async ({ input, ctx }) => ctx.offlineService.get(input)),
-  createPresignedPost: protectedProcedure
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.offlineService.getAll(input)),
+  get: adminProcedure.input(OfflineSchema.shape.id).query(async ({ input, ctx }) => ctx.offlineService.get(input)),
+  createPresignedPost: adminProcedure
     .input(
       z.object({
         filename: z.string(),

--- a/packages/gateway-trpc/src/modules/payment/payment-router.ts
+++ b/packages/gateway-trpc/src/modules/payment/payment-router.ts
@@ -1,18 +1,16 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { PaymentSchema, ProductSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 import { productRouter } from "./product-router"
 import { refundRequestRouter } from "./refund-request-router"
 
 export const paymentRouter = t.router({
   product: productRouter,
   refundRequest: refundRequestRouter,
-  getPaymentProviders: protectedProcedure.query(({ ctx }) => ctx.paymentService.getPaymentProviders()),
-  all: protectedProcedure
-    .input(PaginateInputSchema)
-    .query(async ({ input, ctx }) => ctx.paymentService.getPayments(input)),
-  createStripeCheckoutSession: protectedProcedure
+  getPaymentProviders: adminProcedure.query(({ ctx }) => ctx.paymentService.getPaymentProviders()),
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.paymentService.getPayments(input)),
+  createStripeCheckoutSession: adminProcedure
     .input(
       z.object({
         productId: ProductSchema.shape.id,
@@ -30,7 +28,7 @@ export const paymentRouter = t.router({
         ctx.principal
       )
     ),
-  refundPayment: protectedProcedure
+  refundPayment: adminProcedure
     .input(
       z.object({
         paymentId: PaymentSchema.shape.id,

--- a/packages/gateway-trpc/src/modules/payment/product-router.ts
+++ b/packages/gateway-trpc/src/modules/payment/product-router.ts
@@ -1,22 +1,20 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { ProductPaymentProviderWriteSchema, ProductSchema, ProductWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 
 export const productRouter = t.router({
-  create: protectedProcedure
+  create: adminProcedure
     .input(ProductWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.productService.createProduct(input)),
-  get: protectedProcedure
+  get: adminProcedure
     .input(ProductSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.productService.getProductById(input)),
-  all: protectedProcedure
-    .input(PaginateInputSchema)
-    .query(async ({ input, ctx }) => ctx.productService.getProducts(input)),
-  addPaymentProvider: protectedProcedure
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.productService.getProducts(input)),
+  addPaymentProvider: adminProcedure
     .input(ProductPaymentProviderWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.productPaymentProviderService.addPaymentProvider(input)),
-  deletePaymentProvider: protectedProcedure
+  deletePaymentProvider: adminProcedure
     .input(
       z.object({
         productId: ProductSchema.shape.id,
@@ -26,10 +24,10 @@ export const productRouter = t.router({
     .mutation(async ({ input, ctx }) =>
       ctx.productPaymentProviderService.deletePaymentProvider(input.productId, input.paymentProviderId)
     ),
-  getPaymentProvidersByProductId: protectedProcedure
+  getPaymentProvidersByProductId: adminProcedure
     .input(ProductSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.productPaymentProviderService.getAllByProductId(input)),
-  hasPaymentProviderId: protectedProcedure
+  hasPaymentProviderId: adminProcedure
     .input(
       z.object({
         productId: ProductSchema.shape.id,

--- a/packages/gateway-trpc/src/modules/payment/refund-request-router.ts
+++ b/packages/gateway-trpc/src/modules/payment/refund-request-router.ts
@@ -1,10 +1,10 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { PaymentSchema, RefundRequestSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, t } from "../../trpc"
+import { adminProcedure, t } from "../../trpc"
 
 export const refundRequestRouter = t.router({
-  create: protectedProcedure
+  create: adminProcedure
     .input(
       z.object({
         paymentId: PaymentSchema.shape.id,
@@ -14,22 +14,22 @@ export const refundRequestRouter = t.router({
     .mutation(async ({ input, ctx }) =>
       ctx.refundRequestService.createRefundRequest(input.paymentId, ctx.principal, input.reason)
     ),
-  edit: protectedProcedure
+  edit: adminProcedure
     .input(z.object({ id: RefundRequestSchema.shape.id, reason: z.string().min(0).max(255) }))
     .mutation(async ({ input, ctx }) => ctx.refundRequestService.updateRefundRequest(input.id, input)),
-  approve: protectedProcedure
+  approve: adminProcedure
     .input(RefundRequestSchema.shape.id)
     .mutation(async ({ input, ctx }) => ctx.refundRequestService.approveRefundRequest(input, ctx.principal)),
-  reject: protectedProcedure
+  reject: adminProcedure
     .input(RefundRequestSchema.shape.id)
     .mutation(async ({ input, ctx }) => ctx.refundRequestService.rejectRefundRequest(input, ctx.principal)),
-  delete: protectedProcedure
+  delete: adminProcedure
     .input(RefundRequestSchema.shape.id)
     .mutation(async ({ input, ctx }) => ctx.refundRequestService.deleteRefundRequest(input)),
-  get: protectedProcedure
+  get: adminProcedure
     .input(RefundRequestSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.refundRequestService.getRefundRequestById(input)),
-  all: protectedProcedure
+  all: adminProcedure
     .input(PaginateInputSchema)
     .query(async ({ input, ctx }) => ctx.refundRequestService.getRefundRequests(input)),
 })

--- a/packages/gateway-trpc/src/modules/user/user-router.ts
+++ b/packages/gateway-trpc/src/modules/user/user-router.ts
@@ -1,13 +1,11 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { PrivacyPermissionsWriteSchema, UserSchema, UserWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { protectedProcedure, publicProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, t } from "../../trpc"
 
 export const userRouter = t.router({
-  all: publicProcedure
-    .input(PaginateInputSchema)
-    .query(async ({ input, ctx }) => ctx.userService.getAll(input.take, 0)),
-  get: publicProcedure.input(UserSchema.shape.id).query(async ({ input, ctx }) => ctx.userService.getById(input)),
+  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.userService.getAll(input.take, 0)),
+  get: adminProcedure.input(UserSchema.shape.id).query(async ({ input, ctx }) => ctx.userService.getById(input)),
   registerAndGet: protectedProcedure
     .input(UserSchema.shape.id)
     .mutation(async ({ input, ctx }) => ctx.userService.register(input)),
@@ -31,7 +29,7 @@ export const userRouter = t.router({
       })
     )
     .mutation(async ({ input, ctx }) => ctx.userService.updatePrivacyPermissionsForUserId(input.id, input.data)),
-  searchByFullName: protectedProcedure
+  searchByFullName: adminProcedure
     .input(z.object({ searchQuery: z.string() }))
     .query(async ({ input, ctx }) => ctx.userService.searchForUser(input.searchQuery, 30, 0)),
 })

--- a/packages/gateway-trpc/src/trpc.ts
+++ b/packages/gateway-trpc/src/trpc.ts
@@ -19,7 +19,24 @@ const isAuthed = t.middleware(async ({ ctx, next }) => {
   return next({ ctx: { principal } })
 })
 
+const isAdmin = t.middleware(async ({ ctx, next }) => {
+  const principal = ctx.principal
+  if (principal === null) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Not authenticated" })
+  }
+
+  const adminPrincipals = ctx.adminPrincipals
+
+  if (adminPrincipals.includes("*") || adminPrincipals.includes(principal)) {
+    return next({ ctx: { principal } })
+  }
+
+  throw new TRPCError({ code: "UNAUTHORIZED", message: "Not authorized" })
+})
+
 export const router = t.router
 export const publicProcedure = t.procedure
-export const protectedProcedure = t.procedure.use(isAuthed)
+export const protectedProcedure = publicProcedure.use(isAuthed)
+export const adminProcedure = protectedProcedure.use(isAdmin)
+
 export const createCallerFactory = t.createCallerFactory


### PR DESCRIPTION
# Add Admin Authorization to API Endpoints

This PR adds proper admin authorization to the API by implementing an admin-specific procedure that checks if the authenticated user is in the list of admin users. The changes include:

1. Added an `ADMIN_USERS` environment variable that contains a comma-separated list of Auth0 user IDs with admin privileges
2. Created a new `adminProcedure` middleware that verifies if the authenticated user is in the admin list
3. Updated all administrative endpoints to use the new `adminProcedure` instead of `protectedProcedure` or `publicProcedure`
4. Passed the list of admin principals through the context to make it available for authorization checks

This change ensures that only designated admin users can access sensitive endpoints for creating, updating, and deleting resources, while regular authenticated users can only access endpoints relevant to their own data.