### PR TITLE
Correct mobile navbar color in dark mode

### DIFF
--- a/apps/web/src/components/Navbar/MobileNavigation.tsx
+++ b/apps/web/src/components/Navbar/MobileNavigation.tsx
@@ -34,7 +34,7 @@ export const MobileNavigation: FC<{ links: MenuLink[] }> = ({ links }) => {
                       <Link
                         href={"href" in link ? link.href : "#"}
                         className={cn(
-                          "font-body flex items-center gap-3 p-4 bg-gray-50 rounded-xl",
+                          "font-body flex items-center gap-3 p-4 bg-gray-50 dark:bg-stone-700 rounded-xl",
                           "text-lg font-semibold",
                           "href" in link && "font-medium"
                         )}


### PR DESCRIPTION
<img width="681" height="657" alt="image" src="https://github.com/user-attachments/assets/8d0f0a4a-d9ce-4f75-ae0d-9147734d56f3" />
