### PR TITLE
Require dependencies to be 14 days old

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,9 +12,8 @@
   "patch": {
     "automerge": true
   },
-  "schedule": [
-    "* * * * 6"
-  ],
+  "schedule": ["* * * * 6"],
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "groupName": "next",
@@ -27,9 +26,7 @@
     },
     {
       "enabled": false,
-      "matchPackageNames": [
-        "/^@dotkomonline//"
-      ]
+      "matchPackageNames": ["/^@dotkomonline//"]
     }
   ]
 }


### PR DESCRIPTION
This should prevent us from eating most bad packages (like what happened with debug+friends yesterday)