### PR TITLE
Reset state after transaction

### DIFF
--- a/apps/rpc/src/modules/core.ts
+++ b/apps/rpc/src/modules/core.ts
@@ -135,9 +135,13 @@ export async function createServiceLayer(
 ) {
   async function executeAuditedTransaction<T>(fn: (tx: DBHandle) => Promise<T>, userId: UserId | null): Promise<T> {
     return clients.prisma.$transaction(async (tx) => {
-      await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId || null}, TRUE)`
+      await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId || "NULL"}, TRUE)`
 
-      return fn(tx)
+      const result = await fn(tx)
+
+      await tx.$executeRaw`SELECT set_config('app.current_user_id', NULL, TRUE)`
+
+      return result
     })
   }
 


### PR DESCRIPTION
This fixes audit logs incorrectly crediting people and/or crashing when running tasks