### PR TITLE
Update `tailwindcss` and related packages

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -52,7 +52,6 @@
     "@trpc/client": "11.8.1",
     "@trpc/server": "11.8.1",
     "@trpc/tanstack-react-query": "11.8.1",
-    "clsx": "^2.0.0",
     "date-fns": "^4.1.0",
     "import-in-the-middle": "^3.0.1",
     "jose": "^6.0.11",
@@ -78,7 +77,7 @@
     "postcss": "8.5.15",
     "postcss-preset-mantine": "1.18.0",
     "postcss-simple-vars": "7.0.1",
-    "tailwindcss": "4.1.18",
+    "tailwindcss": "4.3.0",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
   }

--- a/apps/grades-frontend/package.json
+++ b/apps/grades-frontend/package.json
@@ -27,7 +27,6 @@
     "@trpc/next": "11.8.1",
     "@trpc/tanstack-react-query": "11.8.1",
     "axios": "1.16.1",
-    "clsx": "^2.0.0",
     "core-js": "^3.45.1",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
@@ -60,7 +59,7 @@
     "@types/react-dom": "19.2.3",
     "cva": "npm:class-variance-authority@0.7.1",
     "postcss": "8.5.15",
-    "tailwindcss": "4.1.18",
+    "tailwindcss": "4.3.0",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,6 @@
     "@trpc/next": "11.8.1",
     "@trpc/tanstack-react-query": "11.8.1",
     "axios": "1.16.1",
-    "clsx": "^2.0.0",
     "core-js": "^3.45.1",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
@@ -80,7 +79,7 @@
     "@types/react-dom": "19.2.3",
     "cva": "npm:class-variance-authority@0.7.1",
     "postcss": "8.5.15",
-    "tailwindcss": "4.1.18",
+    "tailwindcss": "4.3.0",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
   },

--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -14,14 +14,13 @@ import {
   getAttendanceCapacity,
   getReservedAttendeeCount,
 } from "@dotkomonline/types"
-import { Tabs, TabsContent, TabsList, TabsTrigger, Text, Title } from "@dotkomonline/ui"
+import { cn, Tabs, TabsContent, TabsList, TabsTrigger, Text, Title } from "@dotkomonline/ui"
 import {
   createAbsoluteEventPageUrl,
   createEventPageUrl,
   createEventSlug,
   richTextToPlainText,
 } from "@dotkomonline/utils"
-import clsx from "clsx"
 import { isPast } from "date-fns"
 import type { Metadata } from "next"
 import Image from "next/image"
@@ -57,7 +56,7 @@ const mapToImageAndName = (item: Group | Company, type: OrganizerType) => (
         alt={"abbreviation" in item ? item.abbreviation : item.name}
         width={22}
         height={22}
-        className={clsx((type === "COMMITTEE" || type === "NODE_COMMITTEE") && "dark:invert")}
+        className={cn((type === "COMMITTEE" || type === "NODE_COMMITTEE") && "dark:invert")}
       />
     )}
     <Text>{"abbreviation" in item ? item.abbreviation : item.name}</Text>

--- a/apps/web/src/app/arrangementer/components/TimeLocationBox/ActionLink.tsx
+++ b/apps/web/src/app/arrangementer/components/TimeLocationBox/ActionLink.tsx
@@ -1,6 +1,5 @@
-import { Text, Tooltip, TooltipContent, TooltipTrigger } from "@dotkomonline/ui"
+import { cn, Text, Tooltip, TooltipContent, TooltipTrigger } from "@dotkomonline/ui"
 import { IconArrowUpRight } from "@tabler/icons-react"
