### PR TITLE
Add Knight registration to new membership system

### DIFF
--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -1,6 +1,7 @@
 import { on } from "node:events"
 import { TZDate } from "@date-fns/tz"
 import {
+  type AttendancePool,
   AttendancePoolSchema,
   AttendancePoolWriteSchema,
   AttendanceSchema,
@@ -224,7 +225,11 @@ const onRegisterChangeProcedure = procedure
   .use(withDatabaseTransaction())
   .subscription(async function* ({ input, ctx, signal }) {
     for await (const [data] of on(ctx.eventEmitter, "attendance:register-change", { signal })) {
-      const attendeeUpdateData = data as { attendee: Attendee; status: "registered" | "deregistered" }
+      const attendeeUpdateData = data as {
+        attendee: Attendee
+        status: "registered" | "deregistered"
+        newAttendancePool: AttendancePool | undefined
+      }
 
       if (attendeeUpdateData.attendee.attendanceId !== input.attendanceId) {
         continue

--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -543,6 +543,22 @@ export function getAttendanceService(
       // skipped.
       const bypassedChecks: RegistrationBypassCause[] = []
 
+      // This will deprioritize Knight memberships, meaning that if this returns a Knight membership, it is their only
+      // active membership.
+      const membership = findActiveMembership(user)
+
+      // This makes Knights only respect registration end. This requires a lot of trust, but the Knights are Online's
+      // most trusted and devoted members throughout the years. The reason we give them so much lenience is to make it
+      // simple for both us, the developers, and the event organizers. In practice, it's extremely uncommon for Knights
+      // who don't have any other membership (aren't active students) to register to events. This usually happens once a
+      // year, for an event called "Immatrikuleringsball" ("Immball"), and every five years for the anniversary.
+      // Therefore, we give the Knights so much leniency to avoid having any frontend options for the Knights.
+      if (membership?.type === "KNIGHT") {
+        options.overrideTurnstileCheck = true
+        options.ignoreRegisteredToParent = true
+        options.ignoreRegistrationWindow = true
+      }
+
       if (!turnstileCheckResult) {
         if (!options.overrideTurnstileCheck) {
           return { cause: "INVALID_TURNSTILE_TOKEN", success: false }
@@ -592,8 +608,6 @@ export function getAttendanceService(
         }
       }
 
-      const membership = findActiveMembership(user)
-
       if (membership === null) {
         return { cause: "MISSING_MEMBERSHIP", success: false }
       }
@@ -601,7 +615,22 @@ export function getAttendanceService(
       // This is a "free" check that does zero roundtrips against the database, despite having a rather large piece of
       // code associated with it.
       let applicablePool: AttendancePool | null = null
-      if (options.overriddenAttendancePoolId !== null) {
+
+      if (membership.type === "KNIGHT") {
+        // Knights should register to their own pool, and this pool might not exist before they register. "Ridder" is
+        // the Norwegian name for Knights.
+        applicablePool = attendance.pools.find((p) => p.title === "Ridder") ?? {
+          id: crypto.randomUUID(),
+          attendanceId,
+          capacity: 0,
+          yearCriteria: [],
+          title: "Ridder",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          mergeDelayHours: null,
+          taskId: null,
+        }
+      } else if (options.overriddenAttendancePoolId !== null) {
         const pool = attendance.pools.find((p) => p.id === options.overriddenAttendancePoolId)
 
         if (pool === undefined) {
@@ -678,6 +707,16 @@ export function getAttendanceService(
         success,
       })
 
+      let createdAttendancePool: AttendancePool | null = null
+
+      if (pool.title === "Ridder") {
+        const poolExists = attendance.pools.some((p) => p.id === pool.id)
+
+        if (!poolExists) {
+          createdAttendancePool = await attendanceRepository.createAttendancePool(handle, attendance.id, null, pool)
+        }
+      }
+
       const poolAttendees = attendance.attendees.filter((a) => a.attendancePoolId === pool.id && a.reserved)
       const isImmediateReservation =
         (!isFuture(reservationActiveAt) && (pool.capacity === 0 || poolAttendees.length < pool.capacity)) ||
@@ -739,6 +778,7 @@ export function getAttendanceService(
       eventEmitter.emit("attendance:register-change", {
         attendee,
         status: "registered",
+        newAttendancePool: createdAttendancePool ?? undefined,
       })
       logger.info(
         "Attendee(ID=%s,UserID=%s) named %s has registered (effective %s) for Event(ID=%s) named %s with options: %o",
@@ -882,6 +922,7 @@ export function getAttendanceService(
       eventEmitter.emit("attendance:register-change", {
         attendee,
         status: "deregistered",
+        newAttendancePool: undefined,
       })
       logger.info(
         "Attendee(ID=%s,UserID=%s) named %s has deregistered from Event(ID=%s) named %s with options: %o",
@@ -1727,6 +1768,7 @@ function validateAttendanceWrite(data: AttendanceWrite) {
   }
 }
 
+// NOTE: This should allow creating attendance pools with no year criteria
 function validateAttendancePoolWrite(data: AttendancePoolWrite) {
   if (data.mergeDelayHours !== null && (data.mergeDelayHours < 0 || data.mergeDelayHours > 48)) {
     throw new InvalidArgumentError("Merge delay for pool must be between 0 and 48 hours")

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -114,7 +114,7 @@ export const AttendanceCard = ({
         onConnectionStateChange: (state) => {
           setTRPCSSERegisterChangeConnectionState(state.state)
         },
-        onData: ({ status, attendee }) => {
+        onData: ({ status, attendee, newAttendancePool }) => {
           // If the attendee is not the current user, we can update the state
           queryClient.setQueryData(
             trpc.event.attendance.getAttendance.queryOptions({ id: attendance?.id }).queryKey,
@@ -135,9 +135,12 @@ export const AttendanceCard = ({
                 return oldData
               }
 
+              const updatedPools = newAttendancePool ? [...oldData.pools, newAttendancePool] : oldData.pools
+
               return {
                 ...oldData,
                 attendees: [...oldData.attendees, attendee],
+                pools: updatedPools,
               }
             }
           )
@@ -190,6 +193,7 @@ export const AttendanceCard = ({
       console.error("No turnstile token, cannot register")
       return
     }
+
     registerMutation.mutate({ attendanceId: attendance.id, turnstileToken })
   }
 

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/MainPoolCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/MainPoolCard.tsx
@@ -117,14 +117,30 @@ export const MainPoolCard: FC<MainPoolCardProps> = ({ attendance, user, authoriz
     )
   }
 
-  const pool = getAttendablePool(attendance, user)
+  let pool = getAttendablePool(attendance, user)
 
   if (!pool) {
-    return (
-      <div className={cardClassname}>
-        <Text>Du kan ikke melde deg på dette arrangementet</Text>
-      </div>
-    )
+    // Knights will create their own pool when registering if it does not exist. For simplicity, we just mock the pool
+    // as this data is just for visualizing the pool.
+    if (membership?.type === "KNIGHT") {
+      pool = {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "Ridder",
+        attendanceId: attendance.id,
+        mergeDelayHours: null,
+        updatedAt: new Date(),
+        createdAt: new Date(),
+        yearCriteria: [],
+        capacity: 0,
+        taskId: null,
+      }
+    } else {
+      return (
+        <div className={cardClassname}>
+          <Text>Du kan ikke melde deg på dette arrangementet</Text>
+        </div>
+      )
+    }
   }
 
   const unreservedAttendeeCount = getUnreservedAttendeeCount(attendance, pool.id)

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
@@ -60,29 +60,14 @@ const getDisabledText = (
   isSuspended: boolean,
   registeredToParentEvent: boolean | null,
   reservedToParentEvent: boolean | null,
-  hasTurnstileToken: boolean
+  hasTurnstileToken: boolean,
+  isKnight: boolean
 ) => {
   if (!isLoggedIn) {
     return "Du må være innlogget for å melde deg på"
   }
 
   const isAttending = attendee !== null
-
-  if (status === "Closed") {
-    return "Påmeldingen er stengt"
-  }
-
-  if (!pool) {
-    return "Du har ingen påmeldingsgruppe"
-  }
-
-  if (registeredToParentEvent === false) {
-    return "Du er ikke påmeldt foreldrearrangementet"
-  }
-
-  if (reservedToParentEvent === false && registeredToParentEvent === true) {
-    return "Du er i kø på foreldrearrangementet"
-  }
 
   if (isAttending) {
     if (isPastDeregisterDeadline && attendee.reserved) {
@@ -96,20 +81,41 @@ const getDisabledText = (
     return null
   }
 
-  if (!hasTurnstileToken) {
-    return "Du må bekrefte at du ikke er en robot"
-  }
-
   if (isSuspended) {
     return "Du er suspendert fra Online"
+  }
+
+  // Knights ("Riddere") bypass the remaining checks in the backend
+  if (isKnight) {
+    return null
   }
 
   if (!hasMembership) {
     return "Du må ha registrert medlemskap for å melde deg på"
   }
 
+  if (status === "Closed") {
+    return "Påmeldingen er stengt"
+  }
+
+  if (!pool) {
+    return "Du har ingen påmeldingsgruppe"
+  }
+
   if (status === "NotOpened") {
     return "Påmeldinger har ikke åpnet"
+  }
+
+  if (registeredToParentEvent === false) {
+    return "Du er ikke påmeldt foreldrearrangementet"
+  }
+
+  if (reservedToParentEvent === false && registeredToParentEvent === true) {
+    return "Du er i kø på foreldrearrangementet"
+  }
+
+  if (!hasTurnstileToken) {
+    return "Du må bekrefte at du ikke er en robot"
   }
 
   return null
@@ -146,7 +152,10 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   const attendee = getAttendee(attendance, user)
   const pool = getAttendablePool(attendance, user)
   const attendanceStatus = getAttendanceStatus(attendance)
-  const hasMembership = user !== null && Boolean(findActiveMembership(user))
+
+  const membership = user !== null ? findActiveMembership(user) : null
+  const hasMembership = membership !== null
+  const isKnight = membership?.type === "KNIGHT"
 
   const deregisterGracePeriodEnd =
     attendee !== null ? addMilliseconds(attendee.createdAt, DEREGISTER_GRACE_PERIOD_MS) : null
@@ -189,7 +198,8 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
     isSuspended,
     registeredToParentEvent,
     reservedToParentEvent,
-    hasTurnstileToken
+    hasTurnstileToken,
+    isKnight
   )
   const disabled = Boolean(disabledText)
 

--- a/packages/types/src/attendance.ts
+++ b/packages/types/src/attendance.ts
@@ -130,6 +130,12 @@ export function getAttendanceCapacity(attendance: Attendance | AttendanceSummary
 
 export function isAttendable(user: User, pool: AttendancePool) {
   const membership = findActiveMembership(user)
+
+  // Knights can always attend pools named "Ridder". This is a hard-coded name used only for Knight attendance.
+  if (membership?.type === "KNIGHT") {
+    return pool.title === "Ridder"
+  }
+
   const grade = membership?.semester != null ? getStudyGrade(membership.semester) : null
 
   if (grade === null) {


### PR DESCRIPTION
This fixes a regression from the new membership rewrite, where Knights (Riddere) cannot register to any events.

How this works:

- A knight ignore most attendance restrictions a normal user faces
    - They are impacted by suspensions and registration end, and that is about it
    - For example; they can register to an event regardless of registration start time or capacity
- When a knight registers, a new pool named "Knight" will be created if it does not exist
    - If it already exists, they will register to that pool. They are not able to register to any other pool
    - No one else can ever register to this pool

Important to note:

- Our systems will always prioritize every other membership over Knight for event registration. Meaning if a current student is a knight, their regular Bachelor/Master/social membership will take precedence, and they will **not** have the same leniency as described above.
- Our Knights are our most trusted and devoted members in Online's history. This puts a lot of trust into them, but I belive that is totally fine.



TODO:

- Add Dashboard frontend (make it clear that pools named "Ridder" are special pools)
- Disallow setting yearCriteria for pool named "Ridder"
- Disallow duplicated pools named "Ridder"