### PR TITLE
Rename `redirectAfter` to `returnTo`

### DIFF
--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -56,7 +56,7 @@ export const AttendanceCard = ({
   const { setTRPCSSERegisterChangeConnectionState } = useTRPCSSERegisterChangeConnectionState()
 
   const fullPathname = useFullPathname()
-  const authorizeUrl = createAuthorizeUrl({ redirectAfter: fullPathname })
+  const authorizeUrl = createAuthorizeUrl({ returnTo: fullPathname })
 
   const [closeToEvent, setCloseToEvent] = useState(false)
   const [attendanceStatus, setAttendanceStatus] = useState(getAttendanceStatus(initialAttendance))

--- a/apps/web/src/app/innstillinger/bruker/link/page.tsx
+++ b/apps/web/src/app/innstillinger/bruker/link/page.tsx
@@ -12,7 +12,7 @@ export default async function LinkIdentityPage() {
   const session = await getServerSession()
 
   if (!session) {
-    redirect(createAuthorizeUrl({ redirectAfter: "/innstillinger/bruker/link" }))
+    redirect(createAuthorizeUrl({ returnTo: "/innstillinger/bruker/link" }))
   }
 
   const { secondaryUserId } = await getIdentityLinkCookies().catch(() => {

--- a/apps/web/src/app/innstillinger/bruker/page.tsx
+++ b/apps/web/src/app/innstillinger/bruker/page.tsx
@@ -68,7 +68,7 @@ export default function MinBrukerPage() {
   }, [sessionIsAuthenticated, synchronizeEmail])
 
   if (!sessionLoading && !sessionIsAuthenticated) {
-    redirect(createAuthorizeUrl({ redirectAfter: fullPathname }))
+    redirect(createAuthorizeUrl({ returnTo: fullPathname }))
   }
 
   if (sessionLoading || !sessionIsAuthenticated) {
@@ -80,12 +80,12 @@ export default function MinBrukerPage() {
 
   const linkFeideUrl = createLinkIdentityAuthorizeUrl({
     connection: "FEIDE",
-    redirectAfter: `${fullPathname}/link`,
+    returnTo: `${fullPathname}/link`,
   })
 
   const linkUsernamePasswordUrl = createLinkIdentityAuthorizeUrl({
     connection: "Username-Password-Authentication",
-    redirectAfter: `${fullPathname}/link`,
+    returnTo: `${fullPathname}/link`,
   })
 
   const usernamePasswordLinkButtonProps =

--- a/apps/web/src/app/innstillinger/medlemskap/page.tsx
+++ b/apps/web/src/app/innstillinger/medlemskap/page.tsx
@@ -54,7 +54,7 @@ export default function MedlemskapPage() {
   })
 
   if (!sessionLoading && !sessionIsAuthenticated) {
-    redirect(createAuthorizeUrl({ redirectAfter: fullPathname }))
+    redirect(createAuthorizeUrl({ returnTo: fullPathname }))
   }
 
   if (sessionLoading || !sessionIsAuthenticated) {
@@ -63,7 +63,7 @@ export default function MedlemskapPage() {
 
   const feideAuthorizeUrl = createAuthorizeUrl({
     connection: "FEIDE",
-    redirectAfter: fullPathname,
+    returnTo: fullPathname,
   })
 
   const isLoading = userIsLoading || auth0ConnectionsIsLoading || user === undefined || auth0Connections === undefined

--- a/apps/web/src/app/innstillinger/profil/page.tsx
+++ b/apps/web/src/app/innstillinger/profil/page.tsx
@@ -38,7 +38,7 @@ const EditProfilePage = () => {
   )
 
   if (!sessionLoading && !sessionIsAuthenticated) {
-    redirect(createAuthorizeUrl({ redirectAfter: fullPathname }))
+    redirect(createAuthorizeUrl({ returnTo: fullPathname }))
   }
 
   if (sessionLoading || !sessionIsAuthenticated || userIsLoading || user === undefined) {

--- a/apps/web/src/app/profil/route.ts
+++ b/apps/web/src/app/profil/route.ts
@@ -9,8 +9,8 @@ export async function GET(req: NextRequest) {
 
   if (!session) {
     const params = new URLSearchParams(req.nextUrl.search)
-    if (!params.has("redirectAfter")) {
-      params.set("redirectAfter", "/profil")
+    if (!params.has("returnTo")) {
+      params.set("returnTo", "/profil")
     }
     redirect(createAuthorizeUrl(params))
   }

--- a/apps/web/src/app/tilbakemelding/[eventId]/page.tsx
+++ b/apps/web/src/app/tilbakemelding/[eventId]/page.tsx
@@ -33,12 +33,13 @@ const EventFeedbackPage = async ({
   const isPreview = preview === "true"
 
   const session = await getServerSession()
-  if (!session) {
-    const params = new URLSearchParams()
-    if (!params.has("redirectAfter")) {
-      params.set("redirectAfter", `/tilbakemelding/${eventId}${preview ? `?preview=${preview}` : ""}`)
+
+  if (session === null) {
+    const authorizeParams = new URLSearchParams()
+    if (!authorizeParams.has("returnTo")) {
+      authorizeParams.set("returnTo", `/tilbakemelding/${eventId}${preview ? `?preview=${preview}` : ""}`)
     }
-    redirect(createAuthorizeUrl(params))
+    redirect(createAuthorizeUrl(authorizeParams))
   }
 
   const feedbackForm = await server.event.feedback.getFormByEventId.query(eventId)

--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -185,7 +185,7 @@ export const Navbar: FC = () => {
             variant="solid"
             color="brand"
             className="font-medium min-w-19 pl-3 pr-4 xs:pl-6 xs:pr-8 py-4 rounded-l-lg rounded-r-4xl shrink-0 h-full"
-            href={createAuthorizeUrl({ redirectAfter: fullPathname })}
+            href={createAuthorizeUrl({ returnTo: fullPathname })}
             prefetch={false}
             icon={<IconLogin2 className="mr-1.5 size-6" />}
           >

--- a/apps/web/src/components/molecules/MembershipDisplay/MembershipDisplay.tsx
+++ b/apps/web/src/components/molecules/MembershipDisplay/MembershipDisplay.tsx
@@ -97,7 +97,7 @@ const MembershipDisplayShell = ({
   let href: string | null = null
 
   if (activeMembership === null && hasFeideConnection) {
-    href = createAuthorizeUrl({ connection: "FEIDE", redirectAfter: pathname })
+    href = createAuthorizeUrl({ connection: "FEIDE", returnTo: pathname })
   } else if (!isMembershipPage) {
     href = "/innstillinger/medlemskap"
   }

--- a/packages/utils/src/urls.ts
+++ b/packages/utils/src/urls.ts
@@ -9,30 +9,15 @@ const LOGOUT_ENDPOINT = "/api/auth/logout"
 // to link the two accounts' identities and merge the two accounts into one.
 const LINK_IDENTITY_AUTHORIZE_ENDPOINT = "/api/auth/link-identity/authorize"
 
-function normalizeAuthorizeSearchParams(...parameters: ConstructorParameters<typeof URLSearchParams>): URLSearchParams {
-  const params = new URLSearchParams(...parameters)
-  const redirectAfter = params.get("redirectAfter")
-
-  if (redirectAfter !== null) {
-    params.delete("redirectAfter")
-
-    if (!params.has("returnTo")) {
-      params.set("returnTo", redirectAfter)
-    }
-  }
-
-  return params
-}
-
 /**
  * Creates an authorize URL with the given search parameters.
  *
  * @example
  * const fullPathname = useFullPathname()
- * const url = createAuthorizeUrl({ connection: "FEIDE", redirectAfter: fullPathname })
+ * const url = createAuthorizeUrl({ connection: "FEIDE", returnTo: fullPathname })
  */
 export const createAuthorizeUrl = (...parameters: ConstructorParameters<typeof URLSearchParams>) => {
-  const searchParams = normalizeAuthorizeSearchParams(...parameters).toString()
+  const searchParams = new URLSearchParams(...parameters).toString()
   if (!searchParams) {
     return AUTHORIZE_ENDPOINT
   }
@@ -46,7 +31,7 @@ export const createAuthorizeUrl = (...parameters: ConstructorParameters<typeof U
  * const url = createLogoutUrl()
  */
 export const createLogoutUrl = (...parameters: ConstructorParameters<typeof URLSearchParams>) => {
-  const searchParams = normalizeAuthorizeSearchParams(...parameters).toString()
+  const searchParams = new URLSearchParams(...parameters).toString()
   if (!searchParams) {
     return LOGOUT_ENDPOINT
   }
@@ -58,14 +43,14 @@ export const createLogoutUrl = (...parameters: ConstructorParameters<typeof URLS
  *
  * @example
  * const fullPathname = useFullPathname()
- * const url = createAbsoluteAuthorizeUrl(window.location.origin, { connection: "FEIDE", redirectAfter: fullPathname })
+ * const url = createAbsoluteAuthorizeUrl(window.location.origin, { connection: "FEIDE", returnTo: fullPathname })
  */
 export const createAbsoluteAuthorizeUrl = (
   origin: string,
   ...parameters: ConstructorParameters<typeof URLSearchParams>
 ) => {
   const url = new URL(AUTHORIZE_ENDPOINT, origin)
-  url.search = normalizeAuthorizeSearchParams(...parameters).toString()
+  url.search = new URLSearchParams(...parameters).toString()
   return url.toString()
 }
 
@@ -80,7 +65,7 @@ export const createAbsoluteLogoutUrl = (
   ...parameters: ConstructorParameters<typeof URLSearchParams>
 ) => {
   const url = new URL(LOGOUT_ENDPOINT, origin)
-  url.search = normalizeAuthorizeSearchParams(...parameters).toString()
+  url.search = new URLSearchParams(...parameters).toString()
   return url.toString()
 }
 
@@ -116,11 +101,11 @@ export const createCloudFrontUrl = (cloudFrontUrl: string, key: string): string 
  * const fullPathname = useFullPathname()
  * const url = createLinkIdentityAuthorizeUrl({
  *   connection: "FEIDE", // or "Username-Password-Authentication"
- *   redirectAfter: `${fullPathname}/link`,
+ *   returnTo: `${fullPathname}/link`,
  * })
  */
 export const createLinkIdentityAuthorizeUrl = (...parameters: ConstructorParameters<typeof URLSearchParams>) => {
-  const searchParams = normalizeAuthorizeSearchParams(...parameters).toString()
+  const searchParams = new URLSearchParams(...parameters).toString()
   if (!searchParams) {
     return LINK_IDENTITY_AUTHORIZE_ENDPOINT
   }
@@ -135,7 +120,7 @@ export const createLinkIdentityAuthorizeUrl = (...parameters: ConstructorParamet
  * const fullPathname = useFullPathname()
  * const url = createAbsoluteLinkIdentityAuthorizeUrl(window.location.origin, {
  *   connection: "FEIDE", // or "Username-Password-Authentication"
- *   redirectAfter: `${fullPathname}/link`,
+ *   returnTo: `${fullPathname}/link`,
  * })
  */
 export const createAbsoluteLinkIdentityAuthorizeUrl = (
@@ -143,6 +128,6 @@ export const createAbsoluteLinkIdentityAuthorizeUrl = (
   ...parameters: ConstructorParameters<typeof URLSearchParams>
 ) => {
   const url = new URL(LINK_IDENTITY_AUTHORIZE_ENDPOINT, origin)
-  url.search = normalizeAuthorizeSearchParams(...parameters).toString()
+  url.search = new URLSearchParams(...parameters).toString()
   return url.toString()
 }


### PR DESCRIPTION
This is for parity with Auth0. This is a breaking change so I thought it was nice to have it in its own PR if we need to revert it