### PR TITLE
Send transactional email upon event registration

### DIFF
--- a/apps/rpc/resources/email/event_attendance.mustache
+++ b/apps/rpc/resources/email/event_attendance.mustache
@@ -9,22 +9,24 @@
       <tbody>
         <tr style="width: 100%">
           <td>
-            <h2>Tilbakemelding på {{ eventName }}</h2>
-            <p>Hei, vi ønsker tilbakemelding på <a href="{{ eventLink }}">{{ eventName }}</a> som du deltok på {{ eventStart }}.</p>
+            <h2>Du er påmeldt {{ eventName }}</h2>
+            <p>Du har meldt deg på arrangementet {{ eventName }} hos Linjeforeningen Online.</p>
+            <br />
+            <a href="{{ eventLink }}">Les mer om arrangementet her</a>
           </td>
         </tr>
 
         <tr style="width: 100%">
           <td>
-            <p>Du kan svare her: <a href="{{ feedbackLink }}">{{ feedbackLink }}</a>.</p>
-            <p>Siste frist til å svare på skjemaet er {{ feedbackDeadline }}.</p>
-            <p>Eventuelle spørsmål sendes til <a href="mailto:{{ organizerEmail }}">{{ organizerEmail }}</a>.</p>
+            <h3>Avmelding</h3>
+            <p>Du har frem til {{ deregistrationDeadline }} å melde deg av arrangementet hvis du ombestemmer deg.</p>
+            <p>Mangel på oppmøte uten avmelding av arrangementet resulterer i prikk og/eller suspensjon. Du kan lese mer om prikkereglene på <a href="https://wiki.online.ntnu.no/info/innsikt-og-interface/prikkeregler/">Online sine nettsider</a></p>
           </td>
         </tr>
 
         <tr style="width: 100%">
           <h3 style="text-align: center">Linjeforeningen Online</h3>
-          <p style="text-align: center">Du mottar denne e-posten fordi du deltok på arrangementet {{ eventName }}</p>
+          <p style="text-align: center">Du mottar denne e-posten fordi du har meldt deg på arrangementet {{ eventName }}</p>
           <p style="text-align: center">Org. Nr. 992 548 045 &ndash; Høgskoleringen 5, 7034 Trondheim</p>
         </tr>
       </tbody>

--- a/apps/rpc/src/modules/email/email-template.ts
+++ b/apps/rpc/src/modules/email/email-template.ts
@@ -10,6 +10,7 @@ export type EmailType =
   | "COMPANY_COLLABORATION_NOTIFICATION"
   | "COMPANY_INVOICE_NOTIFICATION"
   | "FEEDBACK_FORM_LINK"
+  | "EVENT_ATTENDANCE"
 
 export interface EmailTemplate<TData, TType extends EmailType> {
   getSchema(): z.ZodSchema<TData>
@@ -103,6 +104,16 @@ export const emails = {
         organizerEmail: z.string().email(),
       }),
     getTemplate: async () => fsp.readFile(path.join(templates, "feedback_form_link.mustache"), "utf-8"),
+  }),
+  EVENT_ATTENDANCE: createEmailTemplate({
+    type: "EVENT_ATTENDANCE",
+    getSchema: () =>
+      z.object({
+        eventName: z.string(),
+        eventLink: z.string().url(),
+        deregistrationDeadline: z.string().transform((d) => formatDate(new TZDate(d), "eeee dd. MMMM", { locale: nb })),
+      }),
+    getTemplate: async () => fsp.readFile(path.join(templates, "event_attendance.mustache"), "utf-8"),
   }),
   // biome-ignore lint/suspicious/noExplicitAny: used for type inference only
 } satisfies Record<string, EmailTemplate<any, any>>

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@dotkomonline/logger": "workspace:*",
+    "@dotkomonline/utils": "workspace:*",
     "@prisma/client": "^6.8.2",
     "@testcontainers/postgresql": "^11.5.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,6 +885,9 @@ importers:
       '@dotkomonline/logger':
         specifier: workspace:*
         version: link:../logger
+      '@dotkomonline/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@prisma/client':
         specifier: ^6.8.2
         version: 6.8.2(prisma@6.8.2(typescript@5.9.2))(typescript@5.9.2)
@@ -16499,7 +16502,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(@babel/core@7.24.5)(react@19.1.1)
+      styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.7
       '@next/swc-darwin-x64': 15.4.7
@@ -17744,6 +17747,11 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+
+  styled-jsx@5.1.6(react@19.1.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.1
 
   sugarss@5.0.0(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
This cannot be merged right now, because this NEEDS an SQS queue to fulfill because there is a 14 mails per seconds limit on SES for our account.