### PR TITLE
Revert to committee group slugs enum

### DIFF
--- a/apps/rpc/src/authorization.ts
+++ b/apps/rpc/src/authorization.ts
@@ -149,7 +149,7 @@ type IsGroupMemberSelector<TInput> = (input: TInput) => GroupId | null
  *
  * @example
  * ```
- * isGroupMember("dotkom")
+ * isGroupMember(CommitteeGroupSlug.DOTKOM)
  * isGroupMember(input => input.groupSlug)
  * ```
  */
@@ -217,8 +217,7 @@ export function hasCommitteeRole<TInput>(groupRoleType: GroupRoleType): Rule<TIn
       const roles = new Set<GroupRoleType>()
 
       for (const [groupId, groupRoles] of affiliations.entries()) {
-        // biome-ignore lint/suspicious/noExplicitAny: Array#includes expects only committee affiliations for input
-        if (!COMMITTEE_AFFILIATIONS.includes(groupId as any)) {
+        if (!(COMMITTEE_AFFILIATIONS as readonly GroupId[]).includes(groupId)) {
           continue
         }
 

--- a/apps/rpc/src/modules/authorization-service.ts
+++ b/apps/rpc/src/modules/authorization-service.ts
@@ -3,31 +3,36 @@ import type { GroupId, GroupRoleType, UserId } from "@dotkomonline/types"
 import { minutesToMilliseconds } from "date-fns"
 import { LRUCache } from "lru-cache"
 
-export const HOVEDSTYRET_GROUP_SLUG = "hs"
+export const CommitteeGroupSlug = {
+  HOVEDSTYRET: "hs",
+  DOTKOM: "dotkom",
+  APPKOM: "appkom",
+  ARRKOM: "arrkom",
+  BACKLOG: "backlog",
+  BANKOM: "bankom",
+  BEDKOM: "bedkom",
+  DEBUG: "debug",
+  DOTDAGENE: "dotdagene",
+  EKSKOM: "ekskom",
+  FAGKOM: "fagkom",
+  FEMINIT: "feminit",
+  FOND: "fond",
+  JUBKOM: "jubkom",
+  ONLINE_IL: "online-il",
+  PROKOM: "prokom",
+  REDAKSJONEN: "redaksjonen",
+  TRIKOM: "trikom",
+  VELKOM: "velkom",
+} as const satisfies Record<string, GroupId>
 
-export const COMMITTEE_AFFILIATIONS = [
-  HOVEDSTYRET_GROUP_SLUG,
-  "dotkom",
-  "appkom",
-  "arrkom",
-  "backlog",
-  "bankom",
-  "bedkom",
-  "debug",
-  "dotdagene",
-  "ekskom",
-  "fagkom",
-  "feminit",
-  "fond",
-  "jubkom",
-  "online-il",
-  "prokom",
-  "redaksjonen",
-  "trikom",
-  "velkom",
-] as const satisfies GroupId[]
+export type CommitteeGroupSlug = (typeof CommitteeGroupSlug)[keyof typeof CommitteeGroupSlug]
 
-export const ADMIN_AFFILIATIONS = ["dotkom", HOVEDSTYRET_GROUP_SLUG] as const satisfies GroupId[]
+export const COMMITTEE_AFFILIATIONS: CommitteeGroupSlug[] = Object.values(CommitteeGroupSlug)
+
+export const ADMIN_AFFILIATIONS = [
+  CommitteeGroupSlug.DOTKOM,
+  CommitteeGroupSlug.HOVEDSTYRET,
+] as const satisfies readonly GroupId[]
 
 export interface AuthorizationService {
   /**
@@ -44,8 +49,8 @@ export interface AuthorizationService {
    * manually checking affiliations, since this will account for administrator permissions.
    */
   intersectGroupAffiliations(
-    userAffiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | Array<GroupId>,
-    affiliationsToCompare: Set<GroupId> | Array<GroupId>
+    userAffiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | ReadonlyArray<GroupId>,
+    affiliationsToCompare: Set<GroupId> | ReadonlyArray<GroupId>
   ): Set<GroupId>
 
   /**
@@ -53,8 +58,8 @@ export interface AuthorizationService {
    * checking affiliations, since this will account for administrator permissions.
    */
   hasAnyGroupAffiliation(
-    affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | Array<GroupId>,
-    affiliationsToCompare: Set<GroupId> | Array<GroupId>
+    affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | ReadonlyArray<GroupId>,
+    affiliationsToCompare: Set<GroupId> | ReadonlyArray<GroupId>
   ): boolean
 
   /**
@@ -62,19 +67,19 @@ export interface AuthorizationService {
    * affiliations, since this will account for administrator permissions.
    */
   hasEveryGroupAffiliation(
-    affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | Array<GroupId>,
-    affiliationsToCompare: Set<GroupId> | Array<GroupId>
+    affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | ReadonlyArray<GroupId>,
+    affiliationsToCompare: Set<GroupId> | ReadonlyArray<GroupId>
   ): boolean
 
   /**
    * Helper for using intersectGroupAffiliations with all committee affiliations.
    */
-  isCommitteeMember(affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | Array<GroupId>): boolean
+  isCommitteeMember(affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | ReadonlyArray<GroupId>): boolean
 
   /**
    * Helper for using intersectGroupAffiliations with all administrator affiliations.
    */
-  isAdministrator(affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | Array<GroupId>): boolean
+  isAdministrator(affiliations: Map<GroupId, Set<GroupRoleType>> | Set<GroupId> | ReadonlyArray<GroupId>): boolean
 }
 
 export function getAuthorizationService(): AuthorizationService {
@@ -173,7 +178,7 @@ export function getAuthorizationService(): AuthorizationService {
   }
 }
 
-function toSet<T>(input: Map<T, unknown> | Set<T> | Array<T>): Set<T> {
+function toSet<T>(input: Map<T, unknown> | Set<T> | ReadonlyArray<T>): Set<T> {
   if (input instanceof Map) {
     return new Set(input.keys())
   }
@@ -182,5 +187,5 @@ function toSet<T>(input: Map<T, unknown> | Set<T> | Array<T>): Set<T> {
     return new Set(input)
   }
 
-  return input
+  return input as Set<T>
 }

--- a/apps/rpc/src/modules/event/event.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/event.e2e-spec.ts
@@ -1,6 +1,7 @@
 import type { EventWrite, GroupWrite } from "@dotkomonline/types"
 import { faker } from "@faker-js/faker"
 import { describe, expect, it } from "vitest"
+import { CommitteeGroupSlug } from "../authorization-service"
 import { core, dbClient } from "../../../vitest-integration.setup"
 import { FailedPreconditionError } from "../../error"
 
@@ -18,7 +19,7 @@ export function getMockGroup(input: Partial<GroupWrite> = {}): GroupWrite {
     deactivatedAt: null,
     workspaceGroupId: null,
     memberVisibility: "ALL_MEMBERS",
-    slug: "dotkom",
+    slug: CommitteeGroupSlug.DOTKOM,
     showLeaderAsContact: false,
     recruitmentMethod: "AUTUMN_APPLICATION",
     ...input,
@@ -61,7 +62,7 @@ describe("event integration tests", () => {
     // Updating with new ones and removing some
     const group2 = await core.groupService.create(
       dbClient,
-      getMockGroup({ abbreviation: "fagkom", name: "Fag- og kurskomiteen" })
+      getMockGroup({ abbreviation: CommitteeGroupSlug.FAGKOM, name: "Fag- og kurskomiteen" })
     )
     const updated2 = await core.eventService.updateEventOrganizers(
       dbClient,

--- a/apps/rpc/src/modules/group/__test__/group-repository.spec.ts
+++ b/apps/rpc/src/modules/group/__test__/group-repository.spec.ts
@@ -1,4 +1,5 @@
 import type { DBHandle } from "@dotkomonline/db"
+import { CommitteeGroupSlug } from "../../authorization-service"
 import { getGroupRepository } from "../group-repository"
 
 describe("GroupRepository.findManyGroupMemberships", () => {
@@ -18,11 +19,11 @@ describe("GroupRepository.findManyGroupMemberships", () => {
   it("queries all memberships for a group when userId is not provided", async () => {
     const { handle, findMany } = createHandle()
 
-    await groupRepository.findManyGroupMemberships(handle, "dotkom")
+    await groupRepository.findManyGroupMemberships(handle, CommitteeGroupSlug.DOTKOM)
 
     expect(findMany).toHaveBeenCalledWith({
       where: {
-        groupId: "dotkom",
+        groupId: CommitteeGroupSlug.DOTKOM,
       },
       include: {
         roles: {
@@ -37,11 +38,11 @@ describe("GroupRepository.findManyGroupMemberships", () => {
   it("filters memberships by user when userId is provided", async () => {
     const { handle, findMany } = createHandle()
 
-    await groupRepository.findManyGroupMemberships(handle, "dotkom", "user-1")
+    await groupRepository.findManyGroupMemberships(handle, CommitteeGroupSlug.DOTKOM, "user-1")
 
     expect(findMany).toHaveBeenCalledWith({
       where: {
-        groupId: "dotkom",
+        groupId: CommitteeGroupSlug.DOTKOM,
         userId: "user-1",
       },
       include: {

--- a/apps/rpc/src/modules/group/__test__/group-router.spec.ts
+++ b/apps/rpc/src/modules/group/__test__/group-router.spec.ts
@@ -1,5 +1,6 @@
 import type { DBHandle } from "@dotkomonline/db"
 import type { TRPCContext } from "../../../trpc"
+import { CommitteeGroupSlug } from "../../authorization-service"
 import { groupRouter } from "../group-router"
 
 describe("group router service forwarding", () => {
@@ -22,9 +23,9 @@ describe("group router service forwarding", () => {
 
     const caller = groupRouter.createCaller(ctx)
 
-    await caller.getMembers("dotkom")
+    await caller.getMembers(CommitteeGroupSlug.DOTKOM)
 
-    expect(groupService.getLeaders).toHaveBeenCalledWith(txHandle, "dotkom")
+    expect(groupService.getLeaders).toHaveBeenCalledWith(txHandle, CommitteeGroupSlug.DOTKOM)
     expect(groupService.getMembers).not.toHaveBeenCalled()
   })
 
@@ -47,9 +48,9 @@ describe("group router service forwarding", () => {
 
     const caller = groupRouter.createCaller(ctx)
 
-    await caller.getMembers("hs")
+    await caller.getMembers(CommitteeGroupSlug.HOVEDSTYRET)
 
-    expect(groupService.getMembers).toHaveBeenCalledWith(txHandle, "hs")
+    expect(groupService.getMembers).toHaveBeenCalledWith(txHandle, CommitteeGroupSlug.HOVEDSTYRET)
     expect(groupService.getLeaders).not.toHaveBeenCalled()
   })
 
@@ -74,8 +75,8 @@ describe("group router service forwarding", () => {
 
     const caller = groupRouter.createCaller(ctx)
 
-    await caller.getMember({ groupId: "dotkom", userId: "user-1" })
+    await caller.getMember({ groupId: CommitteeGroupSlug.DOTKOM, userId: "user-1" })
 
-    expect(groupService.getMember).toHaveBeenCalledWith(txHandle, "dotkom", "user-1")
+    expect(groupService.getMember).toHaveBeenCalledWith(txHandle, CommitteeGroupSlug.DOTKOM, "user-1")
   })
 })

--- a/apps/rpc/src/modules/group/__test__/group-service.spec.ts
+++ b/apps/rpc/src/modules/group/__test__/group-service.spec.ts
@@ -8,6 +8,7 @@ import { getMembershipService } from "../../user/membership-service"
 import { getUserRepository } from "../../user/user-repository"
 import { getUserService } from "../../user/user-service"
 import { mockDeep } from "vitest-mock-extended"
+import { CommitteeGroupSlug } from "../../authorization-service"
 import { getGroupRepository } from "../group-repository"
 import { getGroupService } from "../group-service"
 import { describe, expect, it, vi } from "vitest"
@@ -34,7 +35,7 @@ describe("GroupService", () => {
 
   it("creates a new group", async () => {
     const group: Omit<Group, "id"> = {
-      slug: "dotkom",
+      slug: CommitteeGroupSlug.DOTKOM,
       abbreviation: "Dotkom",
       name: "Drifts- og utviklingskomiteen",
       createdAt: new Date(),
@@ -60,7 +61,7 @@ describe("GroupService", () => {
 
     const created = await groupService.create(db, group)
     expect(created).toEqual(group)
-    expect(groupRepository.create).toHaveBeenCalledWith(db, "dotkom", group)
+    expect(groupRepository.create).toHaveBeenCalledWith(db, CommitteeGroupSlug.DOTKOM, group)
   })
 
   it("does not find non-existent committees", async () => {

--- a/apps/rpc/src/modules/group/group-router.ts
+++ b/apps/rpc/src/modules/group/group-router.ts
@@ -3,6 +3,7 @@ import {
   GroupMembershipSchema,
   GroupMembershipWriteSchema,
   GroupRoleSchema,
+  GroupRoleTypeSchema,
   GroupRoleWriteSchema,
   GroupSchema,
   GroupWriteSchema,
@@ -12,14 +13,14 @@ import { z } from "zod"
 import { hasGroupRole, isAdministrator, isCommitteeMember, isGroupMember, or } from "../../authorization"
 import { withAuditLogEntry, withAuthentication, withAuthorization, withDatabaseTransaction } from "../../middlewares"
 import { procedure, t } from "../../trpc"
-import { HOVEDSTYRET_GROUP_SLUG } from "../authorization-service"
+import { CommitteeGroupSlug } from "../authorization-service"
 
 export type CreateGroupInput = inferProcedureInput<typeof createGroupProcedure>
 export type CreateGroupOutput = inferProcedureOutput<typeof createGroupProcedure>
 const createGroupProcedure = procedure
   .input(GroupWriteSchema)
   .use(withAuthentication())
-  .use(withAuthorization(or(isAdministrator(), isGroupMember("BACKLOG"))))
+  .use(withAuthorization(or(isAdministrator(), isGroupMember(CommitteeGroupSlug.BACKLOG))))
   .use(withDatabaseTransaction())
   .use(withAuditLogEntry())
   .mutation(async ({ input, ctx }) => {
@@ -82,7 +83,7 @@ const updateGroupProcedure = procedure
       or(
         isAdministrator(),
         isGroupMember((input) => input.id),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -114,8 +115,8 @@ const deleteGroupProcedure = procedure
     withAuthorization(
       or(
         isAdministrator(),
-        hasGroupRole((input) => input, "LEADER"),
-        isGroupMember("BACKLOG")
+        hasGroupRole((input) => input, GroupRoleTypeSchema.enum.LEADER),
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -139,7 +140,7 @@ const getMembersProcedure = procedure
   .use(withDatabaseTransaction())
   .query(async ({ input, ctx }) => {
     // We only show leaders of groups to unathenticated users, except for Hovedstyret who is public
-    if (!ctx.principal && input !== HOVEDSTYRET_GROUP_SLUG) {
+    if (!ctx.principal && input !== CommitteeGroupSlug.HOVEDSTYRET) {
       return ctx.groupService.findLeadersBySlug(ctx.handle, input)
     }
     return ctx.groupService.findMembersBySlug(ctx.handle, input)
@@ -190,7 +191,7 @@ const startMembershipProcedure = procedure
         isAdministrator(),
         hasGroupRole((input) => input.groupId, "LEADER"),
         hasGroupRole((input) => input.groupId, "DEPUTY_LEADER"),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -224,7 +225,7 @@ const endMembershipProcedure = procedure
         isAdministrator(),
         hasGroupRole((input) => input.groupId, "LEADER"),
         hasGroupRole((input) => input.groupId, "DEPUTY_LEADER"),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -264,7 +265,7 @@ const updateMembershipProcedure = procedure
         isAdministrator(),
         hasGroupRole((input) => input.id, "LEADER"),
         hasGroupRole((input) => input.id, "DEPUTY_LEADER"),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -298,7 +299,7 @@ const createRoleProcedure = procedure
         isAdministrator(),
         hasGroupRole((input) => input.groupId, "LEADER"),
         hasGroupRole((input) => input.groupId, "DEPUTY_LEADER"),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )
@@ -334,7 +335,7 @@ const updateRoleProcedure = procedure
         isAdministrator(),
         hasGroupRole((input) => input.id, "LEADER"),
         hasGroupRole((input) => input.id, "DEPUTY_LEADER"),
-        isGroupMember("BACKLOG")
+        isGroupMember(CommitteeGroupSlug.BACKLOG)
       )
     )
   )

--- a/apps/rpc/src/modules/offline/offline-router.ts
+++ b/apps/rpc/src/modules/offline/offline-router.ts
@@ -5,6 +5,7 @@ import { hasGroupRole, isAdministrator, isCommitteeMember, or } from "../../auth
 import { withAuditLogEntry, withAuthentication, withAuthorization, withDatabaseTransaction } from "../../middlewares"
 import { PaginateInputSchema } from "@dotkomonline/utils"
 import { procedure, t } from "../../trpc"
+import { CommitteeGroupSlug } from "../authorization-service"
 
 export type CreateOfflineInput = inferProcedureInput<typeof createOfflineProcedure>
 export type CreateOfflineOutput = inferProcedureOutput<typeof createOfflineProcedure>
@@ -15,9 +16,9 @@ const createOfflineProcedure = procedure
     withAuthorization(
       or(
         isAdministrator(),
-        hasGroupRole("prokom", "LEADER"),
-        hasGroupRole("prokom", "DEPUTY_LEADER"),
-        hasGroupRole("prokom", "EDITOR_IN_CHIEF")
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "LEADER"),
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "DEPUTY_LEADER"),
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "EDITOR_IN_CHIEF")
       )
     )
   )
@@ -41,9 +42,9 @@ const editOfflineProcedure = procedure
     withAuthorization(
       or(
         isAdministrator(),
-        hasGroupRole("prokom", "LEADER"),
-        hasGroupRole("prokom", "DEPUTY_LEADER"),
-        hasGroupRole("prokom", "EDITOR_IN_CHIEF")
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "LEADER"),
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "DEPUTY_LEADER"),
+        hasGroupRole(CommitteeGroupSlug.PROKOM, "EDITOR_IN_CHIEF")
       )
     )
   )


### PR DESCRIPTION
Currently Backlog group authorization overrides are broken because I wrote `BACKLOG` and not `backlog`