### PR TITLE
Rename joblisting deadlineAsap

### DIFF
--- a/apps/dashboard/src/app/(internal)/job-listing/[id]/edit-card.tsx
+++ b/apps/dashboard/src/app/(internal)/job-listing/[id]/edit-card.tsx
@@ -26,7 +26,7 @@ export const JobListingEditCard: FC = () => {
       title: jobListing.title,
       applicationLink: jobListing.applicationLink,
       deadline: jobListing.deadline,
-      deadlineAsap: jobListing.deadlineAsap,
+      rollingAdmission: jobListing.rollingAdmission,
       employment: jobListing.employment,
       featured: jobListing.featured,
       locationIds: jobListing.locations.map((location) => location.name),

--- a/apps/dashboard/src/app/(internal)/job-listing/write-form.tsx
+++ b/apps/dashboard/src/app/(internal)/job-listing/write-form.tsx
@@ -103,7 +103,7 @@ export const useJobListingWriteForm = ({
         placeholder: "apply@company.com",
         type: "email",
       }),
-      deadlineAsap: createCheckboxInput({
+      rollingAdmission: createCheckboxInput({
         label: "Frist så snart som mulig",
       }),
       locationIds: createTagInput({

--- a/apps/rpc/src/mock.ts
+++ b/apps/rpc/src/mock.ts
@@ -38,6 +38,6 @@ export const getJobListingMock = (defaults: Partial<JobListingWrite> = {}): JobL
   employment: "FULLTIME",
   applicationLink: "https://example.com",
   applicationEmail: "hello@example.com",
-  deadlineAsap: false,
+  rollingAdmission: false,
   ...defaults,
 })

--- a/apps/web/src/app/karriere/[id]/page.tsx
+++ b/apps/web/src/app/karriere/[id]/page.tsx
@@ -147,9 +147,9 @@ interface DeadlineProps {
 }
 
 const Deadline = ({ jobListing }: DeadlineProps) => {
-  const { deadline, deadlineAsap } = jobListing
+  const { deadline, rollingAdmission } = jobListing
 
-  if (deadlineAsap) {
+  if (rollingAdmission) {
     return <Text>Frist fortløpende</Text>
   }
 

--- a/apps/web/src/app/karriere/[id]/page.tsx
+++ b/apps/web/src/app/karriere/[id]/page.tsx
@@ -82,14 +82,6 @@ const ApplicationInfoBox = ({ jobListing }: ApplicationInfoBoxProps) => {
       </div>
 
       <div className="flex flex-row gap-2 items-center">
-        <Icon icon="tabler:calendar-event" width={20} height={20} />
-        <div className="flex flex-col gap-0.5">
-          {jobListing.start && <Text>Starter {formatDate(jobListing.start, "dd. MMM yyyy")}</Text>}
-          {jobListing.end && <Text>Slutter {formatDate(jobListing.end, "dd. MMM yyyy")}</Text>}
-        </div>
-      </div>
-
-      <div className="flex flex-row gap-2 items-center">
         <Icon icon="tabler:briefcase" width={20} height={20} />
         <EmploymentType employment={jobListing.employment} />
       </div>

--- a/apps/web/src/app/karriere/page.tsx
+++ b/apps/web/src/app/karriere/page.tsx
@@ -158,9 +158,7 @@ const CompanyAdListItem: FC<CompanyAdListItemProps> = ({ jobListing }: CompanyAd
               </div>
               <div className="flex flex-row gap-1 items-center">
                 <Icon width={16} icon={"tabler:clock-hour-3"} />
-                <Text>
-                  Lagt ut for {formatDistanceToNowStrict(jobListing.start, { locale: nb, addSuffix: true })}
-                </Text>
+                <Text>Lagt ut for {formatDistanceToNowStrict(jobListing.start, { locale: nb, addSuffix: true })}</Text>
               </div>
             </div>
             <div className="flex flex-col items-end gap-1">

--- a/apps/web/src/app/karriere/page.tsx
+++ b/apps/web/src/app/karriere/page.tsx
@@ -159,7 +159,7 @@ const CompanyAdListItem: FC<CompanyAdListItemProps> = ({ jobListing }: CompanyAd
               <div className="flex flex-row gap-1 items-center">
                 <Icon width={16} icon={"tabler:clock-hour-3"} />
                 <Text>
-                  Lagt ut for {formatDistanceToNowStrict(jobListing.createdAt, { locale: nb, addSuffix: true })}
+                  Lagt ut for {formatDistanceToNowStrict(jobListing.start, { locale: nb, addSuffix: true })}
                 </Text>
               </div>
             </div>

--- a/packages/db/prisma/migrations/20251005130233_rename_deadline_asap_to_rolling_admission/migration.sql
+++ b/packages/db/prisma/migrations/20251005130233_rename_deadline_asap_to_rolling_admission/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "job_listing" RENAME COLUMN "deadlineAsap" to "rollingAdmission";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -444,8 +444,8 @@ model JobListing {
   employment       EmploymentType
   applicationLink  String?
   applicationEmail String?
-  // TODO: Find a better name for this
-  deadlineAsap     Boolean
+  ///Applications are reviewed as soon as they are submitted
+  rollingAdmission Boolean
 
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @db.Timestamptz(3)

--- a/packages/db/src/fixtures/job-listing.ts
+++ b/packages/db/src/fixtures/job-listing.ts
@@ -28,7 +28,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       employment: employments.fulltime,
       applicationLink: "https://bekk.no/jobs", // Placeholder link
       applicationEmail: "bekk@bekk.no",
-      deadlineAsap: false, // Placeholder value
+      rollingAdmission: false, // Placeholder value
     },
     {
       companyId: companyIds[1],
@@ -43,7 +43,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       employment: employments.other,
       applicationLink: "https://www.jrc.no/jobs", // Placeholder link
       applicationEmail: "test@jrc.no",
-      deadlineAsap: false, // Placeholder value
+      rollingAdmission: false, // Placeholder value
     },
     {
       companyId: companyIds[1],
@@ -59,7 +59,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-10-19T23:55:55+02:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -76,7 +76,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-10-22T23:59:00+02:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.parttime,
     },
     {
@@ -93,7 +93,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-05T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -110,7 +110,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-12-01T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -127,7 +127,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-02T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -144,7 +144,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-05T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -160,7 +160,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-10-31T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -176,7 +176,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-30T23:59:59+01:00"),
-      deadlineAsap: true,
+      rollingAdmission: true,
       employment: employments.fulltime,
     },
     {
@@ -192,7 +192,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-10-31T23:59:59+01:00"),
-      deadlineAsap: true,
+      rollingAdmission: true,
       employment: employments.fulltime,
     },
     {
@@ -209,7 +209,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-01T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -226,7 +226,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-11-12T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.internship,
     },
     {
@@ -244,7 +244,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: new Date("2023-10-31T23:59:59+01:00"),
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.fulltime,
     },
     {
@@ -261,7 +261,7 @@ export const getJobListingFixtures = (companyIds: string[]) =>
       featured: false,
       hidden: false,
       deadline: null,
-      deadlineAsap: false,
+      rollingAdmission: false,
       employment: employments.fulltime,
     },
   ] as const satisfies Prisma.JobListingCreateManyInput[]


### PR DESCRIPTION
* Renames joblisting#deadlineAsap to rollingAdmission
* Uses joblisting#start instead of createdAt to show when the jobListing was posted
* Hides start and end in karriere/[id] because Bedkom asked for it



closes MONO-759