### PR TITLE
Fix navbar login button height

### DIFF
--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -158,7 +158,7 @@ export const Navbar: FC = () => {
   const showLoginButton = sessionUser === null
 
   return (
-    <header className={cn("sticky top-4 z-50 flex w-full max-w-7xl items-center mt-4", showLoginButton && "gap-1.5")}>
+    <header className={cn("sticky top-4 z-50 flex w-full max-w-7xl items-stretch mt-4", showLoginButton && "gap-1.5")}>
       <div
         className={cn(
           // i have no idea why i need rounded-r-4xl and not rounded-r-full
@@ -181,7 +181,7 @@ export const Navbar: FC = () => {
       </div>
 
       {showLoginButton && (
-        <div className="self-stretch shrink-0 rounded-l-lg rounded-r-4xl bg-blue-100/80 dark:bg-stone-800/90 backdrop-blur-xl shadow-sm">
+        <div className="flex shrink-0 rounded-l-lg rounded-r-4xl bg-blue-100/80 dark:bg-stone-800/90 backdrop-blur-xl shadow-sm">
           <Button
             element="a"
             variant="solid"

--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -181,7 +181,7 @@ export const Navbar: FC = () => {
       </div>
 
       {showLoginButton && (
-        <div className="h-full shrink-0 rounded-l-lg rounded-r-4xl bg-blue-100/80 dark:bg-stone-800/90 backdrop-blur-xl shadow-sm">
+        <div className="self-stretch shrink-0 rounded-l-lg rounded-r-4xl bg-blue-100/80 dark:bg-stone-800/90 backdrop-blur-xl shadow-sm">
           <Button
             element="a"
             variant="solid"


### PR DESCRIPTION
### Problem:
The login button is not the same height as the rest of the navbar pill.

### Fix:
~~Adjust the height to be `self-stretch` to make it fill the cross axis size.~~
Set `items-stretch`  on nav and `flex` on button

### Visual Verification:
Goes from:
<img width="1272" height="142" alt="Screenshot 2026-05-21 at 15 13 34" src="https://github.com/user-attachments/assets/ff06d9c0-fefc-4b28-88c5-0057477d76c6" />

To:
<img width="1229" height="96" alt="Screenshot 2026-05-21 at 15 23 41" src="https://github.com/user-attachments/assets/be4d0fc9-b198-4b4e-9b10-a2da28a8a6aa" />