### PR TITLE
Fix attendees on waitlist not being reserved by task

### DIFF
--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -653,10 +653,11 @@ export function getAttendanceService(
         return
       }
 
-      // If this happens the task was scheduled too early.
       if (isFutureReservationTime) {
-        throw new FailedPreconditionError(
-          `Cannot reserve Attendee(ID=${attendeeId}) before earliestReservationAt (${attendee.earliestReservationAt.toUTCString()})`
+        logger.warn(
+          "ReserveAttendee task for Attendee(ID=%s) ran before earliestReservationAt %s.",
+          attendee.id,
+          attendee.earliestReservationAt.toUTCString()
         )
       }
 


### PR DESCRIPTION
The task failed silently when `earliestReservationAt` was in the past which is always since the task is scheduled for that time