### PR TITLE
Fix dependency injection in WorkspaceService

### DIFF
--- a/apps/rpc/src/modules/core.ts
+++ b/apps/rpc/src/modules/core.ts
@@ -224,9 +224,10 @@ export async function createServiceLayer(
     attendanceService
   )
 
-  const workspaceService = isGoogleWorkspaceFeatureEnabled(configuration)
-    ? getWorkspaceService(clients.workspaceDirectory, userService, groupService)
-    : null
+  const workspaceService =
+    isGoogleWorkspaceFeatureEnabled(configuration) && clients.workspaceDirectory !== null
+      ? getWorkspaceService(clients.workspaceDirectory, userService, groupService, configuration)
+      : null
 
   const authorizationService = getAuthorizationService()
 

--- a/apps/rpc/src/modules/workspace-sync/workspace-service.ts
+++ b/apps/rpc/src/modules/workspace-sync/workspace-service.ts
@@ -6,8 +6,8 @@ import { slugify } from "@dotkomonline/utils"
 import type { admin_directory_v1 } from "googleapis"
 import { GaxiosError, type GaxiosResponseWithHTTP2 } from "googleapis-common"
 import invariant from "tiny-invariant"
-import { configuration, isGoogleWorkspaceFeatureEnabled } from "../../configuration"
-import { IllegalStateError, NotFoundError } from "../../error"
+import type { ConfigurationWithGoogleWorkspace } from "../../configuration"
+import { NotFoundError } from "../../error"
 import type { GroupService } from "../group/group-service"
 import type { UserService } from "../user/user-service"
 
