### PR TITLE
Remove unused turbo-ignore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "monorepo",
   "version": "1.0.0",
   "description": "Monoweb is the next-generation web application for Online. This is the monorepo source.",
-  "keywords": [
-    "online",
-    "ntnu",
-    "student-association"
-  ],
+  "keywords": ["online", "ntnu", "student-association"],
   "homepage": "https://online.ntnu.no",
   "author": "Dotkom <dotkom@online.ntnu> (https://online.ntnu.no)",
   "bugs": {
@@ -39,10 +35,7 @@
     "shell": "pnpm -F @dotkomonline/rpc shell",
     "give-me-staff": "pnpm -rc -F @dotkomonline/rpc exec doppler run --preserve-env pnpm give-me-staff"
   },
-  "workspaces": [
-    "packages/*",
-    "apps/*"
-  ],
+  "workspaces": ["packages/*", "apps/*"],
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "engines": {
     "node": ">=22.0.0",
@@ -51,7 +44,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "turbo": "2.5.6",
-    "turbo-ignore": "2.5.6",
     "typescript": "5.9.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       turbo:
         specifier: 2.5.6
         version: 2.5.6
-      turbo-ignore:
-        specifier: 2.5.6
-        version: 2.5.6
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -8670,10 +8667,6 @@ packages:
     resolution: {integrity: sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==}
     cpu: [arm64]
     os: [darwin]
-
-  turbo-ignore@2.5.6:
-    resolution: {integrity: sha512-ioXKjyxdbarY5oF923tENn4TsS+6kDAO+wvJ8bYaTd4Lmrca9jQJoDJwiHoNcSVnwoXBfyfvn3Uajl18guQpHg==}
-    hasBin: true
 
   turbo-linux-64@2.5.6:
     resolution: {integrity: sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==}
@@ -17953,10 +17946,6 @@ snapshots:
 
   turbo-darwin-arm64@2.5.6:
     optional: true
-
-  turbo-ignore@2.5.6:
-    dependencies:
-      json5: 2.2.3
 
   turbo-linux-64@2.5.6:
     optional: true


### PR DESCRIPTION
This was previously used when we ran on Vercel in the Vercel config.