-import clsx from "clsx"
 import Link from "next/link.js"
 
 interface Props {
@@ -12,7 +11,7 @@ export const ActionLink = ({ href, label }: Props) => (
   <Tooltip delayDuration={150}>
     <TooltipTrigger>
       <Link
-        className={clsx(
+        className={cn(
           "border border-gray-200 hover:bg-gray-100 dark:border-stone-700 dark:hover:bg-stone-700 p-1.5 rounded-lg flex items-center"
         )}
         href={href}

--- a/apps/web/src/app/artikler/ArticleListItem.tsx
+++ b/apps/web/src/app/artikler/ArticleListItem.tsx
@@ -1,6 +1,5 @@
 import type { Article } from "@dotkomonline/types"
-import { Text } from "@dotkomonline/ui"
-import clsx from "clsx"
+import { cn, Text } from "@dotkomonline/ui"
 import { formatDate } from "date-fns"
 import Image from "next/image"
 import Link from "next/link"
@@ -14,7 +13,7 @@ export interface ArticleListItemProps {
 export const ArticleListItem: FC<ArticleListItemProps> = ({ article, orientation }: ArticleListItemProps) => (
   <Link
     href={`/artikler/${article.slug}/${article.id}`}
-    className={clsx(
+    className={cn(
       "flex flex-1 rounded-lg overflow-hidden shadow-md duration-200 transition-transform hover:-translate-y-1 hover:shadow-lg dark:bg-stone-800",
       orientation === "horizontal" ? "sm:flex-row flex-col" : "flex-col max-w-md"
     )}
@@ -25,7 +24,7 @@ export const ArticleListItem: FC<ArticleListItemProps> = ({ article, orientation
       width={0}
       height={0}
       sizes="100%"
-      className={clsx("aspect-[16/9] object-cover w-full", orientation === "horizontal" && "sm:w-[40%]")}
+      className={cn("aspect-[16/9] object-cover w-full", orientation === "horizontal" && "sm:w-[40%]")}
     />
     <div className="p-4 justify-between flex flex-col flex-1">
       <div>

--- a/apps/web/src/app/artikler/[slug]/[id]/page.tsx
+++ b/apps/web/src/app/artikler/[slug]/[id]/page.tsx
@@ -1,9 +1,8 @@
 import { env } from "@/env"
 import { server } from "@/utils/trpc/server"
 import type { Article, ArticleTagName, ArticleTag as ArticleTagType } from "@dotkomonline/types"
-import { Button, RichText, Text, Title, Video } from "@dotkomonline/ui"
+import { Button, cn, RichText, Text, Title, Video } from "@dotkomonline/ui"
 import { richTextToPlainText } from "@dotkomonline/utils"
-import clsx from "clsx"
 import { formatDate, isEqual } from "date-fns"
 import type { Metadata } from "next"
 import Image from "next/image"
@@ -113,7 +112,7 @@ interface BylineItemProps {
 }
 
 const BylineItem = ({ label, value, className }: BylineItemProps) => (
-  <Text className={clsx("whitespace-nowrap", className)}>
+  <Text className={cn("whitespace-nowrap", className)}>
     <span className="text-black dark:text-gray-100 font-medium">{label} </span>
     {value}
   </Text>

--- a/apps/web/src/app/tilbakemelding/components/FeedbackForm.tsx
+++ b/apps/web/src/app/tilbakemelding/components/FeedbackForm.tsx
@@ -15,8 +15,8 @@ import {
   Text,
   TextInput,
   Textarea,
+  cn,
 } from "@dotkomonline/ui"
-import clsx from "clsx"
 import React, { type ReactNode, useRef, useState } from "react"
 import { type Control, Controller, type FieldErrors, useForm } from "react-hook-form"
 import { useCreateFeedbackAnswerMutation } from "../mutations"
@@ -142,7 +142,7 @@ const QuestionCard = React.forwardRef<HTMLDivElement, Props>(({ question, index,
   return (
     <div
       ref={ref}
-      className={clsx("shadow-md p-6 rounded-lg border-2", hasErrors ? "border-red-600" : "border-gray-100")}
+      className={cn("shadow-md p-6 rounded-lg border-2", hasErrors ? "border-red-600" : "border-gray-100")}
     >
       <div className="mb-6">
         <Label htmlFor={question.id} className="text-lg inline dark:text-white break-words">
@@ -272,7 +272,7 @@ const RatingQuestion = ({ question, index, control }: QuestionProps) => (
             <Label
               key={`${question.id}.${n}`}
               htmlFor={`${question.id}.${n}`}
-              className={clsx(
+              className={cn(
                 "items-center justify-center w-10 h-10 hover:bg-gray-200 dark:hover:bg-stone-300 active:bg-gray-300 dark:active:bg-stone-400 rounded-full border border-gray-600 dark:border-stone-300 cursor-pointer",
                 Number(value) === n &&
                   "bg-brand text-white hover:bg-gray-400 dark:hover:bg-stone-300 active:bg-gray-500 dark:active:bg-stone-400"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,7 +20,7 @@
     "@tailwindcss/postcss": "4.1.18",
     "@tailwindcss/typography": "0.5.19",
     "postcss": "8.5.15",
-    "tailwindcss": "4.1.18",
+    "tailwindcss": "4.3.0",
     "tailwindcss-animate": "1.0.7",
     "tailwindcss-radix": "4.0.2",
     "typescript": "5.9.3"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,13 +32,13 @@
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tabler/icons-react": "^3.35.0",
-    "clsx": "^2.0.0",
-    "cva": "npm:class-variance-authority@^0.7.0",
+    "clsx": "^2.1.1",
+    "cva": "npm:class-variance-authority@^0.7.1",
     "isomorphic-dompurify": "^3.0.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-parallax-tilt": "^1.7.299",
-    "tailwind-merge": "^2.6.0",
+    "tailwind-merge": "^3.6.0",
     "vaul": "^1.1.2"
   },
   "peerDependencies": {
@@ -51,7 +51,7 @@
     "@tailwindcss/postcss": "4.1.18",
     "@types/react": "19.2.15",
     "postcss": "8.5.15",
-    "tailwindcss": "4.1.18",
+    "tailwindcss": "4.3.0",
     "typescript": "5.9.3",
     "vite": "6.4.2",
     "vitest": "3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       '@trpc/tanstack-react-query':
         specifier: 11.8.1
         version: 11.8.1(@tanstack/react-query@5.100.11(react@19.2.6))(@trpc/client@11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.8.1(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
-      clsx:
-        specifier: ^2.0.0
-        version: 2.1.1
       date-fns:
         specifier: ^4.1.0
         version: 4.2.1
@@ -211,8 +208,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1(postcss@8.5.15)
       tailwindcss:
-        specifier: 4.1.18
-        version: 4.1.18
+        specifier: 4.3.0
+        version: 4.3.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -342,7 +339,7 @@ importers:
         version: 3.44.0(react@19.2.6)
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.19(tailwindcss@4.1.18)
+        version: 0.5.19(tailwindcss@4.3.0)
       '@tanstack/react-query':
         specifier: ^5.79.0
         version: 5.100.11(react@19.2.6)
@@ -358,9 +355,6 @@ importers:
       axios:
         specifier: 1.16.1
         version: 1.16.1
-      clsx:
-        specifier: ^2.0.0
-        version: 2.1.1
       core-js:
         specifier: ^3.45.1
         version: 3.49.0
@@ -453,8 +447,8 @@ importers:
         specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
-        specifier: 4.1.18
-        version: 4.1.18
+        specifier: 4.3.0
+        version: 4.3.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -695,7 +689,7 @@ importers:
         version: 3.44.0(react@19.2.6)
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.19(tailwindcss@4.1.18)
+        version: 0.5.19(tailwindcss@4.3.0)
       '@tanstack/react-query':
         specifier: ^5.79.0
         version: 5.100.11(react@19.2.6)
@@ -711,9 +705,6 @@ importers:
       axios:
         specifier: 1.16.1
         version: 1.16.1
-      clsx:
-        specifier: ^2.0.0
-        version: 2.1.1
       core-js:
         specifier: ^3.45.1
         version: 3.49.0
@@ -821,8 +812,8 @@ importers:
         specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
-        specifier: 4.1.18
-        version: 4.1.18
+        specifier: 4.3.0
+        version: 4.3.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -843,19 +834,19 @@ importers:
         version: 4.1.18
       '@tailwindcss/typography':
         specifier: 0.5.19
-        version: 0.5.19(tailwindcss@4.1.18)
+        version: 0.5.19(tailwindcss@4.3.0)
       postcss:
         specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
-        specifier: 4.1.18
-        version: 4.1.18
+        specifier: 4.3.0
+        version: 4.3.0
       tailwindcss-animate:
         specifier: 1.0.7
-        version: 1.0.7(tailwindcss@4.1.18)
+        version: 1.0.7(tailwindcss@4.3.0)
       tailwindcss-radix:
         specifier: 4.0.2
-        version: 4.0.2(tailwindcss@4.1.18)
+        version: 4.0.2(tailwindcss@4.3.0)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1156,10 +1147,10 @@ importers:
         specifier: ^3.35.0
         version: 3.44.0(react@19.2.6)
       clsx:
-        specifier: ^2.0.0
+        specifier: ^2.1.1
         version: 2.1.1
       cva:
-        specifier: npm:class-variance-authority@^0.7.0
+        specifier: npm:class-variance-authority@^0.7.1
         version: class-variance-authority@0.7.1
       isomorphic-dompurify:
         specifier: ^3.0.0
@@ -1177,8 +1168,8 @@ importers:
         specifier: ^1.7.299
         version: 1.7.328(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.1
+        specifier: ^3.6.0
+        version: 3.6.0
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1202,8 +1193,8 @@ importers:
         specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
-        specifier: 4.1.18
-        version: 4.1.18
+        specifier: 4.3.0
+        version: 4.3.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -8216,8 +8207,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -8232,6 +8223,9 @@ packages:
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
@@ -12182,10 +12176,10 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.1.18
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 4.1.18
+      tailwindcss: 4.3.0
 
   '@tanstack/query-core@5.100.11': {}
 
@@ -15487,7 +15481,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -16759,11 +16753,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.6
 
-  styled-jsx@5.1.6(react@19.2.6):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.6
-
   sugarss@5.0.1(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
@@ -16792,17 +16781,19 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@2.6.1: {}
+  tailwind-merge@3.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@4.1.18):
+  tailwindcss-animate@1.0.7(tailwindcss@4.3.0):
     dependencies:
-      tailwindcss: 4.1.18
+      tailwindcss: 4.3.0
 
-  tailwindcss-radix@4.0.2(tailwindcss@4.1.18):
+  tailwindcss-radix@4.0.2(tailwindcss@4.3.0):
     dependencies:
-      tailwindcss: 4.1.18
+      tailwindcss: 4.3.0
 
   tailwindcss@4.1.18: {}
+
+  tailwindcss@4.3.0: {}
 
   tapable@2.3.0: {}
 


### PR DESCRIPTION
Updates `tailwindcss`, `tailwind-merge`, `clsx`, and `cva`

Removes `clsx` dependency from web, dashboard, and grades-frontend, and replaces all usage with `cn`