@@ -65,20 +65,75 @@ export interface WorkspaceService {
 }
 
 export function getWorkspaceService(
-  directory: admin_directory_v1.Admin | null,
+  directory: admin_directory_v1.Admin,
   userService: UserService,
-  groupService: GroupService
+  groupService: GroupService,
+  configuration: ConfigurationWithGoogleWorkspace
 ): WorkspaceService {
-  if (!isGoogleWorkspaceFeatureEnabled(configuration)) {
-    throw new IllegalStateError("Google Workspace integration is not enabled")
-  }
-  if (!directory) {
-    throw new IllegalStateError("Google Workspace directory could not be initialized")
-  }
-
   const logger = getLogger("workspace-sync-service")
 
-  const createRecoveryCodes = async (user: User): Promise<string[] | null> => {
+  function joinOnWorkspaceUserId(
+    groupMembers: GroupMember[],
+    workspaceUsers: admin_directory_v1.Schema$Member[]
+  ): UserAndWorkspaceMember[] {
+    const rightJoin: UserAndWorkspaceMember[] = []
+    const leftJoin = new Map<string, UserAndWorkspaceMember>()
+
+    for (const workspaceMember of workspaceUsers) {
+      invariant(workspaceMember.id, "Workspace member must have an ID")
+
+      // Duplicate in the argument, not from Google
+      if (leftJoin.get(workspaceMember.id)?.workspaceMember) {
+        throw new Error(`Duplicate workspace member ID found: ${workspaceMember.id}`)
+      }
+
+      leftJoin.set(workspaceMember.id, { groupMember: null, workspaceMember })
+    }
+
+    for (const groupMember of groupMembers) {
+      let entry = groupMember.workspaceUserId ? leftJoin.get(groupMember.workspaceUserId) : null
+      entry ??= { groupMember: null, workspaceMember: null }
+
+      // Duplicate in the argument, since workspaceUserId is unique in the database.
+      if (entry.groupMember) {
+        throw new Error(`Duplicate workspace user ID found: ${groupMember.workspaceUserId}`)
+      }
+
+      if (!entry.workspaceMember || !groupMember.workspaceUserId) {
+        rightJoin.push({ groupMember, workspaceMember: null })
+        continue
+      }
+
+      leftJoin.set(groupMember.workspaceUserId, { groupMember, workspaceMember: entry.workspaceMember })
+    }
+
+    return [...leftJoin.values()].concat(rightJoin)
+  }
+
+  function getKeys(localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string[] {
+    const keys = new Set<string>()
+
+    const baseKey = getKey(localResolvable, domain)
+
+    // In older versions of OnlineWeb, all dashes (-) were removed from the email local part.
+    // We add this to the set of keys to attempt to find an account created by the older version.
+    keys.add(baseKey)
+    keys.add(baseKey.replace("-", ""))
+
+    const names = getLocal(localResolvable).split(".").filter(Boolean)
+
+    // In older version of OnlineWeb, it was less common to have your full name on your profile.
+    // A lot of older accounts were generated with only first name and last name, so we attempt to
+    // find those accounts as well.
+    if (names.length > 2) {
+      keys.add(getEmail(`${names[0]} ${names.at(-1)}`, domain))
+      keys.add(getEmail(`${names[0]} ${names.at(-1)}`.replace("-", ""), domain))
+    }
+
+    return [...keys]
+  }
+
+  async function createRecoveryCodes(user: User): Promise<string[] | null> {
     await directory.verificationCodes.generate({
       userKey: getKey(user),
     })
@@ -92,6 +147,55 @@ export function getWorkspaceService(
     }
 
     return response.data.items.map((code) => code.verificationCode).filter(Boolean) as string[]
+  }
+
+  /**
+   * @example
+   * getEmail("user") // "user@online.ntnu.no"
+   * getEmail("user@online.ntnu.no") // "user@online.ntnu.no"
+   * getEmail("user", "custom.domain") // "user@custom.domain"
+   */
+  function getEmail(localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string {
+    const local = getLocal(localResolvable)
+
+    if (local.includes("@")) {
+      return local
+    }
+
+    return `${local}@${domain}`
+  }
+
+  /**
+   * Get a key for a user or a group.
+   * A key is used to identify something in Google Workspace. It can be the objects id or an email (primary or alias).
+   *
+   * @example
+   * getKey(user) // <Workspace id>
+   * getKey(userWithoutWorkspaceId) // "full.name@online.ntnu.no"
+   * getKey("Full Name") // "full.name@online.ntnu.no"
+   * getKey("full.name@online.ntnu.no") // "full.name@online.ntnu.no"
+   * getKey("string", "custom.domain") // "string@custom.domain"
+   */
+  function getKey(localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string {
+    if (typeof localResolvable === "object") {
+      if ("workspaceUserId" in localResolvable && localResolvable.workspaceUserId) {
+        return localResolvable.workspaceUserId
+      }
+
+      if ("workspaceGroupId" in localResolvable && localResolvable.workspaceGroupId) {
+        return localResolvable.workspaceGroupId
+      }
+    }
+
+    return getEmail(localResolvable, domain)
+  }
+
+  function getCommitteeEmail(fullName: string) {
+    if (!fullName.trim()) {
+      throw new Error("Invalid full name")
+    }
+
+    return getKey(slugify(fullName, SLUGIFY_OPTIONS))
   }
 
   return {
@@ -382,121 +486,11 @@ const getLocal = (localResolvable: User | Group | string): string => {
   return slugify(localResolvable.name, SLUGIFY_OPTIONS)
 }
 
-/**
- * @example
- * getEmail("user") // "user@online.ntnu.no"
- * getEmail("user@online.ntnu.no") // "user@online.ntnu.no"
- * getEmail("user", "custom.domain") // "user@custom.domain"
- */
-const getEmail = (localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string => {
-  const local = getLocal(localResolvable)
-
-  if (local.includes("@")) {
-    return local
-  }
-
-  return `${local}@${domain}`
-}
-
-/**
- * Get a key for a user or a group.
- * A key is used to identify something in Google Workspace. It can be the objects id or an email (primary or alias).
- *
- * @example
- * getKey(user) // <Workspace id>
- * getKey(userWithoutWorkspaceId) // "full.name@online.ntnu.no"
- * getKey("Full Name") // "full.name@online.ntnu.no"
- * getKey("full.name@online.ntnu.no") // "full.name@online.ntnu.no"
- * getKey("string", "custom.domain") // "string@custom.domain"
- */
-const getKey = (localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string => {
-  if (typeof localResolvable === "object") {
-    if ("workspaceUserId" in localResolvable && localResolvable.workspaceUserId) {
-      return localResolvable.workspaceUserId
-    }
-
-    if ("workspaceGroupId" in localResolvable && localResolvable.workspaceGroupId) {
-      return localResolvable.workspaceGroupId
-    }
-  }
-
-  return getEmail(localResolvable, domain)
-}
-
-const getKeys = (localResolvable: User | Group | string, domain = configuration.googleWorkspace.domain): string[] => {
-  const keys = new Set<string>()
-
-  const baseKey = getKey(localResolvable, domain)
-
-  // In older versions of OnlineWeb, all dashes (-) were removed from the email local part.
-  // We add this to the set of keys to attempt to find an account created by the older version.
-  keys.add(baseKey)
-  keys.add(baseKey.replace("-", ""))
-
-  const names = getLocal(localResolvable).split(".").filter(Boolean)
-
-  // In older version of OnlineWeb, it was less common to have your full name on your profile.
-  // A lot of older accounts were generated with only first name and last name, so we attempt to
-  // find those accounts as well.
-  if (names.length > 2) {
-    keys.add(getEmail(`${names[0]} ${names.at(-1)}`, domain))
-    keys.add(getEmail(`${names[0]} ${names.at(-1)}`.replace("-", ""), domain))
-  }
-
-  return [...keys]
-}
-
 const getTemporaryPassword = () => {
   return randomBytes(TEMPORARY_PASSWORD_LENGTH).toString("base64").slice(0, TEMPORARY_PASSWORD_LENGTH)
-}
-
-const getCommitteeEmail = (fullName: string) => {
-  if (!fullName.trim()) {
-    throw new Error("Invalid full name")
-  }
-
-  return getKey(slugify(fullName, SLUGIFY_OPTIONS))
 }
 
 type UserAndWorkspaceMember = {
   groupMember: GroupMember | null
   workspaceMember: admin_directory_v1.Schema$Member | null
-}
-
-const joinOnWorkspaceUserId = (
-  groupMembers: GroupMember[],
-  workspaceUsers: admin_directory_v1.Schema$Member[]
-): UserAndWorkspaceMember[] => {
-  const rightJoin: UserAndWorkspaceMember[] = []
-  const leftJoin = new Map<string, UserAndWorkspaceMember>()
-
-  for (const workspaceMember of workspaceUsers) {
-    invariant(workspaceMember.id, "Workspace member must have an ID")
-
-    // Duplicate in the argument, not from Google
-    if (leftJoin.get(workspaceMember.id)?.workspaceMember) {
-      throw new Error(`Duplicate workspace member ID found: ${workspaceMember.id}`)
-    }
-
-    leftJoin.set(workspaceMember.id, { groupMember: null, workspaceMember })
-  }
-
-  for (const groupMember of groupMembers) {
-    let entry = groupMember.workspaceUserId ? leftJoin.get(groupMember.workspaceUserId) : null
-    entry ??= { groupMember: null, workspaceMember: null }
-
-    // Duplicate in the argument, since workspaceUserId is unique in the database.
-    if (entry.groupMember) {
-      throw new Error(`Duplicate workspace user ID found: ${groupMember.workspaceUserId}`)
-    }
-
-    if (!entry.workspaceMember || !groupMember.workspaceUserId) {
-      rightJoin.push({ groupMember, workspaceMember: null })
-      continue
-    }
-
-    leftJoin.set(groupMember.workspaceUserId, { groupMember, workspaceMember: entry.workspaceMember })
-  }
-
-  return [...leftJoin.values()].concat(rightJoin)
 }


### PR DESCRIPTION
Previously this read configuration from the global. It should always read it as a dependency. Another benefit is that typing the dependency as `ConfigurationWithGoogleWorkspace` means that none of the credential values are nullable.