### PR TITLE
Consistently name OpenTelemetry spans

### DIFF
--- a/apps/rpc/src/aws.ts
+++ b/apps/rpc/src/aws.ts
@@ -8,7 +8,7 @@ const logger = getLogger("rpc/aws")
 export async function identifyCallerIAMIdentity() {
   await trace
     .getTracer("@dotkomonline/rpc/aws-caller-identity")
-    .startActiveSpan("identifyCallerIAMIdentity", async (span) => {
+    .startActiveSpan("AWS/QueryCallingIdentity", async (span) => {
       try {
         const stsClient = new STSClient({ region: configuration.AWS_REGION })
         const identity = await stsClient.send(new GetCallerIdentityCommand({}))

--- a/apps/rpc/src/modules/email/email-service.ts
+++ b/apps/rpc/src/modules/email/email-service.ts
@@ -52,7 +52,7 @@ export function getEmailService(
   const logger = getLogger("email-service")
   const tracer = trace.getTracer("@dotkomonline/monoweb-rpc/email-service")
   async function processSqsMessage(message: Message): Promise<void> {
-    return await tracer.startActiveSpan("@dotkomonline/rpc/email-submission", async (span) => {
+    return await tracer.startActiveSpan("EmailService/SendEmail", async (span) => {
       try {
         {
           const queueUrl = configuration.AWS_SQS_QUEUE_EMAIL_DELIVERY
@@ -131,7 +131,7 @@ export function getEmailService(
 
   return {
     async send(source, replyTo, to, cc, bcc, subject, definition, data) {
-      return await tracer.startActiveSpan("EmailService#send", async (span) => {
+      return await tracer.startActiveSpan("EmailService/QueueEmail", async (span) => {
         try {
           logger.info(
             "Posting Email(From=%s, ReplyTo=%o, To=%o, Cc=%o, Bcc=%o, Subject=%s, TemplateType=%s) to SQS Queue",
@@ -203,7 +203,7 @@ export function getEmailService(
 
       let interval: ReturnType<typeof setTimeout> | null = null
       async function work() {
-        await tracer.startActiveSpan("@dotkomonline/rpc/email-delivery", { root: true }, async (span) => {
+        await tracer.startActiveSpan("EmailService/DiscoverEmails", { root: true }, async (span) => {
           try {
             // Queue the next recursive call as long as the abort controller hasn't been moved.
             function enqueueWork() {

--- a/apps/rpc/src/modules/task/task-executor.ts
+++ b/apps/rpc/src/modules/task/task-executor.ts
@@ -92,7 +92,7 @@ export function getLocalTaskExecutor(
       // as running regardless of whether the child transaction commits or rollbacks.
       logger.info("Running task", task.type, "with arguments", task.payload)
       await taskService.setTaskExecutionStatus(client, task.id, "RUNNING", "PENDING")
-      return await tracer.startActiveSpan(`TaskExecutor ${task.type}`, { root: true }, async (span) => {
+      return await tracer.startActiveSpan(`TaskExecutor/${task.type}`, { root: true }, async (span) => {
         span.setAttribute("rpc.service", "@dotkomonline/rpc")
         span.setAttribute("rpc.system", "trpc")
         try {

--- a/apps/rpc/src/modules/user/user-service.ts
+++ b/apps/rpc/src/modules/user/user-service.ts
@@ -292,7 +292,7 @@ export function getUserService(
         // track the call stack and timings of the operation.
         await trace
           .getTracer("@dotkomonline/rpc/user-service")
-          .startActiveSpan("UserService#discoverMembership", async (span) => {
+          .startActiveSpan("UserService/DiscoverMembership", async (span) => {
             // According to Semantic Conventions (https://opentelemetry.io/docs/specs/semconv/registry/attributes/user/)
             // we should set the user.id attribute on the span to the user's ID. It makes it easier to trace them across
             // logs as well.

--- a/apps/rpc/src/trpc.ts
+++ b/apps/rpc/src/trpc.ts
@@ -125,7 +125,7 @@ export const router = t.router
  */
 export const procedure = t.procedure.use(async ({ ctx, path, type, next }) => {
   return await trace.getTracer("@dotkomonline/rpc/trpc-request").startActiveSpan(
-    `tRPC ${type} ${path}`,
+    `tRPC/${type}/${path}`,
     {
       root: true,
     },


### PR DESCRIPTION
Slight adoptation of the RPC spans naming described in https://opentelemetry.io/blog/2025/how-to-name-your-spans/