### PR TITLE
Remove turborepo from RPC docker build

### DIFF
--- a/apps/rpc/Dockerfile
+++ b/apps/rpc/Dockerfile
@@ -29,6 +29,5 @@ RUN adduser --system --uid 1001 rpc
 USER rpc
 
 COPY --from=installer --chown=rpc:nodejs --chmod=755 /app .
-COPY --from=builder --chown=rpc:nodejs --chmod=755 /app/out/full .
 
 CMD node --loader ./apps/rpc/runtime.mjs --experimental-strip-types ./apps/rpc/src/bin/server.ts


### PR DESCRIPTION
Should fix the zod v4 stuff happening in production