### PR TITLE
Fix broken and flaky tests

### DIFF
--- a/apps/rpc/src/modules/event/attendance.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/attendance.e2e-spec.ts
@@ -12,7 +12,7 @@ import { addDays, addHours, addMinutes, isFuture, subHours } from "date-fns"
 import { describe, expect, it } from "vitest"
 import { auth0Client, core, dbClient } from "../../../vitest-integration.setup"
 import { AttendanceNotFound, AttendanceValidationError } from "./attendance-error"
-import { getMockGroup } from "./event.e2e-spec"
+import { getMockEvent, getMockGroup } from "./event.e2e-spec"
 
 function getMockAttendance(input: Partial<AttendanceWrite> = {}): AttendanceWrite {
   return {
@@ -175,7 +175,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     const userWithoutMembership = await core.userService.register(dbClient, subject)
     const user = await core.userService.createMembership(dbClient, userWithoutMembership.id, getMockMembership())
     expect(findActiveMembership(user)).not.toBeNull()
@@ -193,7 +195,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     const user = await core.userService.register(dbClient, subject)
     expect(findActiveMembership(user)).toBeNull()
     await expect(
@@ -210,7 +214,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
     const group = await core.groupService.create(dbClient, getMockGroup({ abbreviation: "Bedkom" }))
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // Create a user and suspend them by giving them more than 6 marks.
     const user = await core.userService.register(dbClient, subject)
     const mark = await core.markService.createMark(dbClient, {
@@ -239,6 +245,7 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(
       dbClient,
       getMockAttendance({
@@ -246,6 +253,7 @@ describe("attendance integration tests", async () => {
         registerEnd: addDays(getCurrentUTC(), 2), // Registration ends in two days
       })
     )
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // The membership for the test user is registered to be a first year student
     await core.attendanceService.createAttendancePool(
       dbClient,
@@ -282,7 +290,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // The membership for the test user is registered to be a first year student
     await core.attendanceService.createAttendancePool(
       dbClient,
@@ -318,7 +328,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // The membership for the test user is registered to be a first year student
     await core.attendanceService.createAttendancePool(
       dbClient,
@@ -360,7 +372,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // The membership for the test user is registered to be a first year student
     await core.attendanceService.createAttendancePool(
       dbClient,
@@ -389,7 +403,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // The membership for the test user is registered to be a first year student
     await core.attendanceService.createAttendancePool(
       dbClient,
@@ -414,7 +430,9 @@ describe("attendance integration tests", async () => {
   it("should not deregister an attendee past the deadline", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     await core.attendanceService.createAttendancePool(
       dbClient,
       attendance.id,
@@ -451,7 +469,9 @@ describe("attendance integration tests", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
 
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     // We create an attendance pool that the user cannot attend, because they are not a 5th year student
     const pool = await core.attendanceService.createAttendancePool(
       dbClient,
@@ -496,7 +516,9 @@ describe("attendance integration tests", async () => {
     const betaWOM = await core.userService.register(dbClient, betaSubject)
     const alpha = await core.userService.createMembership(dbClient, alphaWOM.id, getMockMembership())
     const beta = await core.userService.createMembership(dbClient, betaWOM.id, getMockMembership())
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     await core.attendanceService.createAttendancePool(
       dbClient,
       attendance.id,
@@ -547,7 +569,9 @@ describe("attendance integration tests", async () => {
     const betaWOM = await core.userService.register(dbClient, betaSubject)
     const alpha = await core.userService.createMembership(dbClient, alphaWOM.id, getMockMembership())
     const beta = await core.userService.createMembership(dbClient, betaWOM.id, getMockMembership())
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     await core.attendanceService.createAttendancePool(
       dbClient,
       attendance.id,
@@ -594,7 +618,9 @@ describe("attendance integration tests", async () => {
   it("should register the physical attendance of a user for an event", async () => {
     const subject = randomUUID()
     auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
     await core.attendanceService.createAttendancePool(
       dbClient,
       attendance.id,

--- a/apps/rpc/src/modules/event/event.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/event.e2e-spec.ts
@@ -1,21 +1,8 @@
-import type { S3Client } from "@aws-sdk/client-s3"
 import type { EventWrite, GroupWrite } from "@dotkomonline/types"
 import { faker } from "@faker-js/faker"
-import type { ManagementClient } from "auth0"
 import { describe, expect, it } from "vitest"
-import { mockDeep } from "vitest-mock-extended"
-import { dbClient } from "../../../vitest-integration.setup"
-import { getFeideGroupsRepository } from "../feide/feide-groups-repository"
-import { getGroupRepository } from "../group/group-repository"
-import { getGroupService } from "../group/group-service"
-import { getNTNUStudyplanRepository } from "../ntnu-study-plan/ntnu-study-plan-repository"
-import { getNotificationPermissionsRepository } from "../user/notification-permissions-repository"
-import { getPrivacyPermissionsRepository } from "../user/privacy-permissions-repository"
-import { getUserRepository } from "../user/user-repository"
-import { getUserService } from "../user/user-service"
+import { core, dbClient } from "../../../vitest-integration.setup"
 import { EventRelationshipError } from "./event-error"
-import { getEventRepository } from "./event-repository"
-import { getEventService } from "./event-service"
 
 // biome-ignore lint/suspicious/noExportsInTest: used in another spec
 export function getMockGroup(input: Partial<GroupWrite> = {}): GroupWrite {
@@ -52,31 +39,9 @@ export function getMockEvent(input: Partial<EventWrite> = {}): EventWrite {
 }
 
 describe("event integration tests", () => {
-  const managementClient = mockDeep<ManagementClient>()
-  const s3Client = mockDeep<S3Client>()
-  const userRepository = getUserRepository()
-  const notificationPermissionsRepository = getNotificationPermissionsRepository()
-  const privacyPermissionsRepository = getPrivacyPermissionsRepository()
-  const feideGroupsRepository = getFeideGroupsRepository()
-  const ntnuStudyPlanRepository = getNTNUStudyplanRepository()
-  const userService = getUserService(
-    userRepository,
-    privacyPermissionsRepository,
-    notificationPermissionsRepository,
-    feideGroupsRepository,
-    ntnuStudyPlanRepository,
-    managementClient,
-    s3Client,
-    "fake-aws-bucket"
-  )
-  const groupRepository = getGroupRepository()
-  const groupService = getGroupService(groupRepository, userService)
-  const eventRepository = getEventRepository()
-  const eventService = getEventService(eventRepository)
-
   it("should create a new event", async () => {
     const mock = getMockEvent()
-    const event = await eventService.createEvent(dbClient, mock)
+    const event = await core.eventService.createEvent(dbClient, mock)
     expect(event.title).toBe(mock.title)
     expect(event.companies).toHaveLength(0)
     expect(event.hostingGroups).toHaveLength(0)
@@ -84,16 +49,21 @@ describe("event integration tests", () => {
   })
 
   it("should update event organizers by diffing organizers", async () => {
-    const event = await eventService.createEvent(dbClient, getMockEvent())
-    const group = await groupService.create(dbClient, getMockGroup())
-    const updated = await eventService.updateEventOrganizers(dbClient, event.id, new Set([group.slug]), new Set())
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
+    const group = await core.groupService.create(dbClient, getMockGroup())
+    const updated = await core.eventService.updateEventOrganizers(dbClient, event.id, new Set([group.slug]), new Set())
     expect(updated.hostingGroups).toHaveLength(1)
     // Updating with new ones and removing some
-    const group2 = await groupService.create(
+    const group2 = await core.groupService.create(
       dbClient,
       getMockGroup({ abbreviation: "fagkom", name: "Fag- og kurskomiteen" })
     )
-    const updated2 = await eventService.updateEventOrganizers(dbClient, updated.id, new Set([group2.slug]), new Set())
+    const updated2 = await core.eventService.updateEventOrganizers(
+      dbClient,
+      updated.id,
+      new Set([group2.slug]),
+      new Set()
+    )
     expect(updated2.hostingGroups).toHaveLength(1)
     expect(updated2.hostingGroups).not.toContainEqual(
       expect.objectContaining({
@@ -103,12 +73,17 @@ describe("event integration tests", () => {
   })
 
   it("should find events by various filter criteria", async () => {
-    const eventObject = await eventService.createEvent(dbClient, getMockEvent())
-    const group = await groupService.create(dbClient, getMockGroup())
-    const event = await eventService.updateEventOrganizers(dbClient, eventObject.id, new Set([group.slug]), new Set())
+    const eventObject = await core.eventService.createEvent(dbClient, getMockEvent())
+    const group = await core.groupService.create(dbClient, getMockGroup())
+    const event = await core.eventService.updateEventOrganizers(
+      dbClient,
+      eventObject.id,
+      new Set([group.slug]),
+      new Set()
+    )
     // It finds events by a search term
     {
-      const events = await eventService.findEvents(dbClient, {
+      const events = await core.eventService.findEvents(dbClient, {
         bySearchTerm: event.title.substring(0, 5),
         byId: [],
         byStartDate: { min: null, max: null },
@@ -119,7 +94,7 @@ describe("event integration tests", () => {
     }
     // It finds events by an organizing group
     {
-      const events = await eventService.findEvents(dbClient, {
+      const events = await core.eventService.findEvents(dbClient, {
         bySearchTerm: null,
         byId: [],
         byStartDate: { min: null, max: null },
@@ -130,7 +105,7 @@ describe("event integration tests", () => {
     }
     // It finds events by a specific id
     {
-      const events = await eventService.findEvents(dbClient, {
+      const events = await core.eventService.findEvents(dbClient, {
         bySearchTerm: null,
         byId: [event.id],
         byStartDate: { min: null, max: null },
@@ -142,31 +117,35 @@ describe("event integration tests", () => {
   })
 
   it("should prevent assigning itself as a parent event", async () => {
-    const event = await eventService.createEvent(dbClient, getMockEvent())
-    await expect(eventService.updateEventParent(dbClient, event.id, event.id)).rejects.toThrow(EventRelationshipError)
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
+    await expect(core.eventService.updateEventParent(dbClient, event.id, event.id)).rejects.toThrow(
+      EventRelationshipError
+    )
   })
 
   it("should prevent cyclic event relationships", async () => {
-    const event1 = await eventService.createEvent(dbClient, getMockEvent())
-    const event2 = await eventService.createEvent(dbClient, getMockEvent())
+    const event1 = await core.eventService.createEvent(dbClient, getMockEvent())
+    const event2 = await core.eventService.createEvent(dbClient, getMockEvent())
 
     // It is legal to set event1 as a parent of event2
-    await expect(eventService.updateEventParent(dbClient, event2.id, event1.id)).resolves.toBeDefined()
+    await expect(core.eventService.updateEventParent(dbClient, event2.id, event1.id)).resolves.toBeDefined()
 
     // But it should now be illegal to set event2 as a parent of event1
-    await expect(eventService.updateEventParent(dbClient, event1.id, event2.id)).rejects.toThrow(EventRelationshipError)
+    await expect(core.eventService.updateEventParent(dbClient, event1.id, event2.id)).rejects.toThrow(
+      EventRelationshipError
+    )
   })
 
   it("should ban nesting more than one level deep", async () => {
-    const event1 = await eventService.createEvent(dbClient, getMockEvent())
-    const event2 = await eventService.createEvent(dbClient, getMockEvent())
-    const event3 = await eventService.createEvent(dbClient, getMockEvent())
+    const event1 = await core.eventService.createEvent(dbClient, getMockEvent())
+    const event2 = await core.eventService.createEvent(dbClient, getMockEvent())
+    const event3 = await core.eventService.createEvent(dbClient, getMockEvent())
 
     // It is legal to set event1 as a parent of event2
-    await expect(eventService.updateEventParent(dbClient, event2.id, event1.id)).resolves.toBeDefined()
+    await expect(core.eventService.updateEventParent(dbClient, event2.id, event1.id)).resolves.toBeDefined()
 
     // It is not legal to set event2 as a parent of event3, as event2 already has a parent
-    await expect(eventService.updateEventParent(dbClient, event3.id, event2.id)).rejects.toThrowError(
+    await expect(core.eventService.updateEventParent(dbClient, event3.id, event2.id)).rejects.toThrowError(
       EventRelationshipError
     )
   })

--- a/apps/rpc/vitest-integration.config.ts
+++ b/apps/rpc/vitest-integration.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text"],
     },
+    fileParallelism: false,
     setupFiles: ["./vitest-integration.setup.ts"],
   },
 })

--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,7 @@
     "ignore": [
       "**/node_modules/**",
       "**/build/**",
+      "**/coverage/**",
       "**/dist/**",
       "**/out/**",
       "**/.next/**",


### PR DESCRIPTION
Turns off fileParallelism in Vitest to avoid cross-contamination for now. Ideally, each test should run using its own test database from testcontainers.