### PR TITLE
Check for expired Feide access token before continuing

### DIFF
--- a/apps/rpc/src/modules/feide/feide-groups-error.ts
+++ b/apps/rpc/src/modules/feide/feide-groups-error.ts
@@ -1,8 +1,0 @@
-import { ApplicationError } from "../../error"
-import { PROBLEM_DETAILS } from "../../http-problem-details"
-
-export class StudentGroupsNotFoundError extends ApplicationError {
-  constructor(message: string) {
-    super(PROBLEM_DETAILS.NotFound, `Failed to fetch student's feide groups: ${message}`)
-  }
-}


### PR DESCRIPTION
This prevents the procedure from crashing if the token had expired.