### PR TITLE
Optimize Docker image for apps/rpc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,15 +3,29 @@
 .vscode
 .next
 .turbo
-.react-email
 .git
 
 .dockerignore
 .env*
 
+# Dependencies and build outputs
 node_modules
+apps/**/node_modules
+apps/**/.next
+apps/**/.turbo
+apps/**/dist
+apps/**/build
+apps/**/coverage
+
+packages/**/node_modules
+packages/**/dist
+packages/**/build
+packages/**/coverage
+
+# React Email specific build outputs
+packages/email/.react-email
+
+# Code not related to the build
 infra
-out
-build
-dist
-coverage
+docs
+

--- a/apps/rpc/Dockerfile
+++ b/apps/rpc/Dockerfile
@@ -1,28 +1,21 @@
 FROM node:22-alpine@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b AS base
 
-FROM base AS builder
-WORKDIR /app
-
-RUN apk update && apk add --no-cache libc6-compat
-RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY apps ./apps
-COPY packages ./packages
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
-RUN turbo prune @dotkomonline/rpc --docker
-
 FROM base AS installer
 WORKDIR /app
 
-RUN npm install -g pnpm@9.15.5 turbo@2.0.14 --ignore-scripts
-COPY --from=builder /app/out/full .
+COPY apps ./apps
+COPY packages ./packages
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+
+RUN npm install -g pnpm@9.15.5 --ignore-scripts
 RUN pnpm install --ignore-scripts
 RUN pnpm generate
 
 # Install for production
-RUN pnpm install --prod --ignore-scripts
+RUN pnpm deploy --prod --no-optional --ignore-scripts -F @dotkomonline/rpc /opt/rpc
 
 FROM base AS runner
-WORKDIR /app
+WORKDIR /opt/rpc
 
 RUN apk add --no-cache curl
 
@@ -37,7 +30,6 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 rpc
 USER rpc
 
-COPY --from=installer --chown=rpc:nodejs --chmod=755 /app .
-COPY --from=builder --chown=rpc:nodejs --chmod=755 /app/out/full .
+COPY --from=installer --chown=rpc:nodejs --chmod=755 /opt/rpc .
 
-CMD node --loader ./apps/rpc/runtime.mjs --experimental-strip-types ./apps/rpc/src/bin/server.ts
+CMD node --loader ./runtime.mjs --experimental-strip-types ./src/bin/server.ts

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -51,6 +51,9 @@
     },
     "@types/react-dom": {
       "optional": true
+    },
+    "next": {
+      "optional": true
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules, for "file:///opt/rpc/node_modules/.pnpm/@dotkomonline+oauth2@file+packages+oauth2_@opentelemetry+api@1.9.0_@types+react-dom@19.1.7_@t_rqjlkdux7wwlvrdr44udewoie4/node_modules/@dotkomonline/oauth2/src/jwt.ts"
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:156:11)
    at ModuleLoader.<anonymous> (node:internal/modules/esm/translators:524:16)
    at #translate (node:internal/modules/esm/loader:536:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:583:27) {
  code: 'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
}