### PR TITLE
Remove `stop` method from TaskExecutor

### DIFF
--- a/apps/rpc/src/modules/core.ts
+++ b/apps/rpc/src/modules/core.ts
@@ -132,15 +132,10 @@ export function createThirdPartyClients(configuration: Configuration) {
  * For ease of mocking and testing, the function does not construct third-party clients like the AWS S3 client or the
  * Auth0 Management client. Instead it takes a `clients` parameter that holds the clients. This allows us to mock them
  * in tests without having to mock the entire service layer.
- *
- * NOTE: The `signal` variable can optionally be passed by the orchestrator of the service layer has been terminated.
- * Example cases where this is useful is listening for a SIGTERM or SIGKILL that can then be used to gracefully shut
- * down the TaskExecutor or EmailService SQS Queue listener.
  */
 export async function createServiceLayer(
   clients: ReturnType<typeof createThirdPartyClients>,
-  configuration: Configuration,
-  signal: AbortSignal | null = null
+  configuration: Configuration
 ) {
   async function executeAuditedTransaction<T>(fn: (tx: DBHandle) => Promise<T>, userId: UserId | null): Promise<T> {
     return clients.prisma.$transaction(async (tx) => {
@@ -223,8 +218,7 @@ export async function createServiceLayer(
     recurringTaskService,
     taskDiscoveryService,
     taskSchedulingService,
-    attendanceService,
-    signal
+    attendanceService
   )
 
   const workspaceService = configuration.WORKSPACE_ENABLED
@@ -258,7 +252,6 @@ export async function createServiceLayer(
     recurringTaskService,
     workspaceService,
     executeTransaction: clients.prisma.$transaction.bind(clients.prisma),
-    startTaskExecutor: () => taskExecutor.start(clients.prisma),
     // Do not use this directly, it is here for repl/script purposes only
     prisma: clients.prisma,
   }


### PR DESCRIPTION
The entire lifecycle of the background worker can be controlled by the AbortController.