### PR TITLE
Return `204` for unauthenticated authentication profile

### DIFF
--- a/apps/dashboard/src/lib/auth0.ts
+++ b/apps/dashboard/src/lib/auth0.ts
@@ -90,6 +90,7 @@ export const auth0 = new Auth0Client({
     },
   },
   tokenRefreshBuffer: AUTH0_TOKEN_REFRESH_BUFFER_SECONDS,
+  noContentProfileResponseWhenUnauthenticated: true,
   routes: {
     login: "/api/auth/authorize",
     logout: "/api/auth/logout",

--- a/apps/web/src/lib/auth0.ts
+++ b/apps/web/src/lib/auth0.ts
@@ -89,6 +89,7 @@ export const auth0 = new Auth0Client({
     },
   },
   tokenRefreshBuffer: AUTH0_TOKEN_REFRESH_BUFFER_SECONDS,
+  noContentProfileResponseWhenUnauthenticated: true,
   routes: {
     login: "/api/auth/authorize",
     logout: "/api/auth/logout",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,7 +6,6 @@ import {
 } from "@dotkomonline/utils"
 import type { NextRequest } from "next/server"
 import { NextResponse } from "next/server"
-
 import { auth0 } from "@/lib/auth0"
 
 function isRedirectResponse(response: NextResponse): boolean {


### PR DESCRIPTION
Auth0 returns 401 unauthorized when trying to fetch your session profile when you're not authenticated by default, and then it would continue to retry the request since it failed. I thiiink this is due to my recent changes with the middlewares, or I just never noticed it