### PR TITLE
Fix create many group memberships

### DIFF
--- a/apps/rpc/src/modules/group/group-repository.ts
+++ b/apps/rpc/src/modules/group/group-repository.ts
@@ -16,7 +16,6 @@ import {
   GroupSchema,
   type GroupWrite,
   type UserId,
-  type GroupMembershipWriteWithRoles,
 } from "@dotkomonline/types"
 import type { GroupType } from "@prisma/client"
 import z from "zod"
@@ -54,7 +53,6 @@ export interface GroupRepository {
     groupRoleIds: Set<GroupRoleId>
   ): Promise<GroupMembership>
   deleteGroupMemberships(handle: DBHandle, groupMembershipIds: GroupMembershipId[]): Promise<void>
-  createManyGroupMemberships(handle: DBHandle, groupMembershipData: GroupMembershipWriteWithRoles[]): Promise<void>
 
   createGroupRoles(handle: DBHandle, groupRolesData: GroupRoleWrite[]): Promise<GroupRole[]>
   updateGroupRole(
@@ -369,19 +367,6 @@ export function getGroupRepository(): GroupRepository {
             in: groupMembershipIds,
           },
         },
-      })
-    },
-
-    async createManyGroupMemberships(handle, groupMembershipData) {
-      await handle.groupMembership.createMany({
-        data: groupMembershipData.map(({ roleIds, ...membershipData }) => ({
-          ...membershipData,
-          roles: {
-            createMany: {
-              data: [...roleIds].map((roleId) => ({ roleId })),
-            },
-          },
-        })),
       })
     },
   }

--- a/apps/rpc/src/modules/group/group-service.ts
+++ b/apps/rpc/src/modules/group/group-service.ts
@@ -79,7 +79,7 @@ export interface GroupService {
   createManyGroupMemberships(
     handle: DBHandle,
     groupMembershipData: (GroupMembershipWrite & { roleIds: Set<GroupRoleId> })[]
-  ): Promise<void>
+  ): Promise<GroupMembership[]>
   /**
    * Reduces the array of memberships to its simplest form, removing overlapping memberships and merging memberships
    * which could be merged.
@@ -346,16 +346,20 @@ export function getGroupService(
       return results
     },
 
-    createManyGroupMemberships(
+    async createManyGroupMemberships(
       handle: DBHandle,
       groupMembershipData: (GroupMembershipWrite & {
         roleIds: Set<GroupRoleId>
       })[]
-    ): Promise<void> {
-      return groupRepository.createManyGroupMemberships(handle, groupMembershipData)
+    ): Promise<GroupMembership[]> {
+      const operations = groupMembershipData.map(({ roleIds, ...membershipData }) =>
+        groupRepository.createGroupMembership(handle, membershipData, roleIds)
+      )
+
+      return await Promise.all(operations)
     },
 
-    deleteManyGroupMemberships(handle: DBHandle, groupMembershipIds: GroupMembershipId[]): Promise<void> {
+    async deleteManyGroupMemberships(handle: DBHandle, groupMembershipIds: GroupMembershipId[]): Promise<void> {
       return groupRepository.deleteGroupMemberships(handle, groupMembershipIds)
     },
 


### PR DESCRIPTION
Apparently this has to be done in an n+1 query. The original code is illegal and fails at runtime but with no type errors :thinking_face: