### PR TITLE
Fix broken access token route

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^4.19.0",
+    "@auth0/nextjs-auth0": "^4.20.0",
     "@aws-sdk/client-s3": "^3.821.0",
     "@aws-sdk/s3-presigned-post": "^3.821.0",
     "@date-fns/tz": "^1.2.0",

--- a/apps/dashboard/src/lib/auth0.ts
+++ b/apps/dashboard/src/lib/auth0.ts
@@ -66,6 +66,7 @@ export const auth0 = new Auth0Client({
     login: "/api/auth/authorize",
     logout: "/api/auth/logout",
     callback: "/api/auth/callback/auth0",
+    accessToken: env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE,
   },
   signInReturnToPath: "/arrangementer",
 

--- a/apps/dashboard/src/lib/env.ts
+++ b/apps/dashboard/src/lib/env.ts
@@ -14,6 +14,7 @@ export const env = defineConfiguration({
     prd: "https://rpc.online.ntnu.no",
     dev: "http://localhost:4444",
   }),
+  NEXT_PUBLIC_ACCESS_TOKEN_ROUTE: config(process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE, "/api/auth/access-token"),
   RPC_HOST: config(process.env.RPC_HOST, {
     prd: "https://rpc.online.ntnu.no",
     dev: "http://localhost:4444",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^4.19.0",
+    "@auth0/nextjs-auth0": "^4.20.0",
     "@aws-sdk/client-s3": "^3.821.0",
     "@aws-sdk/s3-presigned-post": "^3.821.0",
     "@date-fns/tz": "^1.2.0",

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -19,6 +19,8 @@ export const env = defineConfiguration({
     prd: "https://rpc.online.ntnu.no",
     dev: "http://localhost:4444",
   }),
+  // https://auth0.github.io/nextjs-auth0/types/client.AccessTokenOptions.html#route
+  NEXT_PUBLIC_ACCESS_TOKEN_ROUTE: config(process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE, "/api/auth/access-token"),
   NEXT_PUBLIC_DASHBOARD_URL: config(process.env.NEXT_PUBLIC_DASHBOARD_URL, {
     prd: "https://dashboard.online.ntnu.no",
     dev: "http://localhost:3002",

--- a/apps/web/src/lib/auth0.ts
+++ b/apps/web/src/lib/auth0.ts
@@ -67,6 +67,7 @@ export const auth0 = new Auth0Client({
     login: "/api/auth/authorize",
     logout: "/api/auth/logout",
     callback: "/api/auth/callback/auth0",
+    accessToken: env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE,
   },
   signInReturnToPath: "/",
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   apps/dashboard:
     dependencies:
       '@auth0/nextjs-auth0':
-        specifier: ^4.19.0
-        version: 4.19.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^4.20.0
+        version: 4.20.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@aws-sdk/client-s3':
         specifier: ^3.821.0
         version: 3.1039.0
@@ -631,8 +631,8 @@ importers:
   apps/web:
     dependencies:
       '@auth0/nextjs-auth0':
-        specifier: ^4.19.0
-        version: 4.19.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^4.20.0
+        version: 4.20.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@aws-sdk/client-s3':
         specifier: ^3.821.0
         version: 3.1039.0
@@ -1277,8 +1277,8 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@auth0/nextjs-auth0@4.19.0':
-    resolution: {integrity: sha512-v+uO+ajKOPBfXRq+hR+Ubqb3mYxGwkhc+CsFOstQmKMJ1i9jUWx8m+rj3XYDKBoCE5bo7jCdo3DKjv4KVb/Rhg==}
+  '@auth0/nextjs-auth0@4.20.0':
+    resolution: {integrity: sha512-F6kpRKcLUqtxE622+oazsXTbay+19G+jhIN8IamiGHGLjNdFgaDwgHCaWnZNuHQrhvlqoGLpJ+5bjfGh4v38cw==}
     peerDependencies:
       next: ^14.2.35 || ~15.0.7 || ~15.1.11 || ~15.2.8 || ~15.3.8 || ~15.4.10 || ~15.5.9 || ^16.0.10
       react: ^18.0.0 || ~19.0.1 ||  ~19.1.2 || ^19.2.1
@@ -8831,7 +8831,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth0/nextjs-auth0@4.19.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@auth0/nextjs-auth0@4.20.0(next@15.5.16(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       '@panva/hkdf': 1.2.1
@@ -15583,7 +15583,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.16
       '@next/swc-darwin-x64': 15.5.16
@@ -16750,11 +16750,6 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@babel/core': 7.28.6
-
-  styled-jsx@5.1.6(react@19.2.5):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.5
 
   sugarss@5.0.1(postcss@8.5.14):
     dependencies:


### PR DESCRIPTION
Added `NEXT_PUBLIC_ACCESS_TOKEN_ROUTE=/api/auth/access-token`to Doppler projects for web and dashboard