### PR TITLE
Standardize aspect ratios and contain images

### DIFF
--- a/apps/web/src/app/arrangementer/components/EventHeader.tsx
+++ b/apps/web/src/app/arrangementer/components/EventHeader.tsx
@@ -16,23 +16,27 @@ export const EventHeader: FC<Props> = ({ event, showDashboardLink }) => {
 
   return (
     <section className="flex flex-col gap-8">
-      <Tilt scale={1} tiltMaxAngleX={0.25} tiltMaxAngleY={0.25} glareMaxOpacity={0.1}>
-        {event.imageUrl ? (
-          <img
-            src={event.imageUrl}
-            alt={event.title}
-            className="rounded-xl object-cover aspect-[16/9] md:aspect-[24/9]"
-          />
-        ) : (
-          <div className="rounded-xl w-full bg-gray-100 dark:bg-stone-800 object-cover overflow-hidden aspect-[16/9] md:aspect-[24/9]">
-            <PlaceHolderImage
-              width={16}
-              height={9}
-              variant={event.type}
-              className="scale-160 md:scale-180 md:object-contain"
-            />
-          </div>
-        )}
+      <Tilt
+        scale={1}
+        tiltMaxAngleX={0.25}
+        tiltMaxAngleY={0.25}
+        glareMaxOpacity={0.1}
+        className="rounded-xl bg-gray-100 dark:bg-stone-800"
+      >
+        <div className="flex items-center justify-center aspect-[16/9] md:aspect-[24/9] w-full">
+          {event.imageUrl ? (
+            <img src={event.imageUrl} alt={event.title} className="w-full h-full object-contain rounded-xl" />
+          ) : (
+            <div className="w-full h-full rounded-xl overflow-hidden flex items-center justify-center">
+              <PlaceHolderImage
+                width={16}
+                height={9}
+                variant={event.type}
+                className="w-full h-full object-contain rounded-xl"
+              />
+            </div>
+          )}
+        </div>
       </Tilt>
 
       <div className="flex flex-col gap-2 md:flex-row md:gap-4 md:items-center">

--- a/apps/web/src/app/profil/[profileSlug]/page.tsx
+++ b/apps/web/src/app/profil/[profileSlug]/page.tsx
@@ -260,7 +260,7 @@ export default function ProfilePage() {
     <div className="flex flex-col gap-8 w-full">
       <div className="flex flex-row gap-4">
         <Avatar className="w-16 h-16 md:w-32 md:h-32">
-          <AvatarImage src={user.imageUrl ?? undefined} />
+          <AvatarImage src={user.imageUrl ?? undefined} className="object-cover" />
           <AvatarFallback className="bg-gray-200 dark:bg-stone-600">
             <IconUser width={64} height={64} />
           </AvatarFallback>

--- a/apps/web/src/components/molecules/EventListItem/EventListItem.tsx
+++ b/apps/web/src/components/molecules/EventListItem/EventListItem.tsx
@@ -26,7 +26,7 @@ export const EventListItem: FC<EventListItemProps> = ({ event, attendance, userI
       href={createEventPageUrl(id, title)}
       className={cn(
         // [calc(100%+1rem)] is to offset the -mx-2
-        "group flex flex-row gap-3 w-[calc(100%+1rem)] rounded-xl p-2 -mx-2 last:-mb-2",
+        "group flex flex-row gap-3 sm:gap-4 w-[calc(100%+1rem)] rounded-xl p-2 -mx-2 last:-mb-2",
         "hover:bg-gray-50 dark:hover:bg-stone-800 transition-colors",
         past && "text-gray-600 dark:text-stone-200 hover:text-gray-800 dark:hover:text-stone-300",
         className
@@ -36,7 +36,11 @@ export const EventListItem: FC<EventListItemProps> = ({ event, attendance, userI
 
       <div className="flex flex-col gap-1">
         <div className="flex flex-row gap-1">
-          <Title element="h3" size="sm" className="font-normal text-base md:text-lg">
+          <Title
+            element="h3"
+            size="sm"
+            className="font-normal text-base md:text-lg line-clamp-1 sm:line-clamp-2 break-all"
+          >
             {title}
           </Title>
         </div>
@@ -54,7 +58,7 @@ export const EventListItem: FC<EventListItemProps> = ({ event, attendance, userI
 export const EventListItemSkeleton: FC = () => {
   return (
     <div className="flex flex-row gap-4 w-full rounded-lg py-2">
-      <div className="aspect-[4/3] h-[6rem] bg-gray-300 dark:bg-stone-600 rounded-lg animate-pulse" />
+      <div className="aspect-[16/9] h-22 sm:h-28 bg-gray-300 dark:bg-stone-600 rounded-lg animate-pulse" />
 
       <div className="flex flex-col gap-4 w-full">
         <div className="max-w-64 h-6 bg-gray-300 dark:bg-stone-600 rounded-sm animate-pulse" />

--- a/apps/web/src/components/molecules/EventListItem/Thumbnail.tsx
+++ b/apps/web/src/components/molecules/EventListItem/Thumbnail.tsx
@@ -10,7 +10,7 @@ const EVENTS = {
     backgroundColor: "blue",
   },
   GENERAL_ASSEMBLY: {
-    label: "Generalforsamling",
+    label: "Genfors",
     backgroundColor: "amber",
   },
   INTERNAL: {
@@ -48,7 +48,7 @@ export const Thumbnail: FC<EventListItemThumbnailProps> = ({ imageUrl, alt, star
   return (
     <Tilt>
       <div className="relative w-max">
-        <div className="aspect-[4/3] h-[6rem] bg-gray-100 dark:bg-stone-800 rounded-lg overflow-hidden">
+        <div className="aspect-[16/9] h-22 sm:h-28 bg-gray-100 dark:bg-stone-800 rounded-lg overflow-hidden">
           {imageUrl ? (
             <Image
               src={imageUrl}


### PR DESCRIPTION
Contain images:
![image.png](https://app.graphite.com/user-attachments/assets/602e34b4-31d7-4c4a-86e0-7164a63a5749.png)

Standardize aspect ratios (from 4/3 to 16/9):
![image.png](https://app.graphite.com/user-attachments/assets/86ae89dc-acbb-46e0-9853-0ab0caf1cbcb.png)
