### PR TITLE
Fix type oauth2 type issue

### DIFF
--- a/packages/oauth2/src/session.ts
+++ b/packages/oauth2/src/session.ts
@@ -14,10 +14,10 @@ export async function createSession(value: Session, secret: string): Promise<str
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime(Date.now() + defaultSessionLengthSeconds * 1000)
-    .sign(createSecretKey(Buffer.from(secret)))
+    .sign(createSecretKey(Uint8Array.from(secret)))
 }
 
 export async function getSession(jwt: string, secret: string): Promise<Session> {
-  const { payload } = await jwtVerify(jwt, createSecretKey(Buffer.from(secret)))
+  const { payload } = await jwtVerify(jwt, createSecretKey(Uint8Array.from(secret)))
   return Session.parse(payload)
 }


### PR DESCRIPTION
The type here does not work for me locally. I won't pretend i understand this fully, but chat says:


Node.js’s Buffer is not strictly an ArrayBufferView according to TypeScript’s (and the Web Crypto API’s) types, even though both are binary data.

The error comes up because you’re passing a Buffer to something that wants an ArrayBufferView—for example, crypto.createSecretKey() in Node.js expects an ArrayBufferView, and Buffer isn’t always directly assignable in TypeScript’s view.

