### PR TITLE
Add more filters to event list

### DIFF
--- a/apps/web/src/app/arrangementer/components/EventFilters.tsx
+++ b/apps/web/src/app/arrangementer/components/EventFilters.tsx
@@ -51,7 +51,7 @@ export const EventFilters = ({ onChange, groups }: Props) => {
       bySearchTerm: "",
       byType: "ALL",
       byOrganizingGroup: "ALL",
-      viewMode: "BY_CATEGORY",
+      viewMode: "ATTENDANCE",
     },
   })
   const data = useWatch({ control: form.control }) as FormValues
@@ -140,8 +140,8 @@ export const EventFilters = ({ onChange, groups }: Props) => {
 
                   <SelectContent>
                     <SelectGroup>
-                      <SelectItem value="BY_CATEGORY">Kategori</SelectItem>
-                      <SelectItem value="BY_DATE">Dato</SelectItem>
+                      <SelectItem value="ATTENDANCE">Påmelding</SelectItem>
+                      <SelectItem value="CHRONOLOGICAL">Kronologisk</SelectItem>
                     </SelectGroup>
                   </SelectContent>
                 </Select>

--- a/apps/web/src/app/arrangementer/components/EventFilters.tsx
+++ b/apps/web/src/app/arrangementer/components/EventFilters.tsx
@@ -23,6 +23,7 @@ import { useEffect, useMemo, useState } from "react"
 import { Controller, useForm, useWatch } from "react-hook-form"
 import { useDebounce } from "use-debounce"
 import { z } from "zod"
+import { type EventListViewMode, EventListViewModeSchema } from "./EventList"
 
 const EVENT_TYPE_OPTIONS = Object.values(EventTypeSchema.Values).map((type) => ({
   value: type,
@@ -34,12 +35,13 @@ const FormSchema = EventFilterQuerySchema.pick({
 }).extend({
   byType: EventSchema.shape.type.or(z.literal("ALL")),
   byOrganizingGroup: GroupSchema.shape.slug,
+  viewMode: EventListViewModeSchema,
 })
 
 type FormValues = z.infer<typeof FormSchema>
 
 interface Props {
-  onChange(filters: EventFilterQuery): void
+  onChange(filters: EventFilterQuery, viewMode: EventListViewMode): void
   groups: Group[]
 }
 
@@ -49,6 +51,7 @@ export const EventFilters = ({ onChange, groups }: Props) => {
       bySearchTerm: "",
       byType: "ALL",
       byOrganizingGroup: "ALL",
+      viewMode: "BY_CATEGORY",
     },
   })
   const data = useWatch({ control: form.control }) as FormValues
@@ -59,11 +62,14 @@ export const EventFilters = ({ onChange, groups }: Props) => {
   }, [debouncedData])
 
   const handleSubmit = (values: FormValues) => {
-    onChange({
-      bySearchTerm: values.bySearchTerm,
-      byType: values.byType !== "ALL" ? [values.byType] : [],
-      byOrganizingGroup: values.byOrganizingGroup !== "ALL" ? [values.byOrganizingGroup] : [],
-    })
+    onChange(
+      {
+        bySearchTerm: values.bySearchTerm,
+        byType: values.byType !== "ALL" ? [values.byType] : [],
+        byOrganizingGroup: values.byOrganizingGroup !== "ALL" ? [values.byOrganizingGroup] : [],
+      },
+      values.viewMode
+    )
   }
 
   return (
@@ -115,6 +121,30 @@ export const EventFilters = ({ onChange, groups }: Props) => {
                   Arrangør
                 </Label>
                 <GroupSelect onChange={onChange} groups={groups} value={value} />
+              </div>
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="viewMode"
+            render={({ field: { onChange, value } }) => (
+              <div>
+                <Label htmlFor="viewMode" className="mb-1 text-md">
+                  Sorter
+                </Label>
+                <Select value={value} onValueChange={onChange}>
+                  <SelectTrigger id="viewMode">
+                    <SelectValue />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="BY_CATEGORY">Kategori</SelectItem>
+                      <SelectItem value="BY_DATE">Dato</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
               </div>
             )}
           />

--- a/apps/web/src/app/arrangementer/components/EventFilters.tsx
+++ b/apps/web/src/app/arrangementer/components/EventFilters.tsx
@@ -1,31 +1,180 @@
 "use client"
 
-import type { EventFilterQuery } from "@dotkomonline/types"
-import { TextInput } from "@dotkomonline/ui"
-import { useEffect } from "react"
-import { useForm, useWatch } from "react-hook-form"
+import {
+  type EventFilterQuery,
+  EventFilterQuerySchema,
+  EventSchema,
+  EventTypeSchema,
+  type Group,
+  GroupSchema,
+  mapEventTypeToLabel,
+} from "@dotkomonline/types"
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  TextInput,
+} from "@dotkomonline/ui"
+import { useEffect, useMemo, useState } from "react"
+import { Controller, useForm, useWatch } from "react-hook-form"
 import { useDebounce } from "use-debounce"
+import { z } from "zod"
+
+const EVENT_TYPE_OPTIONS = Object.values(EventTypeSchema.Values).map((type) => ({
+  value: type,
+  label: mapEventTypeToLabel(type),
+}))
+
+const FormSchema = EventFilterQuerySchema.pick({
+  bySearchTerm: true,
+}).extend({
+  byType: EventSchema.shape.type.or(z.literal("ALL")),
+  byOrganizingGroup: GroupSchema.shape.slug,
+})
+
+type FormValues = z.infer<typeof FormSchema>
 
 interface Props {
   onChange(filters: EventFilterQuery): void
+  groups: Group[]
 }
 
-export const EventFilters = ({ onChange }: Props) => {
-  const form = useForm<EventFilterQuery>()
-  const data = useWatch(form) as EventFilterQuery
+export const EventFilters = ({ onChange, groups }: Props) => {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      bySearchTerm: "",
+      byType: "ALL",
+      byOrganizingGroup: "ALL",
+    },
+  })
+  const data = useWatch({ control: form.control }) as FormValues
   const [debouncedData] = useDebounce(data, 300)
 
   useEffect(() => {
-    onChange(debouncedData)
-  }, [onChange, debouncedData])
+    handleSubmit(debouncedData)
+  }, [debouncedData])
 
