### PR TITLE
Add migration to migrate ow4 gender claims

### DIFF
--- a/packages/db/prisma/migrations/20260227133119_migrate_over_gender_claims/migration.sql
+++ b/packages/db/prisma/migrations/20260227133119_migrate_over_gender_claims/migration.sql
@@ -1,0 +1,3 @@
+-- This is an empty migration.
+UPDATE ow_user SET gender = 'Mann' WHERE gender = 'male';
+UPDATE ow_user SET gender = 'Kvinne' WHERE gender = 'female';


### PR DESCRIPTION
All users migrated from ow4 have the gender field be "male" or "female". As a result the value isn't shown in the profile edit form.