### PR TITLE
Forward Trace ID from error to client

### DIFF
--- a/apps/rpc/src/trpc.ts
+++ b/apps/rpc/src/trpc.ts
@@ -158,7 +158,7 @@ export const procedure = t.procedure.use(async ({ ctx, path, type, next }) => {
         if (result.error.cause instanceof ApplicationError) {
           error = new TRPCError({
             code: getTRPCErrorCode(result.error.cause),
-            message: result.error.cause.message,
+            message: `${result.error.cause.message} (TraceID=${traceId})`,
             cause: result.error.cause,
           })
         }


### PR DESCRIPTION
Makes it easier for people to report errors when they can provide the Trace ID.