### PR TITLE
Add mark rules

### DIFF
--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -169,6 +169,8 @@ const EventContent = ({ event, attendance, parentEvent, parentAttendance, punish
       </div>
 
       <div className="flex flex-1 flex-col gap-8 sm:gap-4">
+        <div className="sm:hidden h-1 rounded-full w-full bg-gray-200" />
+        <TimeLocationBox event={event} />
         {attendance !== null && (
           <>
             <div className="sm:hidden h-1 rounded-full w-full bg-gray-200" />
@@ -182,10 +184,6 @@ const EventContent = ({ event, attendance, parentEvent, parentAttendance, punish
             />
           </>
         )}
-
-        <div className="sm:hidden h-1 rounded-full w-full bg-gray-200" />
-
-        <TimeLocationBox event={event} />
       </div>
     </div>
   )

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -21,6 +21,7 @@ import { useEffect, useState } from "react"
 import { getAttendanceStatus } from "../attendanceStatus"
 import { useDeregisterMutation, useRegisterMutation, useSetSelectionsOptionsMutation } from "./../mutations"
 import { AttendanceDateInfo } from "./AttendanceDateInfo"
+import { EventRules } from "./EventRules"
 import { MainPoolCard } from "./MainPoolCard"
 import { NonAttendablePoolsBox } from "./NonAttendablePoolsBox"
 import { PaymentExplanationDialog } from "./PaymentExplanationDialog"
@@ -237,14 +238,13 @@ export const AttendanceCard = ({
         isLoading={isLoading}
       />
 
-      <div className="flex flex-row flex-wrap gap-4 text-gray-800 hover:text-black dark:text-stone-400 dark:hover:text-stone-100 transition-colors">
-        {/* Removed until we add event rules */}
-        {/* <div className="flex flex-row gap-1 items-center cursor-pointer">
-          <Icon icon="tabler:book-2" className="text-lg" />
-          <Text className="text-sm">Arrangementregler</Text>
-        </div> */}
+      <div className="flex flex-row flex-wrap gap-4">
+        <EventRules className="text-slate-800 hover:text-black dark:text-stone-400 dark:hover:text-stone-100 transition-colors" />
 
-        <Link href="/innstillinger/profil" className="flex flex-row gap-1 items-center">
+        <Link
+          href="/innstillinger/profil"
+          className="flex flex-row gap-1 items-center text-slate-800 hover:text-black dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
+        >
           <Icon icon="tabler:edit" className="text-lg" />
           <Text className="text-sm">Oppdater matallergier</Text>
         </Link>

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/EventRules.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/EventRules.tsx
@@ -1,0 +1,57 @@
+import { PenaltyRules } from "@/utils/penalty-rules"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Icon,
+  Text,
+  cn,
+} from "@dotkomonline/ui"
+import { useState } from "react"
+
+interface EventRulesProps {
+  className?: string
+}
+
+export const EventRules = ({ className }: EventRulesProps) => {
+  const [open, setOpen] = useState(false)
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger>
+        <div className={cn("flex flex-row gap-1 items-center cursor-pointer", className)}>
+          <Icon icon="tabler:book-2" className="text-lg" />
+          <Text className="text-sm">Arrangementregler</Text>
+        </div>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        className="relative flex flex-col overflow-hidden max-h-[90vh]"
+        onOutsideClick={() => setOpen(false)}
+      >
+        <AlertDialogTitle className="text-2xl font-bold mb-1">Arrangementregler</AlertDialogTitle>
+        <AlertDialogDescription>
+          Ved påmelding av dette arrangementet godtar du å følge Onlines arrangementregler beskrevet under.
+        </AlertDialogDescription>
+        <section className="overflow-hidden">
+          <Accordion type="single" collapsible>
+            <AccordionItem value="eventRules">
+              <AccordionTrigger>Prikkeregler</AccordionTrigger>
+              <AccordionContent className="grow overflow-y-auto p-4 max-h-[300px]">
+                <PenaltyRules />
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </section>
+        <AlertDialogCancel variant={"solid"} color="brand" className="w-fit mx-auto">
+          Jeg er inneforstått med reglene
+        </AlertDialogCancel>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/web/src/app/profil/[profileSlug]/components/PenaltyDialog.tsx
+++ b/apps/web/src/app/profil/[profileSlug]/components/PenaltyDialog.tsx
@@ -1,0 +1,33 @@
+import { PenaltyRules } from "@/utils/penalty-rules"
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Icon,
+  Title,
+} from "@dotkomonline/ui"
+import { useState } from "react"
+
+export const PenaltyDialog = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger className="w-fit flex items-center gap-1 underline">
+        Hva er en prikk? <Icon icon="tabler:info-circle" />
+      </AlertDialogTrigger>
+      <AlertDialogContent className="max-h-[80vh]" onOutsideClick={() => setOpen(false)}>
+        <AlertDialogTitle asChild>
+          <Title>Online's Prikkeregler</Title>
+        </AlertDialogTitle>
+        <section className="overflow-y-auto max-h-[60vh] p-2">
+          <PenaltyRules />
+        </section>
+        <AlertDialogCancel variant={"solid"} color="brand" className="w-fit mx-auto">
+          Jeg er inneforstått med reglene
+        </AlertDialogCancel>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/web/src/app/profil/[profileSlug]/page.tsx
+++ b/apps/web/src/app/profil/[profileSlug]/page.tsx
@@ -40,6 +40,7 @@ import { nb } from "date-fns/locale"
 import Link from "next/link"
 import { notFound, useParams, useSearchParams } from "next/navigation"
 import { useMemo } from "react"
+import { PenaltyDialog } from "./components/PenaltyDialog"
 import SkeletonProfilePage from "./loading"
 
 const capitalizeFirstLetter = (str: string) => {
@@ -63,11 +64,7 @@ const renderUserInfo = (label: string, value: string | number | null) => {
   )
 }
 
-function MarkDisplay({
-  markInformation: { mark, personalMark },
-}: {
-  markInformation: VisiblePersonalMarkDetails
-}) {
+function MarkDisplay({ markInformation: { mark, personalMark } }: { markInformation: VisiblePersonalMarkDetails }) {
   const expires = getPunishmentExpiryDate(personalMark.createdAt, mark.duration)
   const hasExpired = isPast(expires)
 
@@ -138,7 +135,10 @@ function MarkDisplay({
 const MembershipDisplay = ({
   activeMembership,
   grade,
-}: { activeMembership: Membership | null; grade: number | null }) => {
+}: {
+  activeMembership: Membership | null
+  grade: number | null
+}) => {
   if (activeMembership) {
     return (
       <>
@@ -403,7 +403,10 @@ export default function ProfilePage() {
 
           {marks && marks.length > 0 && (
             <div className="flex flex-col gap-3">
-              <Title>Prikker og suspensjoner</Title>
+              <div>
+                <Title>Prikker og suspensjoner</Title>
+                <PenaltyDialog />
+              </div>
               <div className="flex flex-col gap-2">
                 {marks.map((markInfo) => (
                   <MarkDisplay key={markInfo.mark.id} markInformation={markInfo} />

--- a/apps/web/src/utils/penalty-rules.tsx
+++ b/apps/web/src/utils/penalty-rules.tsx
@@ -1,4 +1,3 @@
-import { env } from "@/env"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Text, Title } from "@dotkomonline/ui"
 import Image from "next/image"
 import Link from "next/link"
@@ -108,7 +107,7 @@ const WaitlistPolicy = () => (
   <section className="space-y-4">
     <Title className="font-bold">Venteliste</Title>
     <ul className="list-disc pl-6 space-y-2">
-      <li>Hvis du står på venteliste kan du melde deg av helt til arrangementet starter.</li>
+      <li>Hvis du står på venteliste kan du melde deg av helt til avmeldingsfristen.</li>
       <li>
         Når du står på venteliste er du inneforstått med at du når som helst kan få plass på arrangementet og dermed er
         bundet til reglene for arrangementet på lik linje med andre påmeldte.
@@ -172,7 +171,7 @@ const WhyHaveIGotMarks = () => {
       <Title className="font-bold">Hvorfor har jeg fått prikk?</Title>
       <Text>
         Under{" "}
-        <Link href={`${env.NEXT_PUBLIC_HOME_URL}profil`} className="text-blue-600 underline">
+        <Link href={"/profil"} className="text-blue-600 underline">
           Profil
         </Link>{" "}
         vil du kunne se prikkene dine, og eventuelle begrunnelser.

--- a/apps/web/src/utils/penalty-rules.tsx
+++ b/apps/web/src/utils/penalty-rules.tsx
@@ -1,65 +1,151 @@
-export const PenaltyRules = () => (
-  <div className="mb-8 flex flex-col space-y-4">
-    <h4>Hva er en prikk?</h4>
-    <p>
-      Det at du har aktive prikker innebærer at du vil måtte vente 24 timer etter ordinær påmeldingsstart for å melde
-      deg på et arrangement. Hver prikk varer i 20 dager, dersom du får ny prikk og du allerede har en aktiv prikk blir
-      de nye 20 dagene lagt til på slutten av virkeperioden til eksisterende prikk(er). Varigheten til prikker er fryst
-      i ferier. Disse er definert fra 1. desember til 15. januar og 1. juni til 15. august. Dersom en prikk gis 15. mai
-      vil altså denne prikken utløpe 20. august. Grunnen til at vi deler ut prikker er å sørge for at medlemmer følger
-      reglene.
-    </p>
-    <h4>Hva gir prikk?</h4>
-    <div className="flex flex-col space-y-3">
-      <p>Dette er en kort punktliste. Unntak og videre forklaringer finner du lenger ned.</p>
-      <ul className="ml-8 list-disc">
-        <li>Å melde seg av etter avmeldingsfristen.</li>
-        <li>Å ikke møte opp på et arrangement man har plass på.</li>
-        <li>Å møte opp etter arrangementets start eller innslipp er ferdig.</li>
-        <li>Å ikke svare på tilbakemeldingsskjema innen tidsfristen.</li>
-        <li>
-          Å ikke overholde betalingsfristen. Dette medfører i tillegg suspensjon fra alle Onlines arrangementer inntil
-          betaling er gjennomført.
-        </li>
-      </ul>
-      <p>Den ansvarlige komiteen kan også foreta en skjønnsmessig vurdering som gagner deltakeren.</p>
+import { env } from "@/env"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Text, Title } from "@dotkomonline/ui"
+import Image from "next/image"
+import Link from "next/link"
+
+export const PenaltyRules = () => {
+  return (
+    <div className="flex flex-col gap-6 ">
+      <WhatIsAMark />
+      <WhatGivesAMark />
+      <CancellationPolicy />
+      <WaitlistPolicy />
+      <PaymentPolicy />
+      <BehaviorPolicy />
+      <CompanyEventPolicy />
+      <WhyHaveIGotMarks />
     </div>
-    <h4>Avmelding</h4>
-    <ul className="ml-8 list-disc space-y-1">
+  )
+}
+
+const WhatIsAMark = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Hva er en prikk?</Title>
+    <Text>
+      Prikker er et straffetiltak for å sikre at medlemmene av Online følger reglene. Det at du har aktive prikker
+      innebærer at du vil måtte vente en viss periode etter ordinær påmeldingsstart for å melde deg på et arrangement.
+      Hver prikk varer i 14 dager fra tidspunktet du får den.
+    </Text>
+
+    <MarkTable />
+    <Text>
+      Prikker er overlappende. Dette betyr at dersom du får nye prikker når du allerede har aktive prikker fra en annen
+      anledning, så vil disse prikkene plusses sammen. Hver anledning som har gitt deg prikker vil ha sin egen levetid
+      før de ikke er aktive lenger.
+    </Text>
+
+    <Title size={"lg"} className="font-semibold mt-4">
+      Eksempel
+    </Title>
+    <Text>
+      Du får 2 prikker for å melde deg av et arrangement sent. Nå har du fire timers utsettelse på alle påmeldinger.
+      Fire dager senere får du to nye prikker for å ikke ha sendt inn tilbakemeldingsskjema innen tidsfristen. Nå vil du
+      i ti dager fremover ha totalt 4 aktive prikker og dermed ha 24 timers utsettelse på alle påmeldinger. Etter disse
+      ti dagene vil de to første prikkene løpe ut og du vil da kun ha to aktive prikker i fire dager. Dette medfører
+      fire timers utsettelse på påmeldinger.
+    </Text>
+
+    <Text className="italic">Eksempelet visualisert:</Text>
+    <Image
+      src="https://s3.eu-north-1.amazonaws.com/cdn.online.ntnu.no/web/prikkeregler-visualisation.png"
+      alt="Eksempel på prikker"
+      className="w-auto h-auto"
+      width={700}
+      height={400}
+    />
+
+    <Title size={"md"} className="font-semibold mt-4">
+      Ferier
+    </Title>
+    <Text>
+      Varigheten til prikker er fryst i ferier. Disse er definert fra 5. desember til 10. januar og 1. juni til 15.
+      august. Dersom en prikk gis 24. mai vil altså denne prikken utløpe 20. august.
+    </Text>
+  </section>
+)
+
+const WhatGivesAMark = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Hva gir prikker?</Title>
+    <Text>Dette er en kort punktliste. Unntak og videre forklaringer finner du lenger ned.</Text>
+    <ul className="list-disc pl-6 space-y-2 ">
       <li>
-        Ved sykdom eller andre ekstraordinære hendelser vil man ikke få prikk ved avmelding 5 timer før
-        arrangementsstart.
+        Å melde seg av etter avmeldingsfristen inntil 2 timer før arrangementstart gir 2 prikker, etter dette gis det 3
+        prikker.
       </li>
+      <li>Å ikke møte opp på et arrangement man har plass på gir 3 prikker.</li>
       <li>
-        Alle komiteer ønsker at du melder deg av arrangementer selv om du vet dette vil medføre prikk. Dette er slik at
-        noen andre kan bli obs på plassen sin så tidlig som mulig.
+        Å møte opp etter arrangementets start eller innslipp er ferdig gir i utgangspunktet 3 prikker. Her vil en
+        skjønnsmessig vurdering bli foretatt ut fra hvor sent deltakeren ankom arrangementet.
+      </li>
+      <li>Å ikke svare på tilbakemeldingsskjema innen tidsfristen gir 2 prikker.</li>
+      <li>
+        Å ikke overholde betalingsfristen gir 1 prikk. Dette medfører i tillegg suspensjon fra alle Onlines
+        arrangementer inntil betaling er gjennomført.
       </li>
     </ul>
-    <h4>Venteliste</h4>
-    <ul className="ml-8 list-disc space-y-1">
+    <Text>Den ansvarlige komiteen kan også foreta en skjønnsmessig vurdering som gagner deltakeren.</Text>
+  </section>
+)
+
+const CancellationPolicy = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Avmelding</Title>
+    <ul className="list-disc pl-6 space-y-2">
+      <li>
+        Ved sykdom eller andre ekstraordinære hendelser vil man ikke få prikk ved avmelding 5 timer før
+        arrangementsstart. Etter dette gis prikker som normalt iht. punktene over.
+      </li>
+      <li>
+        Alle komiteer ønsker at du melder deg av arrangementer selv om du vet dette vil medføre prikker. Dette er slik
+        at noen andre kan bli obs på plassen sin så tidlig som mulig.
+      </li>
+    </ul>
+  </section>
+)
+
+const WaitlistPolicy = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Venteliste</Title>
+    <ul className="list-disc pl-6 space-y-2">
       <li>Hvis du står på venteliste kan du melde deg av helt til arrangementet starter.</li>
       <li>
         Når du står på venteliste er du inneforstått med at du når som helst kan få plass på arrangementet og dermed er
         bundet til reglene for arrangementet på lik linje med andre påmeldte.
       </li>
     </ul>
-    <h4>Betaling</h4>
-    <ul className="ml-8 list-disc space-y-1">
+  </section>
+)
+
+const PaymentPolicy = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Betaling</Title>
+    <ul className="list-disc pl-6 space-y-2">
       <li>Ved manglende betaling suspenderes man fra alle Onlines arrangementer inntil betalingen er gjennomført.</li>
       <li>
         Ved betalt arrangement, men manglende oppmøte, vil man ikke få tilbakebetalt dersom avmelding skjer etter frist.
         Dersom neste på venteliste er tilgjengelig kan dette gjøres unntak for.
       </li>
     </ul>
-    <h4>Oppførsel</h4>
-    <ul className="ml-8 list-disc space-y-1">
+  </section>
+)
+
+const BehaviorPolicy = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Oppførsel</Title>
+    <ul className="list-disc pl-6 space-y-2">
       <li>
         Ved upassende oppførsel under et av Onlines arrangement vil du stå økonomisk ansvarlig for eventuelle skader, og
         i verste fall risikere utestengelse fra alle Onlines arrangement.
       </li>
     </ul>
-    <h4>Bedriftspresentasjoner</h4>
-    <ul className="ml-8 list-disc space-y-1">
+  </section>
+)
+
+const CompanyEventPolicy = () => (
+  <section className="space-y-4">
+    <Title className="font-bold">Bedriftsarrangementer</Title>
+    <ul className="list-disc pl-6 space-y-2">
       <li>
         Ved bedriftsarrangementer åpner dørene i henhold til starttid på arrangementet. Ti minutter etter at dørene
         åpner slippes oppmøte på ventelisten inn dersom det er plass. 15 minutter etter at dørene åpner stenger
@@ -67,18 +153,83 @@ export const PenaltyRules = () => (
       </li>
       <li>
         Det kreves at en deltaker svarer på den elektroniske tilbakemeldingen etter bedriftsarrangementer. Det vil komme
-        e-post etter arrangementet med lenke til tilbakemeldingsskjema som må besvares innen denoppgitte fristen. Dersom
-        en deltager ikke svarer innen fristen vil dette gi en prikk.
+        e-post etter arrangementet med lenke til tilbakemeldingsskjema som må besvares innen den oppgitte fristen.
+        Dersom en deltaker ikke svarer innen fristen, vil dette gi to prikker.
+      </li>
+      <li>
+        Deltakere på bedriftsarrangementer skal delta på alle obligatoriske deler av arrangementet. For
+        bedriftspresentasjon og kurs vil dette henholdsvis innebære selve presentasjonen og kursopplegget. De første 45
+        minuttene med påfølgende mingling regnes også som obligatorisk. Dersom en deltaker forlater den obligatoriske
+        delen uten gyldig grunn vil dette medføre 2 prikker.
       </li>
     </ul>
-    <h4>Hvorfor har jeg fått prikk?</h4>
-    <p>
-      Under &rdquo;Min profil&rdquo; og &rdquo;Prikker og suspensjoner&rdquo; {/*TODO - Legg til linken*/} vil du kunne
-      se prikkene dine, og eventuelle begrunnelser.
-    </p>
-    <p>
-      Dersom du mener noe feil har skjedd, vennligst ta kontakt med arrangøren som står oppført på arrangementet.
-      Kontaktinfo for arrangerende komité vises på arrangementssiden.
-    </p>
-  </div>
+  </section>
+)
+
+const WhyHaveIGotMarks = () => {
+  return (
+    <section className="space-y-4">
+      <Title className="font-bold">Hvorfor har jeg fått prikk?</Title>
+      <Text>
+        Under{" "}
+        <Link href={`${env.NEXT_PUBLIC_HOME_URL}profil`} className="text-blue-600 underline">
+          Profil
+        </Link>{" "}
+        vil du kunne se prikkene dine, og eventuelle begrunnelser.
+      </Text>
+      <Text>
+        Dersom du mener noe feil har skjedd, vennligst ta kontakt med arrangøren som står oppført på arrangementet.
+        Kontaktinfo for arrangerende komité vises på arrangementssiden.
+      </Text>
+    </section>
+  )
+}
+
+const MarkTable = () => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>
+          <Text className="font-bold">Antall prikker</Text>
+        </TableHead>
+        <TableHead>
+          <Text className="font-bold">Utsettelse på påmeldinger</Text>
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>
+          <Text>1 prikk</Text>
+        </TableCell>
+        <TableCell>
+          <Text>1t</Text>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Text>2 prikker</Text>
+        </TableCell>
+        <TableCell>
+          <Text>4t</Text>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Text>3 prikker</Text>
+        </TableCell>
+        <TableCell>
+          <Text>24t</Text>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Text>6+ prikker</Text>
+        </TableCell>
+        <TableCell>
+          <Text>Suspensjon i 14 dager fra siste prikk</Text>
+        </TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
 )

--- a/packages/ui/src/molecules/Dialog/Dialog.tsx
+++ b/packages/ui/src/molecules/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 import type { ComponentPropsWithRef, ComponentPropsWithoutRef, FC } from "react"
-import { Button } from "../../atoms/Button/Button"
+import { Button, ButtonProps } from "../../atoms/Button/Button"
 import { cn } from "../../utils"
 
 export const AlertDialog = AlertDialogPrimitive.Root
@@ -27,7 +27,7 @@ export const AlertDialogOverlay: FC<ComponentPropsWithRef<typeof AlertDialogPrim
   return (
     <AlertDialogPrimitive.Overlay
       className={cn(
-        "animate-in fade-in bg-slate-50/50 fixed inset-0 z-50 backdrop-blur-xs transition-opacity",
+        "animate-in fade-in bg-slate-50/50 dark:bg-slate-950/50 fixed inset-0 z-50 backdrop-blur-xs transition-opacity",
         className
       )}
       {...props}
@@ -47,7 +47,7 @@ export const AlertDialogContent: FC<AlertDialogContentProps> = ({ className, ref
       <AlertDialogPrimitive.Content
         ref={ref}
         className={cn(
-          "animate-in fade-in-90 slide-in-from-bottom-10 sm:zoom-in-90 sm:slide-in-from-bottom-0 bg-gray-200 fixed z-50 grid w-full max-w-[95%] sm:max-w-lg scale-100 gap-4 p-6 opacity-100 rounded-lg md:w-full",
+          "animate-in fade-in-90 slide-in-from-bottom-10 sm:zoom-in-90 sm:slide-in-from-bottom-0 bg-slate-200 dark:bg-stone-800 fixed z-50 grid w-full max-w-[95%] sm:max-w-lg scale-100 gap-4 p-6 opacity-100 rounded-lg md:w-full",
           className
         )}
         {...props}
@@ -77,7 +77,13 @@ export const AlertDialogDescription: FC<ComponentPropsWithRef<typeof AlertDialog
   ref,
   ...props
 }) => {
-  return <AlertDialogPrimitive.Description ref={ref} className={cn("text-gray-900 text-md", className)} {...props} />
+  return (
+    <AlertDialogPrimitive.Description
+      ref={ref}
+      className={cn("text-gray-900 dark:text-stone-100/80 text-md", className)}
+      {...props}
+    />
+  )
 }
 
 export type AlertDialogActionProps = Omit<ComponentPropsWithRef<typeof AlertDialogPrimitive.Action>, "color"> & {
@@ -88,12 +94,21 @@ export const AlertDialogAction: FC<AlertDialogActionProps> = ({ className, ref, 
   return <Button element={AlertDialogPrimitive.Action} {...props} ref={ref} color={destructive ? "red" : undefined} />
 }
 
-export const AlertDialogCancel: FC<Omit<ComponentPropsWithRef<typeof AlertDialogPrimitive.Cancel>, "color">> = ({
+export const AlertDialogCancel: FC<ComponentPropsWithRef<typeof AlertDialogPrimitive.Cancel> & ButtonProps> = ({
   className,
+  color,
   ref,
   ...props
 }) => {
   return (
-    <Button element={AlertDialogPrimitive.Cancel} className={className} {...props} variant="text" size="lg" ref={ref} />
+    <Button
+      element={AlertDialogPrimitive.Cancel}
+      className={className}
+      {...props}
+      variant={props.variant ?? "text"}
+      size={props.size ?? "lg"}
+      color={color}
+      ref={ref}
+    />
   )
 }

--- a/packages/ui/src/molecules/Dialog/Dialog.tsx
+++ b/packages/ui/src/molecules/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 import type { ComponentPropsWithRef, ComponentPropsWithoutRef, FC } from "react"
-import { Button, ButtonProps } from "../../atoms/Button/Button"
+import { Button, type ButtonProps } from "../../atoms/Button/Button"
 import { cn } from "../../utils"
 
 export const AlertDialog = AlertDialogPrimitive.Root


### PR DESCRIPTION
## Description
Added "EventRules" for explaining rules tied to events. Specifically the Mark/Penalty rules

## Changelog
- Added EventRules
- Updated `penalty-rules.tsx` to the new current rules
- Forwared props from Button into AlertCancel for easier styling and for preventing "Expected one parent element"-error
- Moved `TimeLocationBox` before `AttendenceCard` because the majority of "event-checking" are for seeing the date & time
- Styled for both light and darkmode

<img width="500" height="300" alt="Screenshot 2025-09-29 at 13 04 32" src="https://github.com/user-attachments/assets/85967324-9128-4a3b-b8fd-4270b97a0668" />

<img width="500" height="300" alt="Screenshot 2025-09-29 at 13 04 47" src="https://github.com/user-attachments/assets/b0cc224d-4114-4ee6-a5eb-2e6df10e40aa" />
