### PR TITLE
Do not leak error details to the client

### DIFF
--- a/apps/rpc/src/instrumentation.ts
+++ b/apps/rpc/src/instrumentation.ts
@@ -2,10 +2,10 @@ import { getLogger, getResource, startOpenTelemetry } from "@dotkomonline/logger
 import * as Sentry from "@sentry/node"
 
 const logger = getLogger("monoweb-rpc/instrumentation")
+const resource = getResource("monoweb-rpc")
+startOpenTelemetry(resource)
 
 if (process.env.SENTRY_DSN !== undefined) {
-  const resource = getResource("monoweb-rpc")
-  startOpenTelemetry(resource)
   logger.info("Initializing Sentry...")
   Sentry.init({
     dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
Instead, we give them a OpenTelemetry trace ID they can provide to us if
need be. We still get the error reported on our side.