### PR TITLE
Make deregister reason optional near register time

### DIFF
--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -16,12 +16,17 @@ import {
 import { getCurrentUTC } from "@dotkomonline/utils"
 import type { inferProcedureInput, inferProcedureOutput } from "@trpc/server"
 import { TRPCError } from "@trpc/server"
-import { addHours } from "date-fns"
+import { addHours, addMilliseconds, hoursToMilliseconds, isPast } from "date-fns"
 import { z } from "zod"
 import { isAdministrator, isCommitteeMember, isGroupMemberOfAny, isSameSubject, or } from "../../authorization"
-import { FailedPreconditionError } from "../../error"
+import { FailedPreconditionError, InvalidArgumentError, NotFoundError } from "../../error"
 import { withAuditLogEntry, withAuthentication, withAuthorization, withDatabaseTransaction } from "../../middlewares"
 import { procedure, t } from "../../trpc"
+
+// A grace period of 2 hours after registration to allow attendees to deregister in case of accidental registration or a
+// quick change of mind. This duration was chosen arbitrarily, though it seemed nice to not overlap with the 1 hour
+// payment deadline. Frontends should have a few seconds to account for clock skew to avoid errors near the grace end.
+const DEREGISTER_GRACE_PERIOD_MS = hoursToMilliseconds(2)
 
 export type CreatePoolInput = inferProcedureInput<typeof createPoolProcedure>
 export type CreatePoolOutput = inferProcedureOutput<typeof createPoolProcedure>
@@ -257,14 +262,17 @@ const startAttendeePaymentProcedure = procedure
 
 export type DeregisterForEventInput = inferProcedureInput<typeof deregisterForEventProcedure>
 export type DeregisterForEventOutput = inferProcedureOutput<typeof deregisterForEventProcedure>
+
 const deregisterForEventProcedure = procedure
   .input(
     z.object({
       attendanceId: AttendancePoolSchema.shape.id,
-      deregisterReason: z.object({
-        type: DeregisterReasonTypeSchema,
-        details: z.string().nullable(),
-      }),
+      deregisterReason: z
+        .object({
+          type: DeregisterReasonTypeSchema,
+          details: z.string().nullable(),
+        })
+        .optional(),
     })
   )
   .use(withAuthentication())
@@ -273,21 +281,32 @@ const deregisterForEventProcedure = procedure
   .mutation(async ({ input, ctx }) => {
     const attendance = await ctx.attendanceService.getAttendanceById(ctx.handle, input.attendanceId)
     const attendee = attendance.attendees.find((attendee) => attendee.user.id === ctx.principal.subject)
+
     if (attendee === undefined) {
-      throw new TRPCError({ code: "NOT_FOUND" })
+      throw new NotFoundError(`Attendee(ID=${attendance.id},UserID=${ctx.principal.subject}) not found`)
     }
+
+    const gracePeriodEnd = addMilliseconds(attendee.createdAt, DEREGISTER_GRACE_PERIOD_MS)
+
+    if (input.deregisterReason === undefined && isPast(gracePeriodEnd)) {
+      throw new InvalidArgumentError("Deregister reason is required outside the grace period")
+    }
+
     await ctx.attendanceService.deregisterAttendee(ctx.handle, attendee.id, {
       ignoreDeregistrationWindow: false,
     })
 
-    const event = await ctx.eventService.getByAttendanceId(ctx.handle, attendance.id)
-    await ctx.eventService.createDeregisterReason(ctx.handle, {
-      ...input.deregisterReason,
-      userId: ctx.principal.subject,
-      eventId: event.id,
-      registeredAt: attendee.createdAt,
-      userGrade: attendee.userGrade,
-    })
+    if (input.deregisterReason) {
+      const event = await ctx.eventService.getByAttendanceId(ctx.handle, attendance.id)
+
+      await ctx.eventService.createDeregisterReason(ctx.handle, {
+        ...input.deregisterReason,
+        userId: ctx.principal.subject,
+        eventId: event.id,
+        registeredAt: attendee.createdAt,
+        userGrade: attendee.userGrade,
+      })
+    }
   })
 
 export type AdminDeregisterForEventInput = inferProcedureInput<typeof adminDeregisterForEventProcedure>

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -192,8 +192,12 @@ export const AttendanceCard = ({
     }
     registerMutation.mutate({ attendanceId: attendance.id, turnstileToken })
   }
-  const deregisterForAttendance = (deregisterReason: DeregisterReasonFormResult) => {
-    deregisterMutation.mutate({ attendanceId: attendance.id, deregisterReason })
+
+  const deregisterForAttendance = (deregisterReason: DeregisterReasonFormResult | null) => {
+    deregisterMutation.mutate(
+      { attendanceId: attendance.id, deregisterReason: deregisterReason ?? undefined },
+      { onSuccess: () => setTurnstileToken(null) }
+    )
   }
 
   const handleTurnstileVerify = (token: string) => {

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
@@ -14,12 +14,16 @@ import {
 } from "@dotkomonline/types"
 import { Button, Text, Tooltip, TooltipContent, TooltipTrigger, cn } from "@dotkomonline/ui"
 import { IconLoader2, IconLock, IconUserMinus, IconUserPlus } from "@tabler/icons-react"
-import { isFuture } from "date-fns"
-import { min } from "date-fns"
+import { addMilliseconds, hoursToMilliseconds, isFuture, min, secondsToMilliseconds } from "date-fns"
 import { type FC, useState } from "react"
 import { DeregisterModal } from "../DeregisterModal"
 import type { DeregisterReasonFormResult } from "../DeregisterModal"
 import { getAttendanceStatus } from "../attendanceStatus"
+
+// The backend requires a deregister reason 2 hours after registration. We subtract 15 seconds here to account for
+// potential clock skew between client and server, so users near the grace period boundary don't experience errors due
+// to small differences in system time.
+const DEREGISTER_GRACE_PERIOD_MS = hoursToMilliseconds(2) - secondsToMilliseconds(15)
 
 const getButtonColor = (
   disabled: boolean,
@@ -97,7 +101,7 @@ const getDisabledText = (
 
 interface RegistrationButtonProps {
   registerForAttendance: () => void
-  unregisterForAttendance: (deregisterReason: DeregisterReasonFormResult) => void
+  unregisterForAttendance: (deregisterReason: DeregisterReasonFormResult | null) => void
   attendance: Attendance
   parentAttendance: Attendance | null
   punishment: Punishment | null
@@ -126,6 +130,10 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   const pool = getAttendablePool(attendance, user)
   const attendanceStatus = getAttendanceStatus(attendance)
   const hasMembership = user !== null && Boolean(findActiveMembership(user))
+
+  const deregisterGracePeriodEnd =
+    attendee !== null ? addMilliseconds(attendee.createdAt, DEREGISTER_GRACE_PERIOD_MS) : null
+  const isWithinDeregisterGracePeriod = deregisterGracePeriodEnd !== null && isFuture(deregisterGracePeriodEnd)
 
   // TODO: dont calculate this in frontend
   const actualDeregisterDeadline = chargeScheduleDate
@@ -162,6 +170,19 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   )
   const disabled = Boolean(disabledText)
 
+  const handleClick = () => {
+    if (!attendee) {
+      registerForAttendance()
+      return
+    }
+
+    if (isWithinDeregisterGracePeriod) {
+      unregisterForAttendance(null)
+    } else {
+      setDeregisterModalOpen(true)
+    }
+  }
+
   const buttonContent = isLoading ? (
     <IconLoader2 className="size-6 animate-spin py-2" />
   ) : (
@@ -184,7 +205,7 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
 
   const registrationButton = (
     <Button
-      onClick={attendee ? () => setDeregisterModalOpen(true) : registerForAttendance}
+      onClick={handleClick}
       disabled={disabled}
       icon={buttonIcon}
       className={cn(
@@ -210,7 +231,7 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   return (
     <>
       {registrationButton}
-      {attendee && (
+      {attendee && !isWithinDeregisterGracePeriod && (
         <DeregisterModal
           open={deregisterModalOpen}
           setOpen={setDeregisterModalOpen}


### PR DESCRIPTION
This PR adds a 1 hour 15 minute grace period after an attendee registers where a deregister reason is not required. The frontend starts prompting the user after 1 hour and 5 minutes. This is to avoid errors near the grace period end.

The frontend uses specifically 1h 5m to avoid overlap with payment deadlines. This doesn't matter, but I thought it could be nice. I personally do not believe these five minutes of polluting deregister reasons will help the other committees aggregate meaninful and actionable data.