-  const handleSubmit = (values: EventFilterQuery) => {
-    onChange(values)
+  const handleSubmit = (values: FormValues) => {
+    onChange({
+      bySearchTerm: values.bySearchTerm,
+      byType: values.byType !== "ALL" ? [values.byType] : [],
+      byOrganizingGroup: values.byOrganizingGroup !== "ALL" ? [values.byOrganizingGroup] : [],
+    })
   }
 
   return (
-    <form onSubmit={form.handleSubmit(handleSubmit)}>
-      <TextInput placeholder="Søk etter arrangementer..." {...form.register("bySearchTerm")} />
-    </form>
+    <div className="border-gray-200 dark:border-stone-700 h-fit rounded-lg border shadow-b-sm py-4">
+      <div className="mx-4">
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="flex flex-col gap-4">
+          <div>
+            <Label htmlFor="bySearchTerm" className="mb-1 text-md">
+              Søk
+            </Label>
+            <TextInput placeholder="Søk etter arrangementer..." {...form.register("bySearchTerm")} id="bySearchTerm" />
+          </div>
+          <Controller
+            control={form.control}
+            name="byType"
+            render={({ field: { onChange, value } }) => (
+              <div>
+                <Label htmlFor="byType" className="mb-1 text-md">
+                  Type
+                </Label>
+                <Select value={value} onValueChange={onChange}>
+                  <SelectTrigger id="byType">
+                    <SelectValue />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="ALL" key="ALL">
+                        Alle
+                      </SelectItem>
+                      {EVENT_TYPE_OPTIONS.map((type) => (
+                        <SelectItem value={type.value} key={type.value}>
+                          {type.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="byOrganizingGroup"
+            render={({ field: { onChange, value } }) => (
+              <div>
+                <Label htmlFor="byOrganizingGroup" className="mb-1 text-md">
+                  Arrangør
+                </Label>
+                <GroupSelect onChange={onChange} groups={groups} value={value} />
+              </div>
+            )}
+          />
+        </form>
+      </div>
+    </div>
+  )
+}
+
+const GroupSelect = ({
+  value,
+  onChange,
+  groups,
+}: {
+  value?: string
+  onChange: (value: string | undefined) => void
+  groups: Group[]
+}) => {
+  const [search, setSearch] = useState("")
+
+  const filtered = useMemo(() => {
+    const searchValue = search.trim().toLowerCase()
+
+    return groups.filter((group) => group.slug === value || group.abbreviation.toLowerCase().includes(searchValue))
+  }, [search, groups, value])
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      setSearch("")
+    }
+  }
+
+  return (
+    <Select value={value} onValueChange={(val) => onChange(val)} onOpenChange={handleOpenChange}>
+      <SelectTrigger id="byOrganizingGroup">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="max-h-72" hideScrollUpButton>
+        <div
+          className="sticky top-0 z-10 -translate-y-1 p-2
+               bg-white dark:bg-stone-800
+               border-b border-gray-200 dark:border-stone-700"
+        >
+          <TextInput
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            placeholder="Søk…"
+          />
+        </div>
+
+        <SelectGroup>
+          <SelectItem value="ALL">Alle</SelectItem>
+          {filtered.map((group) => (
+            <SelectItem key={group.slug} value={group.slug}>
+              {group.abbreviation}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
   )
 }

--- a/apps/web/src/app/arrangementer/components/EventList.tsx
+++ b/apps/web/src/app/arrangementer/components/EventList.tsx
@@ -7,14 +7,19 @@ import { Text } from "@dotkomonline/ui"
 import { getCurrentUTC } from "@dotkomonline/utils"
 import { interval, isWithinInterval, subDays, subMilliseconds } from "date-fns"
 import { type FC, useEffect, useRef } from "react"
+import z from "zod"
 
 const OPENING_SOON_DAYS_THRESHOLD = 7 as const
+
+export const EventListViewModeSchema = z.enum(["BY_CATEGORY", "BY_DATE"])
+export type EventListViewMode = z.infer<typeof EventListViewModeSchema>
 
 interface EventListProps {
   futureEventWithAttendances: EventWithAttendance[]
   pastEventWithAttendances: EventWithAttendance[]
   onLoadMore?(): void
   alwaysShowChildEvents?: boolean
+  viewMode?: EventListViewMode
 }
 
 export const EventList: FC<EventListProps> = ({
@@ -22,6 +27,7 @@ export const EventList: FC<EventListProps> = ({
   pastEventWithAttendances: pastEvents,
   onLoadMore,
   alwaysShowChildEvents,
+  viewMode = "BY_CATEGORY",
 }: EventListProps) => {
   const now = getCurrentUTC()
   const session = useSession()
@@ -95,44 +101,67 @@ export const EventList: FC<EventListProps> = ({
 
   return (
     <section className="w-full flex flex-col gap-2">
-      {yourEvents.length > 0 && (
+      {viewMode === "BY_DATE" ? (
         <>
-          <Divider text="Dine arrangementer" />
-          {yourEvents.map(({ event, attendance }) => (
-            <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-          ))}
+          {futureEvents.length > 0 && (
+            <>
+              <Divider text="Kommende arrangementer" />
+              {futureEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
+          {pastEvents.length > 0 && (
+            <>
+              <Divider text="Tidligere arrangementer" />
+              {pastEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
         </>
-      )}
-      {openEvents.length > 0 && (
+      ) : (
         <>
-          <Divider text="Åpne arrangementer" />
-          {openEvents.map(({ event, attendance }) => (
-            <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-          ))}
-        </>
-      )}
-      {openingSoonEvents.length > 0 && (
-        <>
-          <Divider text="Åpner snart" />
-          {openingSoonEvents.map(({ event, attendance }) => (
-            <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-          ))}
-        </>
-      )}
-      {otherFutureEvents.length > 0 && (
-        <>
-          <Divider text="Kommende arrangementer" />
-          {otherFutureEvents.map(({ event, attendance }) => (
-            <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-          ))}
-        </>
-      )}
-      {pastEvents.length > 0 && (
-        <>
-          <Divider text="Tidligere arrangementer" />
-          {pastEvents.map(({ event, attendance }) => (
-            <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-          ))}
+          {yourEvents.length > 0 && (
+            <>
+              <Divider text="Dine arrangementer" />
+              {yourEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
+          {openEvents.length > 0 && (
+            <>
+              <Divider text="Åpne arrangementer" />
+              {openEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
+          {openingSoonEvents.length > 0 && (
+            <>
+              <Divider text="Åpner snart" />
+              {openingSoonEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
+          {otherFutureEvents.length > 0 && (
+            <>
+              <Divider text="Kommende arrangementer" />
+              {otherFutureEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
+          {pastEvents.length > 0 && (
+            <>
+              <Divider text="Tidligere arrangementer" />
+              {pastEvents.map(({ event, attendance }) => (
+                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+              ))}
+            </>
+          )}
         </>
       )}
       <div ref={loaderRef} />

--- a/apps/web/src/app/arrangementer/components/EventList.tsx
+++ b/apps/web/src/app/arrangementer/components/EventList.tsx
@@ -11,7 +11,7 @@ import z from "zod"
 
 const OPENING_SOON_DAYS_THRESHOLD = 7 as const
 
-export const EventListViewModeSchema = z.enum(["BY_CATEGORY", "BY_DATE"])
+export const EventListViewModeSchema = z.enum(["ATTENDANCE", "CHRONOLOGICAL"])
 export type EventListViewMode = z.infer<typeof EventListViewModeSchema>
 
 interface EventListProps {
@@ -27,7 +27,7 @@ export const EventList: FC<EventListProps> = ({
   pastEventWithAttendances: pastEvents,
   onLoadMore,
   alwaysShowChildEvents,
-  viewMode = "BY_CATEGORY",
+  viewMode = "ATTENDANCE",
 }: EventListProps) => {
   const now = getCurrentUTC()
   const session = useSession()
@@ -101,16 +101,12 @@ export const EventList: FC<EventListProps> = ({
 
   return (
     <section className="w-full flex flex-col gap-2">
-      {viewMode === "BY_DATE" ? (
+      {viewMode === "CHRONOLOGICAL" ? (
         <>
-          {futureEvents.length > 0 && (
-            <>
-              <Divider text="Kommende arrangementer" />
-              {futureEvents.map(({ event, attendance }) => (
-                <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
-              ))}
-            </>
-          )}
+          {futureEvents.length > 0 &&
+            futureEvents.map(({ event, attendance }) => (
+              <EventListItem event={event} attendance={attendance} userId={session?.sub ?? null} key={event.id} />
+            ))}
           {pastEvents.length > 0 && (
             <>
               <Divider text="Tidligere arrangementer" />

--- a/apps/web/src/app/arrangementer/page.tsx
+++ b/apps/web/src/app/arrangementer/page.tsx
@@ -56,6 +56,8 @@ const EventPage = () => {
     },
   })
 
+  const { data: groups } = useQuery(trpc.group.all.queryOptions())
+
   const handleViewChange = (newView: string) => {
     const params = new URLSearchParams(searchParams.toString())
 
@@ -104,16 +106,20 @@ const EventPage = () => {
           )}
         </div>
 
-        <TabsContent value="list" className="flex flex-col gap-4">
-          <EventFilters onChange={setFilter} />
-          {!isLoading && (
-            <EventList
-              futureEventWithAttendances={futureEventWithAttendances}
-              pastEventWithAttendances={pastEventWithAttendances}
-              onLoadMore={fetchNextPage}
-            />
-          )}
-          {isLoading && <EventListSkeleton />}
+        <TabsContent value="list" className="flex flex-col gap-4 md:flex-row">
+          <div className="md:w-[30%] w-full scroll">
+            <EventFilters onChange={setFilter} groups={groups ?? []} />
+          </div>
+          <div className="flex flex-col gap-8 md:w-[70%]">
+            {!isLoading && (
+              <EventList
+                futureEventWithAttendances={futureEventWithAttendances}
+                pastEventWithAttendances={pastEventWithAttendances}
+                onLoadMore={fetchNextPage}
+              />
+            )}
+            {isLoading && <EventListSkeleton />}
+          </div>
         </TabsContent>
 
         <TabsContent value="cal">

--- a/apps/web/src/app/arrangementer/page.tsx
+++ b/apps/web/src/app/arrangementer/page.tsx
@@ -55,7 +55,6 @@ const EventPage = () => {
       excludingType: isStaff ? [] : undefined,
       orderBy: "desc",
     },
-    page: { take: 1 },
   })
 
   const { data: groups } = useQuery(trpc.group.all.queryOptions())

--- a/apps/web/src/app/arrangementer/page.tsx
+++ b/apps/web/src/app/arrangementer/page.tsx
@@ -19,7 +19,7 @@ const EventPage = () => {
   const searchParams = useSearchParams()
   const now = roundToNearestMinutes(getCurrentUTC(), { roundingMethod: "floor" })
   const [filter, setFilter] = useState<EventFilterQuery>({})
-  const [viewMode, setViewMode] = useState<EventListViewMode>("BY_CATEGORY")
+  const [viewMode, setViewMode] = useState<EventListViewMode>("ATTENDANCE")
 
   const view = searchParams.get("view") || "list"
   const year = Number.parseInt(searchParams.get("y") || now.getFullYear().toString())

--- a/packages/ui/src/atoms/Select/Select.tsx
+++ b/packages/ui/src/atoms/Select/Select.tsx
@@ -59,8 +59,18 @@ export const SelectScrollDownButton = ({ className, ref, ...props }: SelectScrol
 )
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
 
-type SelectContentProps = React.ComponentPropsWithRef<typeof SelectPrimitive.Content>
-export const SelectContent = ({ className, children, position = "popper", ref, ...props }: SelectContentProps) => (
+type SelectContentProps = React.ComponentPropsWithRef<typeof SelectPrimitive.Content> & {
+  hideScrollUpButton?: boolean
+}
+
+export const SelectContent = ({
+  className,
+  children,
+  position = "popper",
+  ref,
+  hideScrollUpButton,
+  ...props
+}: SelectContentProps) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
@@ -80,7 +90,7 @@ export const SelectContent = ({ className, children, position = "popper", ref, .
       position={position}
       {...props}
     >
-      <SelectScrollUpButton />
+      {!hideScrollUpButton && <SelectScrollUpButton />}
       <SelectPrimitive.Viewport
         className={cn(
           "p-1",


### PR DESCRIPTION
Adds filters for type and organizing group, and an option to group the list by category or date.
On mobile the filters takes up a lot of space so maybe we should hide all of them except the search?

<img width="1904" height="1001" alt="image" src="https://github.com/user-attachments/assets/c85875f0-6d67-47d1-9102-a8cfa73b100c" />
<img width="1842" height="1081" alt="image" src="https://github.com/user-attachments/assets/851648c1-d198-409c-bb95-ccbf212b1431" />
<img width="512" height="594" alt="image" src="https://github.com/user-attachments/assets/3cd85223-f818-403e-ae5d-527eab49dbf9" />
<img width="899" height="944" alt="image" src="https://github.com/user-attachments/assets/3d954532-8b78-4db4-9c64-ccec2de36cc4" />
