### PR TITLE
Make most query endpoints public procedures

### DIFF
--- a/packages/gateway-trpc/src/modules/company/company-router.ts
+++ b/packages/gateway-trpc/src/modules/company/company-router.ts
@@ -1,7 +1,7 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { CompanySchema, CompanyWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { adminProcedure, t } from "../../trpc"
+import { adminProcedure, publicProcedure, t } from "../../trpc"
 import { companyEventRouter } from "./company-event-router"
 
 export const companyRouter = t.router({
@@ -16,11 +16,13 @@ export const companyRouter = t.router({
       })
     )
     .mutation(async ({ input: changes, ctx }) => ctx.companyService.updateCompany(changes.id, changes.input)),
-  all: t.procedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.companyService.getCompanies(input)),
-  getById: t.procedure
+  all: publicProcedure
+    .input(PaginateInputSchema)
+    .query(async ({ input, ctx }) => ctx.companyService.getCompanies(input)),
+  getById: publicProcedure
     .input(CompanySchema.shape.id)
     .query(async ({ input, ctx }) => ctx.companyService.getCompanyById(input)),
-  getBySlug: t.procedure
+  getBySlug: publicProcedure
     .input(CompanySchema.shape.slug)
     .query(async ({ input, ctx }) => ctx.companyService.getCompanyBySlug(input)),
   event: companyEventRouter,

--- a/packages/gateway-trpc/src/modules/group/group-router.ts
+++ b/packages/gateway-trpc/src/modules/group/group-router.ts
@@ -1,21 +1,21 @@
 import { GroupMemberSchema, GroupMemberWriteSchema, GroupSchema, GroupWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { adminProcedure, protectedProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, publicProcedure, t } from "../../trpc"
 
 export const groupRouter = t.router({
   create: adminProcedure
     .input(GroupWriteSchema)
     .mutation(async ({ input, ctx }) => ctx.groupService.createGroup(input)),
-  all: adminProcedure.query(async ({ ctx }) => ctx.groupService.getGroups()),
-  allByType: adminProcedure
+  all: publicProcedure.query(async ({ ctx }) => ctx.groupService.getGroups()),
+  allByType: publicProcedure
     .input(GroupSchema.shape.type)
     .query(async ({ input, ctx }) => ctx.groupService.getGroupsByType(input)),
-  allIds: adminProcedure.query(async ({ ctx }) => ctx.groupService.getAllGroupIds()),
-  allIdsByType: adminProcedure
+  allIds: publicProcedure.query(async ({ ctx }) => ctx.groupService.getAllGroupIds()),
+  allIdsByType: publicProcedure
     .input(GroupSchema.shape.type)
     .query(async ({ input, ctx }) => ctx.groupService.getAllGroupIdsByType(input)),
-  get: adminProcedure.input(GroupSchema.shape.id).query(async ({ input, ctx }) => ctx.groupService.getGroup(input)),
-  getByType: adminProcedure
+  get: publicProcedure.input(GroupSchema.shape.id).query(async ({ input, ctx }) => ctx.groupService.getGroup(input)),
+  getByType: publicProcedure
     .input(z.object({ groupId: GroupSchema.shape.id, type: GroupSchema.shape.type }))
     .query(async ({ input, ctx }) => ctx.groupService.getGroupByType(input.groupId, input.type)),
   update: protectedProcedure
@@ -29,10 +29,10 @@ export const groupRouter = t.router({
   delete: protectedProcedure
     .input(GroupSchema.shape.id)
     .mutation(async ({ input, ctx }) => await ctx.groupService.deleteGroup(input)),
-  getMembers: adminProcedure
+  getMembers: publicProcedure
     .input(GroupMemberSchema.shape.userId)
     .query(async ({ input, ctx }) => ctx.groupService.getMembers(input)),
-  allByMember: adminProcedure
+  allByMember: publicProcedure
     .input(GroupMemberSchema.shape.userId)
     .query(async ({ input, ctx }) => ctx.groupService.getGroupsByMember(input)),
   addMember: adminProcedure

--- a/packages/gateway-trpc/src/modules/interest-group/interest-group-router.ts
+++ b/packages/gateway-trpc/src/modules/interest-group/interest-group-router.ts
@@ -1,13 +1,13 @@
 import { EventSchema, InterestGroupSchema, InterestGroupWriteSchema, UserSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { adminProcedure, t } from "../../trpc"
+import { adminProcedure, publicProcedure, t } from "../../trpc"
 
 export const interestGroupRouter = t.router({
   create: adminProcedure
     .input(InterestGroupWriteSchema)
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.create(input)),
-  all: adminProcedure.query(async ({ ctx }) => await ctx.interestGroupService.getAll()),
-  get: adminProcedure
+  all: publicProcedure.query(async ({ ctx }) => await ctx.interestGroupService.getAll()),
+  get: publicProcedure
     .input(InterestGroupSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getById(input)),
   update: adminProcedure
@@ -21,10 +21,10 @@ export const interestGroupRouter = t.router({
   delete: adminProcedure
     .input(InterestGroupSchema.shape.id)
     .mutation(async ({ input, ctx }) => await ctx.interestGroupService.delete(input)),
-  getByMember: adminProcedure
+  getByMember: publicProcedure
     .input(UserSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getByMember(input)),
-  getMembers: adminProcedure
+  getMembers: publicProcedure
     .input(InterestGroupSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getMembers(input)),
   addMember: adminProcedure
@@ -35,7 +35,7 @@ export const interestGroupRouter = t.router({
     .mutation(
       async ({ input, ctx }) => await ctx.interestGroupService.removeMember(input.interestGroupId, input.userId)
     ),
-  allByEventId: adminProcedure
+  allByEventId: publicProcedure
     .input(EventSchema.shape.id)
     .query(async ({ input, ctx }) => await ctx.interestGroupService.getAllByEventId(input)),
 })

--- a/packages/gateway-trpc/src/modules/job-listing/job-listing-router.ts
+++ b/packages/gateway-trpc/src/modules/job-listing/job-listing-router.ts
@@ -1,7 +1,7 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { JobListingSchema, JobListingWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { adminProcedure, protectedProcedure, t } from "../../trpc"
+import { adminProcedure, protectedProcedure, publicProcedure, t } from "../../trpc"
 
 export const jobListingRouter = t.router({
   create: adminProcedure
@@ -15,14 +15,14 @@ export const jobListingRouter = t.router({
       })
     )
     .mutation(async ({ input: { id, input }, ctx }) => ctx.jobListingService.update(id, input)),
-  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.jobListingService.getAll(input)),
-  active: adminProcedure
+  all: publicProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.jobListingService.getAll(input)),
+  active: publicProcedure
     .input(PaginateInputSchema)
     .query(async ({ input, ctx }) => ctx.jobListingService.getActive(input)),
-  get: adminProcedure
+  get: publicProcedure
     .input(JobListingSchema.shape.id)
     .query(async ({ input, ctx }) => ctx.jobListingService.getById(input)),
-  getLocations: adminProcedure
+  getLocations: publicProcedure
     .input(PaginateInputSchema)
     .query(async ({ ctx }) => ctx.jobListingService.getLocations()),
 })

--- a/packages/gateway-trpc/src/modules/mark/mark-router.ts
+++ b/packages/gateway-trpc/src/modules/mark/mark-router.ts
@@ -1,7 +1,7 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { MarkSchema, MarkWriteSchema } from "@dotkomonline/types"
 import { t } from "../../trpc"
-import { adminProcedure } from "./../../trpc"
+import { adminProcedure } from "../../trpc"
 import { personalMarkRouter } from "./personal-mark-router"
 
 export const markRouter = t.router({

--- a/packages/gateway-trpc/src/modules/offline/offline-router.ts
+++ b/packages/gateway-trpc/src/modules/offline/offline-router.ts
@@ -1,7 +1,7 @@
 import { PaginateInputSchema } from "@dotkomonline/core"
 import { OfflineSchema, OfflineWriteSchema } from "@dotkomonline/types"
 import { z } from "zod"
-import { adminProcedure, t } from "../../trpc"
+import { adminProcedure, publicProcedure, t } from "../../trpc"
 
 export const offlineRouter = t.router({
   create: adminProcedure.input(OfflineWriteSchema).mutation(async ({ input, ctx }) => ctx.offlineService.create(input)),
@@ -13,8 +13,8 @@ export const offlineRouter = t.router({
       })
     )
     .mutation(async ({ input: changes, ctx }) => ctx.offlineService.update(changes.id, changes.input)),
-  all: adminProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.offlineService.getAll(input)),
-  get: adminProcedure.input(OfflineSchema.shape.id).query(async ({ input, ctx }) => ctx.offlineService.get(input)),
+  all: publicProcedure.input(PaginateInputSchema).query(async ({ input, ctx }) => ctx.offlineService.getAll(input)),
+  get: publicProcedure.input(OfflineSchema.shape.id).query(async ({ input, ctx }) => ctx.offlineService.get(input)),
   createPresignedPost: adminProcedure
     .input(
       z.object({


### PR DESCRIPTION
Quite a few links on the website breaks now because these were made private. Job listings in particular