### PR TITLE
Add relative link identity authorize URL helper

### DIFF
--- a/apps/web/src/app/innstillinger/bruker/page.tsx
+++ b/apps/web/src/app/innstillinger/bruker/page.tsx
@@ -5,7 +5,7 @@ import { useTRPC } from "@/utils/trpc/client"
 import { useFullPathname } from "@/utils/use-full-pathname"
 import { useSession } from "@dotkomonline/oauth2/react"
 import { Button, Text, TextInput, Title, cn } from "@dotkomonline/ui"
-import { createAbsoluteLinkIdentityAuthorizeUrl, createAuthorizeUrl } from "@dotkomonline/utils"
+import { createAuthorizeUrl, createLinkIdentityAuthorizeUrl } from "@dotkomonline/utils"
 import { IconAlertTriangle, IconCheck, IconCopy, IconLink, IconMail, IconPassword, IconX } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { secondsToMilliseconds } from "date-fns"
@@ -88,12 +88,12 @@ export default function MinBrukerPage() {
   const isFeideLinked = auth0Connections?.hasFeide === true
   const isUsernamePasswordLinked = auth0Connections?.hasUsernamePassword === true
 
-  const linkFeideUrl = createAbsoluteLinkIdentityAuthorizeUrl(window.location.origin, {
+  const linkFeideUrl = createLinkIdentityAuthorizeUrl({
     connection: "FEIDE",
     redirectAfter: `${fullPathname}/link`,
   })
 
-  const linkUsernamePasswordUrl = createAbsoluteLinkIdentityAuthorizeUrl(window.location.origin, {
+  const linkUsernamePasswordUrl = createLinkIdentityAuthorizeUrl({
     connection: "Username-Password-Authentication",
     redirectAfter: `${fullPathname}/link`,
   })

--- a/packages/utils/src/urls.ts
+++ b/packages/utils/src/urls.ts
@@ -96,6 +96,25 @@ export const createCloudFrontUrl = (cloudFrontUrl: string, key: string): string 
 }
 
 /**
+ * Creates a link identity authorize URL with the given search parameters. This will not replace the user's session,
+ * and will instead put a JWT in a HTTP-only cookie that can be used to verify the user's identity.
+ *
+ * @example
+ * const fullPathname = useFullPathname()
+ * const url = createLinkIdentityAuthorizeUrl({
+ *   connection: "FEIDE", // or "Username-Password-Authentication"
+ *   redirectAfter: `${fullPathname}/link`,
+ * })
+ */
+export const createLinkIdentityAuthorizeUrl = (...parameters: ConstructorParameters<typeof URLSearchParams>) => {
+  const searchParams = new URLSearchParams(...parameters).toString()
+  if (!searchParams) {
+    return LINK_IDENTITY_AUTHORIZE_ENDPOINT
+  }
+  return `${LINK_IDENTITY_AUTHORIZE_ENDPOINT}?${searchParams}`
+}
+
+/**
  * Creates an link identity authorize URL with the given search parameters. This will not replace the user's session,
  * and will instead put a JWT in a HTTP-only cookie that can be used to verify the user's identity.
  *


### PR DESCRIPTION
This used absolute links because in earlier iterations of this code it had to. Since then, the link identity routes have been moved and it's now possible to use them relative, like with the regular authorize URLs. I kept the absolute helper, since it's nice to have if one should need it in the future. This fixes an error i rarely got when developing this where window was not defined, as window is no longer needed.