### PR TITLE
Fix payment status unknown

### DIFF
--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -368,6 +368,9 @@ export function getAttendanceService(
       if (attendance.attendancePrice) {
         const paymentDeadline = options.immediatePayment ? addMinutes(new TZDate(), 15) : addHours(new TZDate(), 24)
         const payment = await this.startAttendeePayment(handle, attendee.id, paymentDeadline)
+        attendee.paymentDeadline = paymentDeadline
+        attendee.paymentId = payment.id
+        attendee.paymentLink = payment.url
       }
 
       // When a user is immediately reserved, there is no reason to schedule a task for them.


### PR DESCRIPTION
Whenever you registered for an event, you would receive a message on the frontend saying payment status was unknown instead of the link and countdown.