### PR TITLE
Make layout spacing more consistent

### DIFF
--- a/apps/web/src/app/events/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/events/[slug]/[eventId]/page.tsx
@@ -35,7 +35,7 @@ const EventDetailPage = async ({ params }: { params: Promise<{ eventId: string }
   const organizers = [...companyList, ...hostingGroups, ...hostingInterestGroups]
 
   return (
-    <div className="mt-8 flex flex-col gap-8">
+    <div className="flex flex-col gap-8">
       <EventHeader event={eventDetail.event} />
       <div className="flex w-full flex-col md:flex-row">
         <section className="mr-10 w-full flex flex-col space-y-4 md:w-[60%]">

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -8,8 +8,10 @@ const EventPage = async () => {
 
   return (
     <div className="flex flex-col gap-4">
-      <Title element="h1" className="font-semibold font-poppins text-3xl">Arrangementer</Title>
-      
+      <Title element="h1" className="font-semibold font-poppins text-3xl">
+        Arrangementer
+      </Title>
+
       <div className="flex flex-col gap-4">
         <EventsViewToggle active="list" />
         <EventList events={events.map(({ event }) => event)} />

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -1,16 +1,20 @@
 import { EventsViewToggle } from "@/components/molecules/EventsViewToggle"
 import { EventList } from "@/components/organisms/EventList"
 import { server } from "@/utils/trpc/server"
+import { Title } from "@dotkomonline/ui"
 
 const EventPage = async () => {
   const events = await server.event.all.query()
 
   return (
-    <>
-      <h1 className="py-6">Arrangement</h1>
-      <EventsViewToggle active="list" />
-      <EventList events={events.map(({ event }) => event)} />
-    </>
+    <div className="flex flex-col gap-4">
+      <Title element="h1" className="font-semibold font-poppins text-3xl">Arrangementer</Title>
+      
+      <div className="flex flex-col gap-4">
+        <EventsViewToggle active="list" />
+        <EventList events={events.map(({ event }) => event)} />
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/app/for-bedrifter/page.tsx
+++ b/apps/web/src/app/for-bedrifter/page.tsx
@@ -7,7 +7,7 @@ import { type FC, Fragment } from "react"
 
 export default async function Page() {
   return (
-    <main className="flex flex-col gap-16 items-center py-8">
+    <main className="flex flex-col gap-16 items-center">
       <HeroSection />
       <InterestSection />
       <ProductSection />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -60,9 +60,9 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         <SessionProvider session={session}>
           <QueryProvider>
             <ThemeProvider defaultTheme="light" enableSystem={false} attribute="data-theme">
-              <div className="min-h-screen flex flex-col mx-auto w-full max-w-screen-xl">
+              <div className="min-h-screen flex flex-col gap-8 mx-auto w-full max-w-screen-xl">
                 <Navbar />
-                <main className="flex-grow px-4 lg:px-12 lg:py-6">
+                <main className="flex-grow px-4 lg:px-12">
                   <div className="">{children}</div>
                 </main>
                 <Footer />

--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { LogoSection } from "./LogoSection"
 import { SocialSection } from "./SocialSection"
 
 export const Footer = () => (
-  <footer className="pt-24 pb-12 text-slate-10">
+  <footer className="mt-24 mb-12 text-slate-10">
     <div className="max-w-screen-xl px-4 lg:px-12 flex flex-col gap-8 md:gap-12">
       <LogoSection />
       <SocialSection />

--- a/apps/web/src/components/molecules/EventsViewToggle/index.tsx
+++ b/apps/web/src/components/molecules/EventsViewToggle/index.tsx
@@ -8,7 +8,7 @@ interface EventsViewToggleProps {
 
 export const EventsViewToggle: FC<EventsViewToggleProps> = ({ active }) => {
   return (
-    <div className="w-full sm:w-fit text-foreground bg-slate-3 inline-flex items-center justify-center rounded-md p-1 my-4">
+    <div className="w-full sm:w-fit text-foreground bg-slate-3 inline-flex items-center justify-center rounded-md p-1">
       {active === "list" ? (
         <div className="w-full text-slate-12 bg-slate-2 shadow-sm flex gap-1 items-center justify-center rounded-[0.185rem] px-4 py-1.5">
           <Icon icon="tabler:layout-list" width={20} height={20} />

--- a/apps/web/src/components/organisms/EventList/index.tsx
+++ b/apps/web/src/components/organisms/EventList/index.tsx
@@ -9,7 +9,7 @@ interface EventListProps {
 // Temporary eventlist design
 export const EventList: FC<EventListProps> = (props: EventListProps) => (
   <div className="w-full">
-    <ul className="mt-4 flex list-none flex-col gap-y-2">
+    <ul className="flex list-none flex-col gap-y-2">
       {(props.events || []).map((event) => (
         <li key={event.id}>
           <EventListItem {...event} attending={1} max_attending={10} />

--- a/apps/web/src/components/views/JobListingView/JobListingView.tsx
+++ b/apps/web/src/components/views/JobListingView/JobListingView.tsx
@@ -58,10 +58,10 @@ export const JobListingView: FC<JoblistingProps> = (props: JoblistingProps) => {
   return (
     <div>
       <div className="border-slate-7 left-0 z-0 w-full border-b">
-        <div className="flex flex-row gap-96 py-5">
-          <div className="flex flex-col">
-            <p className="mt-4 text-3xl font-bold border-b-0">Karrieremuligheter</p>
-            <p className="text-slate-9 pt-2">Ser du etter en jobb? Ta en titt på disse karrieremulighetene</p>
+        <div className="flex flex-row gap-96">
+          <div className="flex flex-col gap-2">
+            <p className="text-3xl font-bold border-b-0">Karrieremuligheter</p>
+            <p className="text-slate-9">Ser du etter en jobb? Ta en titt på disse karrieremulighetene</p>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/views/ProfileView/index.tsx
+++ b/apps/web/src/components/views/ProfileView/index.tsx
@@ -6,9 +6,9 @@ export const ProfilePoster: NextPage<{ user: User }> = ({ user }) => {
   return (
     <div className="min-h-screen">
       <div className="border-slate-7 left-0 z-0 w-full border-b">
-        <div className="flex flex-row gap-96 py-5">
+        <div className="flex flex-row gap-96">
           <div className="flex flex-col">
-            <p className="mt-4 text-3xl font-bold border-b-0">Min profil</p>
+            <p className="text-3xl font-bold border-b-0">Min profil</p>
             <p className="text-slate-9 pt-2">Oversikt over din profil</p>
           </div>
         </div>


### PR DESCRIPTION
Removes unnecessary manual padding visible in easily accessible OW5 pages. Previous PRs affecting the navbar and footer introduced duplicated spacing between the navbar and page content. This change reduces that excess spacing on some of the affected pages