### PR TITLE
Move allEvents isStaff check to router to prevent double queries

### DIFF
--- a/apps/web/src/app/arrangementer/components/calendar/EventMonthCalendar/EventMonthCalendar.tsx
+++ b/apps/web/src/app/arrangementer/components/calendar/EventMonthCalendar/EventMonthCalendar.tsx
@@ -34,12 +34,11 @@ export const EventMonthCalendar: FC<CalendarProps> = ({ year, month }) => {
   const session = useSession()
 
   const trpc = useTRPC()
-  const [userResult, isStaffResult] = useQueries({
-    queries: [trpc.user.findMe.queryOptions(), trpc.user.isStaff.queryOptions()],
+  const [userResult] = useQueries({
+    queries: [trpc.user.findMe.queryOptions()],
   })
 
   const { data: user } = userResult
-  const { data: isStaff = false } = isStaffResult
 
   // fetch 10 days prior to first day of month as a buffer since fliter is by start date
   const calendarStart = new TZDate(year, month, 1 - 10)
@@ -53,7 +52,6 @@ export const EventMonthCalendar: FC<CalendarProps> = ({ year, month }) => {
         max: calendarEnd,
       },
       orderBy: "asc",
-      excludingType: isStaff ? [] : undefined,
     },
     page: {
       take: 1000,

--- a/apps/web/src/app/arrangementer/components/calendar/EventWeekCalendar/EventWeekCalendar.tsx
+++ b/apps/web/src/app/arrangementer/components/calendar/EventWeekCalendar/EventWeekCalendar.tsx
@@ -34,12 +34,11 @@ export const EventWeekCalendar: FC<WeekCalendarProps> = ({ year, weekNumber }) =
   const session = useSession()
 
   const trpc = useTRPC()
-  const [userResult, isStaffResult] = useQueries({
-    queries: [trpc.user.findMe.queryOptions(), trpc.user.isStaff.queryOptions()],
+  const [userResult] = useQueries({
+    queries: [trpc.user.findMe.queryOptions()],
   })
 
   const { data: user } = userResult
-  const { data: isStaff = false } = isStaffResult
 
   let weekDate = new Date()
   weekDate = setISOWeekYear(weekDate, year)
@@ -56,7 +55,6 @@ export const EventWeekCalendar: FC<WeekCalendarProps> = ({ year, weekNumber }) =
         max: new TZDate(weekEnd),
       },
       orderBy: "asc",
-      excludingType: isStaff ? [] : undefined,
     },
     page: {
       take: 1000,

--- a/apps/web/src/app/arrangementer/page.tsx
+++ b/apps/web/src/app/arrangementer/page.tsx
@@ -84,7 +84,6 @@ const EventPage = () => {
         max: null,
         min: now,
       },
-      excludingType: isStaff ? [] : undefined,
       orderBy: "asc",
     },
     page: {
@@ -99,7 +98,6 @@ const EventPage = () => {
         max: now,
         min: null,
       },
-      excludingType: isStaff ? [] : undefined,
       orderBy: "desc",
     },
   })

--- a/apps/web/src/app/grupper/components/GroupPage.tsx
+++ b/apps/web/src/app/grupper/components/GroupPage.tsx
@@ -23,8 +23,6 @@ interface CommitteePageProps {
 export const GroupPage = async ({ params }: CommitteePageProps) => {
   const { slug } = await params
 
-  const isStaff = await server.user.isStaff.query()
-
   const now = getCurrentUTC()
 
   const [session, group, futureEventWithAttendances, pastEventWithAttendances] = await Promise.all([
@@ -37,7 +35,6 @@ export const GroupPage = async ({ params }: CommitteePageProps) => {
           max: null,
           min: now,
         },
-        excludingType: isStaff ? [] : undefined,
         orderBy: "asc",
       },
     }),
@@ -48,7 +45,6 @@ export const GroupPage = async ({ params }: CommitteePageProps) => {
           min: null,
         },
         byOrganizingGroup: [slug],
-        excludingType: isStaff ? [] : undefined,
         orderBy: "desc",
       },
     }),

--- a/apps/web/src/app/profil/[profileSlug]/ProfilePage.tsx
+++ b/apps/web/src/app/profil/[profileSlug]/ProfilePage.tsx
@@ -184,12 +184,11 @@ export function ProfilePage() {
   const session = useSession()
   const fullPathname = useFullPathname()
 
-  const [userResult, isStaffResult] = useQueries({
-    queries: [trpc.user.findByProfileSlug.queryOptions(profileSlug), trpc.user.isStaff.queryOptions()],
+  const [userResult] = useQueries({
+    queries: [trpc.user.findByProfileSlug.queryOptions(profileSlug)],
   })
 
   const { data: user, isLoading: userLoading } = userResult
-  const { data: isStaff = false } = isStaffResult
 
   // "Compilation" is an inaugural tradition in Online where you "officially" become a member
   const isCompiled = false // TODO: Reimplement compilation with flags
@@ -208,7 +207,6 @@ export function ProfilePage() {
                 min: now,
                 max: null,
               },
-              excludingType: isStaff ? [] : undefined,
             },
           },
           { enabled: isLoggedIn && Boolean(user?.id) }
@@ -225,7 +223,6 @@ export function ProfilePage() {
         max: now,
         min: null,
       },
-      excludingType: isStaff ? [] : undefined,
     },
     enabled: isLoggedIn && Boolean(user?.id),
   })


### PR DESCRIPTION
The event list and other places calls event.all twice for staff users because isStaff updates after the initial query, so they're almost twice as slow as they should be. Also, excluding internal events from non-staff shouldn't be in the client either way