### PR TITLE
Send registration email when registered from waitlist by deregistration

### DIFF
--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -877,6 +877,8 @@ export function getAttendanceService(
         event.title,
         attendee.id
       )
+
+      sendEventRegistrationEmail(event, attendance, firstUnreservedAdjacentAttendee)
     },
 
     async findChargeAttendeeScheduleDate(handle, attendeeId) {


### PR DESCRIPTION
We should refactor this a bit to reuse the same logic for `executeReserveAttendeeTask` and deregister - this is just a quick fix