### PR TITLE
Use CloudFront base url for uploaded files

### DIFF
--- a/apps/dashboard/src/app/(internal)/offline/use-s3-upload-file.ts
+++ b/apps/dashboard/src/app/(internal)/offline/use-s3-upload-file.ts
@@ -1,10 +1,11 @@
 import { env } from "@/lib/env"
 import { uploadFileToS3PresignedUrl } from "@/lib/s3"
 import { useTRPC } from "@/lib/trpc-client"
+import { createCloudFrontUrl } from "@dotkomonline/utils"
 import { notifications } from "@mantine/notifications"
 import { useMutation } from "@tanstack/react-query"
 
-const TEST_MODE_IMG_URL = "https://s3.eu-north-1.amazonaws.com/cdn.online.ntnu.no/img1.jpeg"
+const TEST_MODE_IMG_URL = "https://cdn.online.ntnu.no/img1.jpeg"
 
 export const useS3UploadFile = () => {
   const trpc = useTRPC()
@@ -16,7 +17,9 @@ export const useS3UploadFile = () => {
         filename: `${file.name}`,
         mimeType: file.type,
       })
-      return await uploadFileToS3PresignedUrl(file, presignedPost.fields, presignedPost.url)
+      await uploadFileToS3PresignedUrl(file, presignedPost.fields, presignedPost.url)
+
+      return createCloudFrontUrl(env.AWS_CLOUDFRONT_URL, presignedPost.fields.key)
     }
 
     notifications.show({

--- a/apps/dashboard/src/lib/env.ts
+++ b/apps/dashboard/src/lib/env.ts
@@ -28,4 +28,9 @@ export const env = defineConfiguration({
   }),
   // Feature toggle for uploading files to S3. If disabled, uploads are faked and replaced with static URL
   S3_UPLOAD_ENABLED: config(process.env.S3_UPLOAD_ENABLED, "true"),
+  AWS_CLOUDFRONT_URL: config(process.env.AWS_CLOUDFRONT_URL, {
+    prd: "https://cdn.online.ntnu.no",
+    stg: "https://cdn.staging.online.ntnu.no",
+    dev: "https://cdn.staging.online.ntnu.no",
+  }),
 })

--- a/apps/dashboard/src/lib/s3.ts
+++ b/apps/dashboard/src/lib/s3.ts
@@ -1,3 +1,6 @@
+import { createCloudFrontUrl } from "@dotkomonline/utils"
+import { env } from "./env"
+
 // Expected response: 204 No Content
 export async function uploadFileToS3PresignedUrl(
   file: File,
@@ -24,7 +27,7 @@ export async function uploadFileToS3PresignedUrl(
       throw new Error("File upload failed: No location header")
     }
 
-    return location
+    return createCloudFrontUrl(env.AWS_CLOUDFRONT_URL, fields.key)
   } catch (e) {
     throw new Error(`File upload failed: ${e}`)
   }

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -28,4 +28,9 @@ export const env = defineConfiguration({
     dev: "http://localhost:3002",
   }),
   NEXT_PUBLIC_HOME_URL: config(process.env.NEXT_PUBLIC_HOME_URL, "/"),
+  AWS_CLOUDFRONT_URL: config(process.env.AWS_CLOUDFRONT_URL, {
+    prd: "https://cdn.online.ntnu.no",
+    stg: "https://cdn.staging.online.ntnu.no",
+    dev: "https://cdn.staging.online.ntnu.no",
+  }),
 })

--- a/apps/web/src/s3.ts
+++ b/apps/web/src/s3.ts
@@ -1,4 +1,6 @@
+import { createCloudFrontUrl } from "@dotkomonline/utils"
 import { useMutation } from "@tanstack/react-query"
+import { env } from "./env"
 import { useTRPC } from "./utils/trpc/client"
 
 /**
@@ -47,6 +49,8 @@ export const useCreateAvatarUploadURL = () => {
   const presignedPostMut = useMutation(trpc.user.createAvatarUploadURL.mutationOptions())
   return async (file: File) => {
     const presignedPost = await presignedPostMut.mutateAsync()
-    return await uploadFileToS3PresignedUrl(file, presignedPost.fields, presignedPost.url)
+    await uploadFileToS3PresignedUrl(file, presignedPost.fields, presignedPost.url)
+
+    return createCloudFrontUrl(env.AWS_CLOUDFRONT_URL, presignedPost.fields.key)
   }
 }

--- a/packages/utils/src/urls.ts
+++ b/packages/utils/src/urls.ts
@@ -84,3 +84,7 @@ export const createAbsoluteEventPageUrl = (
 
   return `${origin}/arrangementer/${slug}/${eventId}`
 }
+
+export const createCloudFrontUrl = (cloudFrontUrl: string, key: string): string => {
+  return new URL(key, cloudFrontUrl).toString()
+}


### PR DESCRIPTION
Stores uploaded files as `https://cdn.online.ntnu.no/{key}` instead of using the s3 url for articles, offlines and avatars