### PR TITLE
Add script for migrating offlines from ow4

### DIFF
--- a/tools/shell/src/scripts/migrate-offlines-from-ow4.ts
+++ b/tools/shell/src/scripts/migrate-offlines-from-ow4.ts
@@ -1,0 +1,16 @@
+import { prisma } from "../services"
+// @ts-ignore data.json is not in source control
+import data from "./data.json" assert { type: "json" }
+
+// see migrating-from-ow4.md for more information
+
+for (const item of data) {
+  await prisma.offline.create({
+    data: {
+      title: item.title,
+      published: new Date(item.release_date),
+      fileUrl: item.issue,
+      imageUrl: item.image_id.toString(),
+    },
+  })
+}

--- a/tools/shell/src/scripts/migrate-offlines-from-ow4.ts
+++ b/tools/shell/src/scripts/migrate-offlines-from-ow4.ts
@@ -1,16 +1,40 @@
-import { prisma } from "../services"
-// @ts-ignore data.json is not in source control
-import data from "./data.json" assert { type: "json" }
-
 // see migrating-from-ow4.md for more information
 
-for (const item of data) {
-  await prisma.offline.create({
-    data: {
-      title: item.title,
-      published: new Date(item.release_date),
-      fileUrl: item.issue,
-      imageUrl: item.image_id.toString(),
-    },
-  })
+import fs from "node:fs"
+import { prisma } from "../services"
+
+// @ts-ignore does not exist before running dumpSanityData
+import dumpedData from "./dumpedData.json" assert { type: "json" }
+
+async function dumpSanityData() {
+  // Sanity configuration
+  const SANITY_PROJECT_ID = "wsqi2mae"
+  const SANITY_DATASET = "production"
+  const SANITY_API_VERSION = "2023-05-03"
+
+  // Sanity query
+  const query = `*[_type == "offline"]`
+  const url = `https://${SANITY_PROJECT_ID}.api.sanity.io/v${SANITY_API_VERSION}/data/query/${SANITY_DATASET}?query=${encodeURIComponent(
+    query
+  )}`
+
+  const response = await fetch(url)
+  const { result } = await response.json()
+  fs.writeFileSync("./dumpedData.json", JSON.stringify(result, null, 2))
 }
+
+async function insertDump() {
+  for (const item of dumpedData) {
+    await prisma.offline.create({
+      data: {
+        title: item.title,
+        published: new Date(item.release_date),
+        fileUrl: item.pdf.asset._ref,
+        imageUrl: item.thumbnail.asset._ref,
+      },
+    })
+  }
+}
+
+await dumpSanityData()
+await insertDump()

--- a/tools/shell/src/scripts/migrating-from-ow4.md
+++ b/tools/shell/src/scripts/migrating-from-ow4.md
@@ -1,0 +1,24 @@
+# Migrere data fra OW4
+
+1. Eksporter OW4 tabell til en json fil
+
+Alternative 1: bruke tableplus
+
+åpne tableplus, klikk på tabellen du vil eksportere, klikk på export, velg json og klikk på export
+
+Alternativ 2: bruke psql
+
+```bash
+psql "postgres://ow:owpassword123@localhost:4010/ow" -c "SELECT json_agg(t) FROM event t;" > data.json
+```
+
+- Bytt ut connection string med ow4 connection string
+- Bytt ut `event` med tabellen du vil eksportere
+
+Denne er litt jalla, du må slette noen linjer fra data.json
+
+2. Skriv script som inserter inn i monoweb-db
+
+3. Sett opp riktig miljø du vil migrere. Letteste er å bruke monoweb-rpc i riktig miljø.
+
+4. Kjør scriptet i riktig miljø: `doppler run -- tsx ./src/scripts/migrate-offlines-from-ow4.ts`


### PR DESCRIPTION
man kan selvfølgelig skrive one-off scripts for migrering av data akkurat som man vil, men tenker det er nice å lagre noen scripts slik at man kan copy-paste og gå ut ifra et tidligere script

Det er ganske digg at man får type safety out of the box når man importerer en json fil som dette btw