### PR TITLE
Use generated pool title if it was not previously generated

### DIFF
--- a/apps/dashboard/src/app/(internal)/arrangementer/components/pool-form.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/pool-form.tsx
@@ -63,8 +63,8 @@ export const usePoolForm = (props: PoolFormProps) => {
 
   const generatedTitle = createPoolName(yearCriteria ?? [])
   const defaultTitle = form.formState.defaultValues?.title
-  const defaultTitleWasGenerated = defaultTitle === createPoolName(props.defaultValues.yearCriteria ?? [])
-  const titleIsDirty = Boolean(form.formState.dirtyFields.title)
+  const isDefaultGeneratedTitle = defaultTitle === createPoolName(props.defaultValues.yearCriteria ?? [])
+  const isTitleDirty = Boolean(form.formState.dirtyFields.title)
 
   const fields = useMemo(
     () =>
@@ -135,13 +135,13 @@ export const usePoolForm = (props: PoolFormProps) => {
   )
 
   useEffect(() => {
-    if (!yearCriteria || !defaultTitleWasGenerated || titleIsDirty) {
+    if (!yearCriteria || !isDefaultGeneratedTitle || isTitleDirty) {
       return
     }
 
     form.setValue("title", generatedTitle, { shouldDirty: false, shouldTouch: false })
     form.trigger("title")
-  }, [yearCriteria, generatedTitle, defaultTitleWasGenerated, titleIsDirty, form])
+  }, [yearCriteria, generatedTitle, isDefaultGeneratedTitle, isTitleDirty, form])
 
   const onSubmit = form.handleSubmit((values) => {
     form.resetField("yearCriteria")


### PR DESCRIPTION
A lot of people seems to create a pool with all year criteria (1-5), and later remove some criteria, but the title stays as "Alle".

This pr should make pools use generated titles as long as:
1. It wasn't set to a custom value when previously created/updated
2. It hasn't been manually edited this session