### PR TITLE
Add basic frontend for child parent events

### DIFF
--- a/apps/rpc/src/modules/event/event-service.ts
+++ b/apps/rpc/src/modules/event/event-service.ts
@@ -30,6 +30,7 @@ export interface EventService {
   updateEventParent(handle: DBHandle, eventId: EventId, parentEventId: EventId | null): Promise<Event>
   findEvents(handle: DBHandle, query: EventFilterQuery, page?: Pageable): Promise<Event[]>
   findEventsByAttendingUserId(handle: DBHandle, userId: UserId, page?: Pageable): Promise<Event[]>
+  findByParentEventId(handle: DBHandle, parentEventId: EventId): Promise<Event[]>
   findEventById(handle: DBHandle, eventId: EventId): Promise<Event | null>
   /**
    * Get an event by its id
@@ -53,6 +54,9 @@ export function getEventService(eventRepository: EventRepository): EventService 
     },
     async findEvents(handle, query, page) {
       return await eventRepository.findMany(handle, query, page ?? { take: 20 })
+    },
+    async findByParentEventId(handle, parentEventId) {
+      return await eventRepository.findByParentEventId(handle, parentEventId)
     },
     async findEventById(handle, eventId) {
       return await eventRepository.findById(handle, eventId)

--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -4,6 +4,7 @@ import { server } from "@/utils/trpc/server"
 import type { Attendance, Company, Event, Group, GroupType, Punishment, User } from "@dotkomonline/types"
 import { Tabs, TabsContent, TabsList, TabsTrigger, Text } from "@dotkomonline/ui"
 import clsx from "clsx"
+import { isPast } from "date-fns"
 import Image from "next/image"
 import Link from "next/link"
 import { RedirectType, notFound, permanentRedirect } from "next/navigation"
@@ -12,7 +13,6 @@ import { EventDescription } from "../../components/EventDescription"
 import { EventHeader } from "../../components/EventHeader"
 import { EventList } from "../../components/EventList"
 import { TimeLocationBox } from "../../components/TimeLocationBox/TimeLocationBox"
-import { isPast } from "date-fns"
 
 type OrganizerType = GroupType | "COMPANY"
 
@@ -55,7 +55,7 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<{ slug: str
   }
 
   const { event, attendance } = eventDetail
-  
+
   if (slug !== getEventSlug(event.title)) {
     permanentRedirect(getEventUrl(eventId, event.title), RedirectType.replace)
   }
@@ -65,7 +65,7 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<{ slug: str
     session ? server.user.getMe.query() : null,
     session ? server.user.isStaff.query() : null,
   ])
-  
+
   const punishment = attendance && user && (await server.personalMark.getExpiryDateForUser.query({ userId: user.id }))
 
   const futureChildEvents = childEvents.filter(({ event }) => !isPast(event.end))
@@ -88,7 +88,11 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<{ slug: str
 
           <TabsContent value="child-events" className="p-0 border-none mt-4">
             <div>
-              <EventList futureEventWithAttendances={futureChildEvents} pastEventWithAttendances={pastChildEvents} alwaysShowChildEvents />
+              <EventList
+                futureEventWithAttendances={futureChildEvents}
+                pastEventWithAttendances={pastChildEvents}
+                alwaysShowChildEvents
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/apps/web/src/app/arrangementer/components/EventList.tsx
+++ b/apps/web/src/app/arrangementer/components/EventList.tsx
@@ -14,17 +14,30 @@ interface EventListProps {
   futureEventWithAttendances: EventWithAttendance[]
   pastEventWithAttendances: EventWithAttendance[]
   onLoadMore?(): void
+  alwaysShowChildEvents?: boolean
 }
 
 export const EventList: FC<EventListProps> = ({
   futureEventWithAttendances: futureEvents,
   pastEventWithAttendances: pastEvents,
   onLoadMore,
+  alwaysShowChildEvents,
 }: EventListProps) => {
   const now = getCurrentUTC()
   const session = useSession()
 
-  const groupedEvents = Object.groupBy(futureEvents, (event) => {
+  const filteredFutureEvents = alwaysShowChildEvents
+    ? futureEvents
+    : futureEvents.filter((e) => {
+        if (!e.event.parentId) {
+          return true
+        }
+
+        const event = futureEvents.find((ev) => ev.event.id === e.event.parentId)
+        return event?.attendance?.attendees.some((a) => a.user.id === session?.sub) ?? false
+      })
+
+  const groupedEvents = Object.groupBy(filteredFutureEvents, (event) => {
     if (!event.attendance) {
       return "otherFutureEvents"
     }


### PR DESCRIPTION
Hides all events in event list with a parentId unless you are an attendee at the parentEvent or `alwaysShowChildEvents` prop is true. Does not hide from calendar

This is meant to be updated and worked on in the future

<img width="2139" height="1212" alt="image" src="https://github.com/user-attachments/assets/1b858505-1315-4e34-af50-f4393891c6e7" />
<img width="2139" height="1212" alt="image" src="https://github.com/user-attachments/assets/f31c47cd-e76e-4fac-a804-5aa154cef764" />
