### PR TITLE
Fix IDOR on attendee selection response

### DIFF
--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -10,6 +10,7 @@ import {
   AttendeeSelectionResponseSchema,
   DeregisterReasonTypeSchema,
   EventSchema,
+  type GroupId,
   UserSchema,
 } from "@dotkomonline/types"
 import { getCurrentUTC } from "@dotkomonline/utils"
@@ -356,13 +357,22 @@ const updateSelectionResponsesProcedure = procedure
   .use(withAuditLogEntry())
   .mutation(async ({ input, ctx }) => {
     const attendee = await ctx.attendanceService.getAttendeeById(ctx.handle, input.attendeeId)
+    const event = await ctx.eventService.getByAttendanceId(ctx.handle, attendee.attendanceId)
+
+    if (event.hostingGroups.length === 0) {
+      throw new FailedPreconditionError(`Event(ID=${event.id}) does not have hosting groups`)
+    }
+
+    const hostingGroupIds = event.hostingGroups.map((g) => g.slug) as [GroupId, ...GroupId[]]
+
     await ctx.addAuthorizationGuard(
       or(
-        isCommitteeMember(),
+        isGroupMemberOfAny(hostingGroupIds),
         isSameSubject(() => attendee.userId)
       ),
       input
     )
+
     await ctx.attendanceService.updateAttendeeById(ctx.handle, input.attendeeId, { selections: input.options })
   })
 

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -356,7 +356,13 @@ const updateSelectionResponsesProcedure = procedure
   .use(withAuditLogEntry())
   .mutation(async ({ input, ctx }) => {
     const attendee = await ctx.attendanceService.getAttendeeById(ctx.handle, input.attendeeId)
-    await ctx.addAuthorizationGuard(or(isCommitteeMember(), isSameSubject(() => attendee.userId)), input)
+    await ctx.addAuthorizationGuard(
+      or(
+        isCommitteeMember(),
+        isSameSubject(() => attendee.userId)
+      ),
+      input
+    )
     await ctx.attendanceService.updateAttendeeById(ctx.handle, input.attendeeId, { selections: input.options })
   })
 

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -355,6 +355,8 @@ const updateSelectionResponsesProcedure = procedure
   .use(withDatabaseTransaction())
   .use(withAuditLogEntry())
   .mutation(async ({ input, ctx }) => {
+    const attendee = await ctx.attendanceService.getAttendeeById(ctx.handle, input.attendeeId)
+    await ctx.addAuthorizationGuard(or(isCommitteeMember(), isSameSubject(() => attendee.userId)), input)
     await ctx.attendanceService.updateAttendeeById(ctx.handle, input.attendeeId, { selections: input.options })
   })
 


### PR DESCRIPTION
Kjære dotkom,

Takk for at dere viste oss hvordan [responsible disclosure](https://github.com/webkom/lego/pull/4134) gjøres🙏 Vi tok det til oss.

Vi fant at `updateSelectionResponsesProcedure` kun sjekket at du var innlogget - ikke at du faktisk eier attendee-recordet du prøver å endre. To linjer fikset det. Lar hvem som helst melde seg på pils og sprit på andres vegne🍺


Men siden vi først var innom kodebasen ofret vi et par tusen tokens til... og fant vi et par ting👀

- `user.findByUsername` og `user.getByUsername` er helt åpne og returnerer full `UserSchema` - epost, telefon, kosthold og alt. Ingen auth. Ingen projeksjon. Bare ta deg til rette.
- `event.get`, `event.find` og `event.attendance.getAttendance` er heller ikke autentisert, og embedder full `UserSchema` på alle attendees. Historisk masseeksponering av PII for alle som har meldt seg på et arrangement.

Dere har til og med laget `PublicUserSchema` - så dere er på god vei😇

Ingen interessegrupper for pils og sprit ble stiftet i prosessen.

Mvh Webkom❤️
PS: Vi er også den beste kodekomiteen på NTNU