### PR TITLE
Factor out instantiating core and prisma from the repl entrypoint file

### DIFF
--- a/tools/shell/src/index.ts
+++ b/tools/shell/src/index.ts
@@ -1,24 +1,5 @@
 import repl from "node:repl"
-import { type ServiceLayerOptions, createServiceLayer } from "@dotkomonline/core"
-import { createPrisma } from "@dotkomonline/db"
-import { env } from "./env"
-
-const prisma = createPrisma(env.DATABASE_URL)
-// biome-ignore lint/suspicious/noExplicitAny: we don't provide s3 support for shell just yet
-const s3Client = new Proxy<ServiceLayerOptions["s3Client"]>({} as any, {})
-// biome-ignore lint/suspicious/noExplicitAny: we don't provide auth0 support for shell just yet
-const auth0Client = new Proxy<ServiceLayerOptions["managementClient"]>({} as any, {})
-// biome-ignore lint/suspicious/noExplicitAny: we don't provide stripe support for shell just yet
-const stripeAccounts = new Proxy<ServiceLayerOptions["stripeAccounts"]>({} as any, {})
-const s3BucketName = `shell-invalid-s3-bucket-${crypto.randomUUID()}`
-
-const core = await createServiceLayer({
-  db: prisma,
-  s3Client,
-  managementClient: auth0Client,
-  s3BucketName,
-  stripeAccounts,
-})
+import { core, prisma } from "./services"
 
 console.warn("The monoweb shell does not support s3, auth0, or stripe operations at this time.")
 
@@ -29,3 +10,4 @@ const replServer = repl.start({
 
 // Make services available in the REPL
 replServer.context.core = core
+replServer.context.prisma = prisma

--- a/tools/shell/src/services.ts
+++ b/tools/shell/src/services.ts
@@ -1,0 +1,22 @@
+import { type ServiceLayerOptions, createServiceLayer } from "@dotkomonline/core"
+import { createPrisma } from "@dotkomonline/db"
+import { env } from "./env"
+
+const prisma = createPrisma(env.DATABASE_URL)
+// biome-ignore lint/suspicious/noExplicitAny: we don't provide s3 support for shell just yet
+const s3Client = new Proxy<ServiceLayerOptions["s3Client"]>({} as any, {})
+// biome-ignore lint/suspicious/noExplicitAny: we don't provide auth0 support for shell just yet
+const auth0Client = new Proxy<ServiceLayerOptions["managementClient"]>({} as any, {})
+// biome-ignore lint/suspicious/noExplicitAny: we don't provide stripe support for shell just yet
+const stripeAccounts = new Proxy<ServiceLayerOptions["stripeAccounts"]>({} as any, {})
+const s3BucketName = `shell-invalid-s3-bucket-${crypto.randomUUID()}`
+
+const core = await createServiceLayer({
+  db: prisma,
+  s3Client,
+  managementClient: auth0Client,
+  s3BucketName,
+  stripeAccounts,
+})
+
+export { core, prisma }


### PR DESCRIPTION
For å kunne importere core og prisma i andre filer uten at repl'en starter