### PR TITLE
Update mark rules link in emails

### DIFF
--- a/apps/rpc/resources/email/event_attendance.mustache
+++ b/apps/rpc/resources/email/event_attendance.mustache
@@ -20,14 +20,16 @@
           <td>
             <h3>Avmelding</h3>
             <p>Du har frem til {{ deregistrationDeadline }} å melde deg av arrangementet hvis du ombestemmer deg.</p>
-            <p>Mangel på oppmøte uten avmelding av arrangementet resulterer i prikk og/eller suspensjon. Du kan lese mer om prikkereglene på <a href="https://wiki.online.ntnu.no/info/innsikt-og-interface/prikkeregler/">Online sine nettsider</a></p>
+            <p>Mangel på oppmøte uten avmelding av arrangementet resulterer i prikk og/eller suspensjon. Du kan lese mer om prikkereglene på <a href="https://wiki.online.ntnu.no/online-info/prikkeregler/">Online sine nettsider</a></p>
           </td>
         </tr>
 
         <tr style="width: 100%">
-          <h3 style="text-align: center">Linjeforeningen Online</h3>
-          <p style="text-align: center">Du mottar denne e-posten fordi du har meldt deg på arrangementet {{ eventName }}</p>
-          <p style="text-align: center">Org. Nr. 992 548 045 &ndash; Høgskoleringen 5, 7034 Trondheim</p>
+          <td>
+            <h3 style="text-align: center">Linjeforeningen Online</h3>
+            <p style="text-align: center">Du mottar denne e-posten fordi du har meldt deg på arrangementet {{ eventName }}</p>
+            <p style="text-align: center">Org. Nr. 992 548 045 &ndash; Høgskoleringen 5, 7034 Trondheim</p>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/apps/rpc/resources/email/received_mark.mustache
+++ b/apps/rpc/resources/email/received_mark.mustache
@@ -19,15 +19,15 @@
 
         <tr style="width: 100%">
           <td>
-            <p>Du kan lese mer om prikkereglene på <a href="https://wiki.online.ntnu.no/info/innsikt-og-interface/prikkeregler/">Online sine nettsider</a></p>
+            <p>Du kan lese mer om prikkereglene på <a href="https://wiki.online.ntnu.no/online-info/prikkeregler/">Online sine nettsider</a></p>
           </td>
         </tr>
 
         <tr style="width: 100%">
-        <td>
-          <h3 style="text-align: center">Linjeforeningen Online</h3>
-          <p style="text-align: center">Du mottar denne e-posten fordi du er medlem i Linjeforeningen Online</p>
-          <p style="text-align: center">Org. Nr. 992 548 045 &ndash; Høgskoleringen 5, 7034 Trondheim</p>
+          <td>
+            <h3 style="text-align: center">Linjeforeningen Online</h3>
+            <p style="text-align: center">Du mottar denne e-posten fordi du er medlem i Linjeforeningen Online</p>
+            <p style="text-align: center">Org. Nr. 992 548 045 &ndash; Høgskoleringen 5, 7034 Trondheim</p>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Also fixes so the footer is on the bottom in outlook