### PR TITLE
Stop renovate from automerging failing prs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "configMigration": true,
   "extends": ["config:best-practices"],
   "semanticCommits": "disabled",
+  "platformAutomerge": false,
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
I think(?) this should stop renovate from automerging prs that fails CI
ref https://docs.renovatebot.com/configuration-options/#automerge: "If you don't select any status check, and you use platform automerge, then GitHub might automerge PRs with failing tests!"