### PR TITLE
Extend default query stale time to 5 minutes

### DIFF
--- a/apps/web/src/utils/trpc/QueryProvider.tsx
+++ b/apps/web/src/utils/trpc/QueryProvider.tsx
@@ -12,7 +12,7 @@ import {
   loggerLink,
   splitLink,
 } from "@trpc/client"
-import { secondsToMilliseconds } from "date-fns"
+import { minutesToMilliseconds } from "date-fns"
 import { type Dispatch, type PropsWithChildren, type SetStateAction, createContext, useContext, useState } from "react"
 import superjson from "superjson"
 import { TRPCProvider } from "./client"
@@ -44,8 +44,7 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
   const trpcConfig: CreateTRPCClientOptions<AppRouter> = {
     links: [
       loggerLink({
-        enabled: (opts) =>
-          env.NEXT_PUBLIC_ORIGIN === "development" || (opts.direction === "down" && opts.result instanceof Error),
+        enabled: (opts) => opts.direction === "down" && opts.result instanceof Error,
       }),
       splitLink({
         condition: (op) => op.type === "subscription",
@@ -77,10 +76,12 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: secondsToMilliseconds(30),
+            staleTime: minutesToMilliseconds(5),
+            retry: false,
           },
           mutations: {
             onError: console.error,
+            retry: false,
           },
         },
       })


### PR DESCRIPTION
It's quite jarring to see the event list refetch because the query takes a while. There is rather little data that needs this short of a stale time in my opinion as well.

Also disables retries of queries and mutations. This is especially important for mutations.