### PR TITLE
Give more space to textarea input on profile page

### DIFF
--- a/apps/web/src/app/innstillinger/profil/form.tsx
+++ b/apps/web/src/app/innstillinger/profil/form.tsx
@@ -196,7 +196,7 @@ export function ProfileForm({ user, onSubmit, isSaving, saveSuccess, saveError, 
         />
 
         <div className="w-full flex flex-col gap-1">
-          <Textarea label="Biografi" placeholder="Skriv noe om deg selv..." {...register("biography")} />
+          <Textarea label="Biografi" placeholder="Skriv noe om deg selv..." {...register("biography")} rows={10} />
           {errors.biography && (
             <Text className="text-red-600 dark:text-red-400 text-xs text-left transition-all fade-in fade-out">
               {errors.biography?.message ?? "En feil oppstod"}

--- a/packages/ui/src/atoms/Textarea/Textarea.tsx
+++ b/packages/ui/src/atoms/Textarea/Textarea.tsx
@@ -24,7 +24,7 @@ export const Textarea: FC<TextareaProps> = ({ className, error, message, label, 
       )}
       <textarea
         className={cn(
-          "font-body flex min-h-10 h-15 w-full",
+          "font-body flex min-h-10 w-full",
           "px-3 py-2 rounded-md text-sm",
           "border border-gray-200 dark:border-stone-700 dark:bg-stone-800",
           "placeholder:text-gray-500 dark:placeholder:text-stone-400",


### PR DESCRIPTION
The old one was practically unusable because of the h-15

<img width="1400" height="659" alt="image" src="https://github.com/user-attachments/assets/1e1e83a7-b727-4869-8e7d-9ab7aeff6c55" />
