### PR TITLE
Add organization and invoice number fields to Company

### DIFF
--- a/packages/db/prisma/migrations/20251210150814_add_company_credentials/migration.sql
+++ b/packages/db/prisma/migrations/20251210150814_add_company_credentials/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "company" ADD COLUMN     "invoiceNumber" TEXT,
+ADD COLUMN     "organizationNumber" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -93,17 +93,19 @@ model User {
 }
 
 model Company {
-  id          String   @id @default(uuid())
-  name        String
-  slug        String   @unique
-  description String?
-  phone       String?
-  email       String?
-  website     String
-  location    String?
-  imageUrl    String?
-  createdAt   DateTime @default(now()) @db.Timestamptz(3)
-  updatedAt   DateTime @default(now()) @updatedAt @db.Timestamptz(3)
+  id                 String   @id @default(uuid())
+  name               String
+  slug               String   @unique
+  description        String?
+  phone              String?
+  email              String?
+  organizationNumber String?
+  invoiceNumber      String?
+  website            String
+  location           String?
+  imageUrl           String?
+  createdAt          DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt          DateTime @default(now()) @updatedAt @db.Timestamptz(3)
 
   events     EventCompany[]
   JobListing JobListing[]


### PR DESCRIPTION
Currently these are left unused, but we will require them when I move
`rif` and `invocification` to rpc.