### PR TITLE
Implement registration and deregistration availability views

### DIFF
--- a/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
+++ b/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
@@ -1,0 +1,232 @@
+import { TZDate } from "@date-fns/tz"
+import type { Attendance, Attendee, Punishment } from "@dotkomonline/types"
+import { getCurrentUTC } from "@dotkomonline/utils"
+import { addDays, addHours, subHours } from "date-fns"
+import { describe, expect, it } from "vitest"
+import {
+  type RegistrationAvailabilityResult,
+  type RegistrationAvailabilitySuccess,
+  buildDeregistrationAvailabilityView,
+  buildRegistrationAvailabilityView,
+} from "./attendance-service"
+
+const userId = "00000000-0000-4000-8000-000000000001"
+
+const createAttendance = (overrides: Partial<Attendance> = {}): Attendance =>
+  ({
+    id: "00000000-0000-4000-8000-000000000010",
+    registerStart: subHours(getCurrentUTC(), 1),
+    registerEnd: addHours(getCurrentUTC(), 12),
+    deregisterDeadline: addDays(getCurrentUTC(), 2),
+    attendancePrice: 100,
+    pools: [
+      {
+        id: "00000000-0000-4000-8000-000000000020",
+        title: "Pool",
+        capacity: 2,
+        mergeDelayHours: null,
+        yearCriteria: [1],
+        attendanceId: "00000000-0000-4000-8000-000000000010",
+        taskId: null,
+        createdAt: getCurrentUTC(),
+        updatedAt: getCurrentUTC(),
+      },
+    ],
+    attendees: [],
+    selections: [],
+    createdAt: getCurrentUTC(),
+    updatedAt: getCurrentUTC(),
+    ...overrides,
+  }) as Attendance
+
+const createAttendee = (overrides: Partial<Attendee> = {}): Attendee =>
+  ({
+    id: "00000000-0000-4000-8000-000000000030",
+    userId,
+    attendanceId: "00000000-0000-4000-8000-000000000010",
+    attendancePoolId: "00000000-0000-4000-8000-000000000020",
+    createdAt: getCurrentUTC(),
+    updatedAt: getCurrentUTC(),
+    reserved: true,
+    attendedAt: null,
+    earliestReservationAt: getCurrentUTC(),
+    paymentChargedAt: null,
+    paymentRefundedAt: null,
+    paymentDeadline: null,
+    paymentId: null,
+    paymentLink: null,
+    paymentChargeDeadline: null,
+    paymentReservedAt: null,
+    paymentRefundedById: null,
+    paymentCheckoutUrl: null,
+    userGrade: 1,
+    selections: [],
+    user: {
+      id: userId,
+      name: "Test User",
+      email: "test@example.com",
+      username: "testuser",
+      imageUrl: null,
+      createdAt: getCurrentUTC(),
+      updatedAt: getCurrentUTC(),
+      memberships: [],
+      auth0Id: "auth0|test",
+      phoneNumber: null,
+      allergies: [],
+      dietaryPreferences: [],
+    },
+    ...overrides,
+  }) as Attendee
+
+const createSuccessResult = (
+  attendance: Attendance,
+  reservationActiveAt: Date = getCurrentUTC()
+): RegistrationAvailabilitySuccess => ({
+  success: true,
+  reservationActiveAt: new TZDate(reservationActiveAt),
+  event: {} as never,
+  attendance,
+  user: createAttendee().user,
+  membership: {} as never,
+  pool: attendance.pools[0],
+  bypassedChecks: [],
+  options: {
+    ignoreRegistrationWindow: false,
+    ignoreRegisteredToParent: false,
+    immediateReservation: false,
+    immediatePayment: true,
+    overriddenAttendancePoolId: null,
+    overrideTurnstileCheck: true,
+  },
+})
+
+describe("buildRegistrationAvailabilityView", () => {
+  it("returns rejection cause when registration is not allowed", () => {
+    const attendance = createAttendance()
+    const punishment: Punishment = { suspended: true, delay: 0 }
+    const result: RegistrationAvailabilityResult = { success: false, cause: "SUSPENDED" }
+
+    const view = buildRegistrationAvailabilityView(userId, result, punishment, attendance)
+
+    expect(view).toEqual({
+      userId,
+      punishment,
+      pool: null,
+      registration: {
+        canRegister: false,
+        rejectionCause: "SUSPENDED",
+        reservationActiveAt: null,
+        willBeUnreserved: false,
+        hasMergeDelay: false,
+      },
+      deregistration: null,
+    })
+  })
+
+  it("returns unreserved state when registration succeeds with delay", () => {
+    const reservationActiveAt = addHours(getCurrentUTC(), 2)
+    const attendance = createAttendance()
+    const punishment: Punishment = { suspended: false, delay: 2 }
+    const result = createSuccessResult(attendance, reservationActiveAt)
+
+    const view = buildRegistrationAvailabilityView(userId, result, punishment, attendance)
+
+    expect(view.registration?.canRegister).toBe(true)
+    expect(view.registration?.rejectionCause).toBeNull()
+    expect(view.registration?.willBeUnreserved).toBe(true)
+    expect(view.punishment).toEqual(punishment)
+    expect(view.pool).toEqual({
+      id: attendance.pools[0].id,
+      mergeDelayHours: null,
+      isPoolFull: false,
+    })
+  })
+
+  it("marks pool as full when reserved count reaches capacity", () => {
+    const attendance = createAttendance({
+      attendees: [
+        createAttendee({ id: "00000000-0000-4000-8000-000000000031", reserved: true }),
+        createAttendee({ id: "00000000-0000-4000-8000-000000000032", reserved: true }),
+      ],
+    })
+    const result = createSuccessResult(attendance)
+
+    const view = buildRegistrationAvailabilityView(userId, result, null, attendance)
+
+    expect(view.pool?.isPoolFull).toBe(true)
+    expect(view.registration?.willBeUnreserved).toBe(true)
+  })
+})
+
+describe("buildDeregistrationAvailabilityView", () => {
+  it("allows deregistration within grace period", () => {
+    const attendance = createAttendance()
+    const attendee = createAttendee({ createdAt: getCurrentUTC() })
+
+    const view = buildDeregistrationAvailabilityView(userId, attendee, attendance, null)
+
+    expect(view.deregistration).toEqual(
+      expect.objectContaining({
+        canDeregister: true,
+        rejectionCause: null,
+        isWithinGracePeriod: true,
+        requiresDeregisterReason: false,
+        hasBeenCharged: false,
+        chargeScheduleDate: null,
+      })
+    )
+  })
+
+  it("requires deregister reason after grace period", () => {
+    const attendance = createAttendance()
+    const attendee = createAttendee({ createdAt: subHours(getCurrentUTC(), 3) })
+
+    const view = buildDeregistrationAvailabilityView(userId, attendee, attendance, null)
+
+    expect(view.deregistration?.isWithinGracePeriod).toBe(false)
+    expect(view.deregistration?.requiresDeregisterReason).toBe(true)
+    expect(view.deregistration?.canDeregister).toBe(true)
+  })
+
+  it("blocks deregistration when payment has been charged", () => {
+    const attendance = createAttendance()
+    const attendee = createAttendee({
+      paymentChargedAt: getCurrentUTC(),
+      paymentRefundedAt: null,
+    })
+
+    const view = buildDeregistrationAvailabilityView(userId, attendee, attendance, null)
+
+    expect(view.deregistration?.canDeregister).toBe(false)
+    expect(view.deregistration?.rejectionCause).toBe("PAYMENT_COMPLETED")
+    expect(view.deregistration?.hasBeenCharged).toBe(true)
+  })
+
+  it("blocks deregistration after deadline for reserved attendees", () => {
+    const attendance = createAttendance({
+      deregisterDeadline: subHours(getCurrentUTC(), 1),
+    })
+    const attendee = createAttendee({
+      createdAt: subHours(getCurrentUTC(), 3),
+      reserved: true,
+    })
+
+    const view = buildDeregistrationAvailabilityView(userId, attendee, attendance, null)
+
+    expect(view.deregistration?.canDeregister).toBe(false)
+    expect(view.deregistration?.rejectionCause).toBe("DEREGISTER_DEADLINE_PASSED")
+    expect(view.deregistration?.isPastDeregisterDeadline).toBe(true)
+  })
+
+  it("uses the earlier charge schedule date as deregister deadline", () => {
+    const deregisterDeadline = addDays(getCurrentUTC(), 2)
+    const chargeScheduleDate = addHours(getCurrentUTC(), 6)
+    const attendance = createAttendance({ deregisterDeadline })
+    const attendee = createAttendee({ createdAt: subHours(getCurrentUTC(), 3) })
+
+    const view = buildDeregistrationAvailabilityView(userId, attendee, attendance, chargeScheduleDate)
+
+    expect(view.deregistration?.actualDeregisterDeadline).toEqual(chargeScheduleDate)
+    expect(view.deregistration?.chargeScheduleDate).toEqual(chargeScheduleDate)
+  })
+})

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -9,24 +9,22 @@ import {
   AttendeeSchema,
   AttendeeSelectionResponseSchema,
   DeregisterReasonTypeSchema,
+  DEREGISTER_GRACE_PERIOD_MS,
   EventSchema,
   type GroupId,
+  RegistrationAvailabilityViewSchema,
   UserSchema,
 } from "@dotkomonline/types"
 import { getCurrentUTC } from "@dotkomonline/utils"
 import type { inferProcedureInput, inferProcedureOutput } from "@trpc/server"
 import { TRPCError } from "@trpc/server"
-import { addHours, addMilliseconds, hoursToMilliseconds, isPast } from "date-fns"
+import { addHours, addMilliseconds, isPast } from "date-fns"
 import { z } from "zod"
 import { isAdministrator, isCommitteeMember, isGroupMemberOfAny, isSameSubject, or } from "../../authorization"
 import { FailedPreconditionError, InvalidArgumentError, NotFoundError } from "../../error"
 import { withAuditLogEntry, withAuthentication, withAuthorization, withDatabaseTransaction } from "../../middlewares"
 import { procedure, t } from "../../trpc"
-
-// A grace period of 2 hours after registration to allow attendees to deregister in case of accidental registration or a
-// quick change of mind. This duration was chosen arbitrarily, though it seemed nice to not overlap with the 1 hour
-// payment deadline. Frontends should have a few seconds to account for clock skew to avoid errors near the grace end.
-const DEREGISTER_GRACE_PERIOD_MS = hoursToMilliseconds(2)
+import { buildDeregistrationAvailabilityView, buildRegistrationAvailabilityView } from "./attendance-service"
 
 export type CreatePoolInput = inferProcedureInput<typeof createPoolProcedure>
 export type CreatePoolOutput = inferProcedureOutput<typeof createPoolProcedure>
@@ -169,23 +167,41 @@ const getSelectionsResultsProcedure = procedure
 export type GetRegistrationAvailabilityInput = inferProcedureInput<typeof getRegistrationAvailabilityProcedure>
 export type GetRegistrationAvailabilityOutput = inferProcedureOutput<typeof getRegistrationAvailabilityProcedure>
 const getRegistrationAvailabilityProcedure = procedure
-  .input(z.object({ attendanceId: AttendanceSchema.shape.id, turnstileToken: z.string() }))
+  .input(
+    z.object({
+      attendanceId: AttendanceSchema.shape.id,
+    })
+  )
+  .output(RegistrationAvailabilityViewSchema)
   .use(withAuthentication())
   .use(withDatabaseTransaction())
   .query(async ({ input, ctx }) => {
-    return await ctx.attendanceService.getRegistrationAvailability(
-      ctx.handle,
-      input.attendanceId,
-      input.turnstileToken,
-      ctx.principal.subject,
-      {
+    const userId = ctx.principal.subject
+    const attendance = await ctx.attendanceService.getAttendanceById(ctx.handle, input.attendanceId)
+    const attendee = attendance.attendees.find((attendee) => attendee.userId === userId)
+
+    if (attendee !== undefined) {
+      const chargeScheduleDate = await ctx.attendanceService.findChargeAttendeeScheduleDate(ctx.handle, attendee.id)
+
+      return RegistrationAvailabilityViewSchema.parse(
+        buildDeregistrationAvailabilityView(userId, attendee, attendance, chargeScheduleDate)
+      )
+    }
+
+    const [punishment, result] = await Promise.all([
+      ctx.personalMarkService.findPunishmentByUserId(ctx.handle, userId),
+      ctx.attendanceService.getRegistrationAvailability(ctx.handle, input.attendanceId, null, userId, {
         ignoreRegistrationWindow: false,
         immediateReservation: false,
         immediatePayment: true,
         overriddenAttendancePoolId: null,
         ignoreRegisteredToParent: false,
-        overrideTurnstileCheck: false,
-      }
+        overrideTurnstileCheck: true,
+      }),
+    ])
+
+    return RegistrationAvailabilityViewSchema.parse(
+      buildRegistrationAvailabilityView(userId, result, punishment, attendance)
     )
   })
 

--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -17,14 +17,20 @@ import {
   type AttendeeWrite,
   AttendeeWriteSchema,
   DEFAULT_MARK_DURATION,
+  DEREGISTER_GRACE_PERIOD_CLOCK_SKEW_MS,
+  DEREGISTER_GRACE_PERIOD_MS,
   type Event,
   type Membership,
+  type Punishment,
+  type RegistrationAvailabilityView,
+  type RegistrationRejectionCause,
   type TaskId,
   type User,
   type UserId,
   findActiveMembership,
-  hasAttendeePaid,
+  getReservedAttendeeCount,
   isAttendable,
+  isAttendeeChargedAndUnrefunded,
   findFirstHostingGroupEmail,
 } from "@dotkomonline/types"
 import {
@@ -38,6 +44,7 @@ import {
 import {
   addDays,
   addHours,
+  addMilliseconds,
   compareAsc,
   differenceInHours,
   endOfYesterday,
@@ -111,19 +118,7 @@ type EventDeregistrationOptions = {
   ignoreDeregistrationWindow: boolean
 }
 
-/** Different types of problems that prevent a user from registering for an event */
-export type RegistrationRejectionCause = keyof typeof RegistrationRejectionCause
-export const RegistrationRejectionCause = {
-  SUSPENDED: "SUSPENDED",
-  TOO_EARLY: "TOO_EARLY",
-  TOO_LATE: "TOO_LATE",
-  ALREADY_REGISTERED: "ALREADY_REGISTERED",
-  MISSING_PARENT_REGISTRATION: "MISSING_PARENT_REGISTRATION",
-  MISSING_PARENT_RESERVATION: "MISSING_PARENT_RESERVATION",
-  MISSING_MEMBERSHIP: "MISSING_MEMBERSHIP",
-  NO_MATCHING_POOL: "NO_MATCHING_POOL",
-  INVALID_TURNSTILE_TOKEN: "INVALID_TURNSTILE_TOKEN",
-} as const
+export type { RegistrationRejectionCause } from "@dotkomonline/types"
 
 export type RegistrationBypassCause = keyof typeof RegistrationBypassCause
 export const RegistrationBypassCause = {
@@ -854,12 +849,7 @@ export function getAttendanceService(
         throw new NotFoundError(`Attendee(ID=${attendeeId}) not found in Attendance(ID=${attendance.id})`)
       }
 
-      const hasPaid = hasAttendeePaid(attendee, attendance.attendancePrice, {
-        excludePaymentReservation: true,
-      })
-
-      // If the attendee has paid and not been refunded, we cannot allow deregistration.
-      if (hasPaid && !attendee.paymentRefundedAt) {
+      if (isAttendeeChargedAndUnrefunded(attendee)) {
         throw new FailedPreconditionError(
           `Cannot deregister Attendee(ID=${attendeeId}) from Attendance(ID=${attendance.id}) because payment has been completed`
         )
@@ -1811,5 +1801,101 @@ function emitRegistrationAvailabilityDiagnostics(
         )
         continue diag
     }
+  }
+}
+
+export function buildRegistrationAvailabilityView(
+  userId: UserId,
+  result: RegistrationAvailabilityResult,
+  punishment: Punishment | null,
+  attendance: Attendance
+): RegistrationAvailabilityView {
+  if (!result.success) {
+    return {
+      userId,
+      punishment,
+      pool: null,
+      registration: {
+        canRegister: false,
+        rejectionCause: result.cause,
+        reservationActiveAt: null,
+        willBeUnreserved: false,
+        hasMergeDelay: false,
+      },
+      deregistration: null,
+    }
+  }
+
+  const { pool, reservationActiveAt } = result
+  const reservedCount = getReservedAttendeeCount(attendance, pool.id)
+  const isPoolFull = pool.capacity !== 0 && reservedCount >= pool.capacity
+  const willBeUnreserved = isFuture(reservationActiveAt) || isPoolFull
+  const hasMergeDelay = pool.mergeDelayHours !== null && pool.mergeDelayHours > 0
+
+  return {
+    userId,
+    punishment,
+    pool: {
+      id: pool.id,
+      mergeDelayHours: pool.mergeDelayHours,
+      isPoolFull,
+    },
+    registration: {
+      canRegister: true,
+      rejectionCause: null,
+      reservationActiveAt,
+      willBeUnreserved,
+      hasMergeDelay,
+    },
+    deregistration: null,
+  }
+}
+
+export function buildDeregistrationAvailabilityView(
+  userId: UserId,
+  attendee: Attendee,
+  attendance: Attendance,
+  chargeScheduleDate: Date | null
+): RegistrationAvailabilityView {
+  const actualDeregisterDeadline = chargeScheduleDate
+    ? min([attendance.deregisterDeadline, chargeScheduleDate])
+    : attendance.deregisterDeadline
+
+  const isPastDeregisterDeadline = !isFuture(actualDeregisterDeadline)
+  const hasBeenCharged = isAttendeeChargedAndUnrefunded(attendee)
+
+  const gracePeriodEnd = addMilliseconds(
+    attendee.createdAt,
+    DEREGISTER_GRACE_PERIOD_MS - DEREGISTER_GRACE_PERIOD_CLOCK_SKEW_MS
+  )
+  const isWithinGracePeriod = isFuture(gracePeriodEnd)
+  const requiresDeregisterReason = !isWithinGracePeriod
+
+  let rejectionCause: NonNullable<RegistrationAvailabilityView["deregistration"]>["rejectionCause"] = null
+
+  if (hasBeenCharged) {
+    rejectionCause = "PAYMENT_COMPLETED"
+  } else if (attendee.reserved && isPastDeregisterDeadline) {
+    rejectionCause = "DEREGISTER_DEADLINE_PASSED"
+  }
+
+  const canDeregister = rejectionCause === null
+
+  return {
+    userId,
+    punishment: null,
+    pool: null,
+    registration: null,
+    deregistration: {
+      attendeeId: attendee.id,
+      canDeregister,
+      rejectionCause,
+      isWithinGracePeriod,
+      requiresDeregisterReason,
+      actualDeregisterDeadline,
+      isPastDeregisterDeadline,
+      hasBeenCharged,
+      chargeScheduleDate,
+    },
   }
 }

--- a/apps/rpc/src/modules/event/attendance.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/attendance.e2e-spec.ts
@@ -13,6 +13,7 @@ import invariant from "tiny-invariant"
 import { describe, expect, it } from "vitest"
 import { auth0Client, core, dbClient } from "../../../vitest-integration.setup"
 import { FailedPreconditionError, InvalidArgumentError, NotFoundError } from "../../error"
+import { buildDeregistrationAvailabilityView, buildRegistrationAvailabilityView } from "./attendance-service"
 import { getMockEvent, getMockGroup } from "./event.e2e-spec"
 
 // biome-ignore lint/suspicious/noExportsInTest: used in another spec
@@ -799,6 +800,90 @@ describe("attendance integration tests", async () => {
   it("should fail if you attempt to registrer physical attendance for a non-registered user", async () => {
     await expect(core.attendanceService.registerAttendance(dbClient, randomUUID(), getCurrentUTC())).rejects.toThrow(
       NotFoundError
+    )
+  })
+
+  it("should build registration availability view without turnstile token", async () => {
+    const subject = randomUUID()
+    auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
+
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
+    const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
+    await core.attendanceService.createAttendancePool(
+      dbClient,
+      attendance.id,
+      getMockAttendancePool({
+        yearCriteria: [1],
+      })
+    )
+
+    const userWithoutMembership = await core.userService.register(dbClient, subject)
+    const user = await core.userService.createMembership(dbClient, userWithoutMembership.id, getMockMembership())
+
+    const [punishment, result] = await Promise.all([
+      core.personalMarkService.findPunishmentByUserId(dbClient, user.id),
+      core.attendanceService.getRegistrationAvailability(dbClient, attendance.id, null, user.id, {
+        immediateReservation: false,
+        immediatePayment: false,
+        ignoreRegistrationWindow: false,
+        overriddenAttendancePoolId: null,
+        ignoreRegisteredToParent: false,
+        overrideTurnstileCheck: true,
+      }),
+    ])
+
+    invariant(result.success)
+
+    const view = buildRegistrationAvailabilityView(user.id, result, punishment, attendance)
+
+    expect(view.registration?.canRegister).toBe(true)
+    expect(view.deregistration).toBeNull()
+    expect(view.registration?.rejectionCause).toBeNull()
+  })
+
+  it("should build deregistration availability view for registered attendee", async () => {
+    const subject = randomUUID()
+    auth0Client.users.get.mockResolvedValue(getMockAuth0UserResponse(subject))
+
+    const event = await core.eventService.createEvent(dbClient, getMockEvent())
+    const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    await core.eventService.updateEventAttendance(dbClient, event.id, attendance.id)
+    await core.attendanceService.createAttendancePool(
+      dbClient,
+      attendance.id,
+      getMockAttendancePool({
+        yearCriteria: [1],
+      })
+    )
+
+    const userWithoutMembership = await core.userService.register(dbClient, subject)
+    const user = await core.userService.createMembership(dbClient, userWithoutMembership.id, getMockMembership())
+
+    const result = await core.attendanceService.getRegistrationAvailability(dbClient, attendance.id, null, user.id, {
+      immediateReservation: true,
+      immediatePayment: false,
+      ignoreRegistrationWindow: false,
+      overriddenAttendancePoolId: null,
+      ignoreRegisteredToParent: false,
+      overrideTurnstileCheck: true,
+    })
+    invariant(result.success)
+    const attendee = await core.attendanceService.registerAttendee(dbClient, result)
+    const updatedAttendance = await core.attendanceService.getAttendanceById(dbClient, attendance.id)
+    const registeredAttendee = updatedAttendance.attendees.find((entry) => entry.id === attendee.id)
+    invariant(registeredAttendee !== undefined)
+
+    const view = buildDeregistrationAvailabilityView(user.id, registeredAttendee, updatedAttendance, null)
+
+    expect(view.registration).toBeNull()
+    expect(view.deregistration).toEqual(
+      expect.objectContaining({
+        attendeeId: attendee.id,
+        canDeregister: true,
+        isWithinGracePeriod: true,
+        requiresDeregisterReason: false,
+      })
     )
   })
 })

--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -8,7 +8,6 @@ import {
   type Company,
   type Event,
   type Group,
-  type Punishment,
   type User,
   createGroupPageUrl,
   getAttendanceCapacity,
@@ -26,6 +25,7 @@ import type { Metadata } from "next"
 import Link from "next/link"
 import { RedirectType, notFound, permanentRedirect } from "next/navigation"
 import { AttendanceCard } from "../../components/AttendanceCard/AttendanceCard"
+import type { AttendanceRouter } from "@dotkomonline/rpc"
 import { EventDescription } from "../../components/EventDescription"
 import { EventHeader } from "../../components/EventHeader"
 import { EventList } from "../../components/EventList"
@@ -58,6 +58,8 @@ const mapToImageAndName = (item: Group | Company) => (
     <Text>{"abbreviation" in item ? item.abbreviation : item.name}</Text>
   </Link>
 )
+
+type RegistrationAvailability = AttendanceRouter.GetRegistrationAvailabilityOutput
 
 interface EventPageParams {
   slug: string
@@ -99,7 +101,12 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<EventPagePa
 
   const isOrganizer = user ? await server.event.isOrganizer.query({ eventId }) : false
   const isAdmin = user ? await server.user.isAdmin.query() : false
-  const punishment = attendance && user && (await server.personalMark.getExpiryDateForUser.query({ userId: user.id }))
+  const registrationAvailability =
+    attendance && user
+      ? await server.event.attendance.getRegistrationAvailability.query({
+          attendanceId: attendance.id,
+        })
+      : null
 
   const parentEvent = parentEventWithAttendance?.event ?? null
   const parentAttendance = parentEventWithAttendance?.attendance ?? null
@@ -135,7 +142,7 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<EventPagePa
                 parentEvent={parentEvent}
                 attendance={attendance}
                 parentAttendance={parentAttendance}
-                punishment={punishment}
+                registrationAvailability={registrationAvailability}
                 user={user}
               />
             </TabsContent>
@@ -158,7 +165,7 @@ const EventWithAttendancePage = async ({ params }: { params: Promise<EventPagePa
             attendance={attendance}
             parentEvent={parentEvent}
             parentAttendance={parentAttendance}
-            punishment={punishment}
+            registrationAvailability={registrationAvailability}
             user={user}
           />
         )}
@@ -172,11 +179,18 @@ interface EventContentProps {
   attendance: Attendance | null
   parentEvent: Event | null
   parentAttendance: Attendance | null
-  punishment: Punishment | null
+  registrationAvailability: RegistrationAvailability | null
   user: User | null
 }
 
-const EventContent = ({ event, attendance, parentEvent, parentAttendance, punishment, user }: EventContentProps) => {
+const EventContent = ({
+  event,
+  attendance,
+  parentEvent,
+  parentAttendance,
+  registrationAvailability,
+  user,
+}: EventContentProps) => {
   const hostingGroups = event.hostingGroups.map((group) => mapToImageAndName(group))
   const companyList = event.companies.map((company) => mapToImageAndName(company))
   const organizers = [...companyList, ...hostingGroups]
@@ -211,9 +225,8 @@ const EventContent = ({ event, attendance, parentEvent, parentAttendance, punish
 
             <AttendanceCard
               initialAttendance={attendance}
-              initialPunishment={punishment}
+              initialRegistrationAvailability={registrationAvailability}
               parentEvent={parentEvent}
-              parentAttendance={parentAttendance}
               user={user}
               event={event}
             />

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -4,18 +4,18 @@ import { env } from "@/env"
 import { useTRPCSSERegisterChangeConnectionState } from "@/utils/trpc/QueryProvider"
 import { useTRPC } from "@/utils/trpc/client"
 import { useFullPathname } from "@/utils/use-full-pathname"
+import type { AttendanceRouter } from "@dotkomonline/rpc"
 import {
   type Attendance,
   type AttendanceSelectionResponse,
   type Event,
-  type Punishment,
   type User,
   getAttendee,
 } from "@dotkomonline/types"
 import { Text, Title, cn } from "@dotkomonline/ui"
 import { createAuthorizeUrl, getCurrentUTC } from "@dotkomonline/utils"
 import { IconEdit } from "@tabler/icons-react"
-import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSubscription } from "@trpc/tanstack-react-query"
 import { differenceInSeconds, isBefore, isPast, secondsToMilliseconds } from "date-fns"
 import Link from "next/link"
@@ -35,21 +35,21 @@ import { SelectionsForm } from "./SelectionsForm"
 import { TicketButton } from "./TicketButton"
 import { ViewAttendeesButton } from "./ViewAttendeesButton"
 
+type RegistrationAvailability = AttendanceRouter.GetRegistrationAvailabilityOutput
+
 interface AttendanceCardProps {
   initialAttendance: Attendance
-  initialPunishment: Punishment | null
+  initialRegistrationAvailability: RegistrationAvailability | null
   user: User | null
   event: Event
   parentEvent: Event | null
-  parentAttendance: Attendance | null
 }
 
 export const AttendanceCard = ({
   user,
   event,
   initialAttendance,
-  initialPunishment,
-  parentAttendance,
+  initialRegistrationAvailability,
 }: AttendanceCardProps) => {
   const trpc = useTRPC()
   const queryClient = useQueryClient()
@@ -60,39 +60,39 @@ export const AttendanceCard = ({
 
   const [closeToEvent, setCloseToEvent] = useState(false)
   const [attendanceStatus, setAttendanceStatus] = useState(getAttendanceStatus(initialAttendance))
-  const [_, setTurnstileHasLoaded] = useState(false) // can be used later if we want to be aware of when turnstile has loaded
+  const [turnstileHasLoaded, setTurnstileHasLoaded] = useState(false)
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null)
   const [hideTurnstile, setHideTurnstile] = useState(false)
 
-  const [attendanceResponse, punishmentResponse] = useQueries({
-    queries: [
-      trpc.event.attendance.getAttendance.queryOptions(
-        {
-          id: initialAttendance.id,
-        },
-        {
-          initialData: initialAttendance,
-          enabled: Boolean(user),
-          refetchInterval: closeToEvent ? secondsToMilliseconds(1) : secondsToMilliseconds(60),
-        }
-      ),
-      trpc.personalMark.getExpiryDateForUser.queryOptions(
-        {
-          userId: user?.id ?? "",
-        },
-        {
-          initialData: initialPunishment,
-          enabled: Boolean(user),
-        }
-      ),
-    ],
-  })
+  const { data: attendance, isLoading: attendanceLoading } = useQuery(
+    trpc.event.attendance.getAttendance.queryOptions(
+      {
+        id: initialAttendance.id,
+      },
+      {
+        initialData: initialAttendance,
+        enabled: Boolean(user),
+        refetchInterval: closeToEvent ? secondsToMilliseconds(1) : secondsToMilliseconds(60),
+      }
+    )
+  )
 
-  const { data: attendance, isLoading: attendanceLoading } = attendanceResponse
-  const { data: punishment, isLoading: punishmentLoading } = punishmentResponse
+  const { data: registrationAvailability, isLoading: registrationAvailabilityLoading } = useQuery(
+    trpc.event.attendance.getRegistrationAvailability.queryOptions(
+      {
+        attendanceId: initialAttendance.id,
+      },
+      {
+        initialData: initialRegistrationAvailability ?? undefined,
+        enabled: Boolean(user),
+      }
+    )
+  )
 
   useEffect(() => {
-    setAttendanceStatus(getAttendanceStatus(attendance))
+    if (attendance) {
+      setAttendanceStatus(getAttendanceStatus(attendance))
+    }
   }, [attendance])
 
   useEffect(() => {
@@ -114,8 +114,7 @@ export const AttendanceCard = ({
         onConnectionStateChange: (state) => {
           setTRPCSSERegisterChangeConnectionState(state.state)
         },
-        onData: ({ status, attendee }) => {
-          // If the attendee is not the current user, we can update the state
+        onData: ({ status, attendee: updatedAttendee }) => {
           queryClient.setQueryData(
             trpc.event.attendance.getAttendance.queryOptions({ id: attendance?.id }).queryKey,
             (oldData) => {
@@ -126,52 +125,75 @@ export const AttendanceCard = ({
               if (status === "deregistered") {
                 return {
                   ...oldData,
-                  attendees: oldData.attendees.filter((oldAttendee) => oldAttendee.id !== attendee.id),
+                  attendees: oldData.attendees.filter((oldAttendee) => oldAttendee.id !== updatedAttendee.id),
                 }
               }
 
-              if (oldData.attendees.some((oldAttendee) => oldAttendee.id === attendee.id)) {
+              if (oldData.attendees.some((oldAttendee) => oldAttendee.id === updatedAttendee.id)) {
                 console.warn("Attendee already exists in the list, not updating state.")
                 return oldData
               }
 
               return {
                 ...oldData,
-                attendees: [...oldData.attendees, attendee],
+                attendees: [...oldData.attendees, updatedAttendee],
               }
             }
           )
+
+          if (user && updatedAttendee.userId === user.id) {
+            void queryClient.invalidateQueries(
+              trpc.event.attendance.getRegistrationAvailability.queryOptions({
+                attendanceId: attendance?.id ?? "",
+              })
+            )
+          }
         },
       }
     )
   )
 
   const attendee = getAttendee(attendance, user)
-
-  const { data: chargeScheduleDate } = useQuery(
-    trpc.event.attendance.findChargeAttendeeScheduleDate.queryOptions(
-      {
-        attendeeId: attendee?.id ?? "",
-      },
-      { enabled: Boolean(attendee?.id) && Boolean(attendance.attendancePrice) }
-    )
-  )
+  const punishment = registrationAvailability?.punishment ?? null
+  const chargeScheduleDate = registrationAvailability?.deregistration?.chargeScheduleDate ?? null
 
   useEffect(() => {
-    // This can maybe be enabled, but I don't trust it because it will create lots of spam calls to the server
-    // right before even open (as if we don't have enough already)
-    // const attendanceEventDateTimes = [attendance.registerStart, attendance.registerEnd, attendance.deregisterDeadline, attendee?.paymentDeadline]
     const attendanceEventDateTimes = [attendee?.paymentDeadline]
     setCloseToEvent(
       attendanceEventDateTimes.some((date) => date && Math.abs(differenceInSeconds(date, new Date())) < 60)
     )
-    // }, [attendance, attendee])
   }, [attendee])
 
   const [attendeeListOpen, setAttendeeListOpen] = useState(false)
 
-  const registerMutation = useRegisterMutation()
-  const deregisterMutation = useDeregisterMutation()
+  const registerMutation = useRegisterMutation({
+    onSuccess: () => {
+      if (!user) {
+        return
+      }
+
+      void queryClient.invalidateQueries(
+        trpc.event.attendance.getRegistrationAvailability.queryOptions({
+          attendanceId: attendance.id,
+        })
+      )
+    },
+  })
+
+  const deregisterMutation = useDeregisterMutation({
+    onSuccess: () => {
+      if (!user) {
+        return
+      }
+
+      void queryClient.invalidateQueries(
+        trpc.event.attendance.getRegistrationAvailability.queryOptions({
+          attendanceId: attendance.id,
+        })
+      )
+    },
+  })
+
   const selectionsMutation = useSetSelectionsOptionsMutation()
 
   const handleSelectionChange = (selections: AttendanceSelectionResponse[]) => {
@@ -209,9 +231,10 @@ export const AttendanceCard = ({
     setTurnstileToken(null)
   }
 
-  const isLoading = attendanceLoading || punishmentLoading || deregisterMutation.isPending || registerMutation.isPending
+  const isLoading =
+    attendanceLoading || registrationAvailabilityLoading || deregisterMutation.isPending || registerMutation.isPending
 
-  const hasPunishment = punishment && (punishment.delay > 0 || punishment.suspended)
+  const hasPunishment = punishment !== null && (punishment.delay > 0 || punishment.suspended)
 
   if (isBefore(getCurrentUTC(), attendance.registerStart)) {
     setTimeout(() => {
@@ -268,12 +291,11 @@ export const AttendanceCard = ({
         registerForAttendance={registerForAttendance}
         unregisterForAttendance={deregisterForAttendance}
         attendance={attendance}
-        parentAttendance={parentAttendance}
-        punishment={punishment}
+        registrationAvailability={registrationAvailability}
         user={user}
         event={event}
         isLoading={isLoading}
-        chargeScheduleDate={chargeScheduleDate ?? null}
+        turnstileHasLoaded={turnstileHasLoaded}
         hasTurnstileToken={Boolean(turnstileToken)}
       />
 

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
@@ -1,31 +1,18 @@
 "use client"
 
-import {
-  type Attendance,
-  type AttendanceStatus,
-  type Attendee,
-  type Event,
-  type Punishment,
-  type User,
-  findActiveMembership,
-  getAttendablePool,
-  getAttendee,
-  getReservedAttendeeCount,
-} from "@dotkomonline/types"
+import type { AttendanceRouter } from "@dotkomonline/rpc"
+import { type Attendance, type Event, type User, getAttendee } from "@dotkomonline/types"
 import { Button, Text, Tooltip, TooltipContent, TooltipTrigger, cn } from "@dotkomonline/ui"
 import { IconLoader2, IconLock, IconUserMinus, IconUserPlus, IconX } from "@tabler/icons-react"
-import { addMilliseconds, hoursToMilliseconds, isFuture, min, secondsToMilliseconds } from "date-fns"
 import { type FC, useEffect, useState } from "react"
 import { DeregisterModal } from "../DeregisterModal"
 import type { DeregisterReasonFormResult } from "../DeregisterModal"
-import { getAttendanceStatus } from "../attendanceStatus"
-
-// The backend requires a deregister reason 2 hours after registration. We subtract 15 seconds here to account for
-// potential clock skew between client and server, so users near the grace period boundary don't experience errors due
-// to small differences in system time.
-const DEREGISTER_GRACE_PERIOD_MS = hoursToMilliseconds(2) - secondsToMilliseconds(15)
+import { deregistrationRejectionMessages } from "./deregistrationRejectionMessages"
+import { registrationRejectionMessages } from "./registrationRejectionMessages"
 
 const DEREGISTER_BUTTON_COLOR = "bg-red-300 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800" as const
+
+type RegistrationAvailability = AttendanceRouter.GetRegistrationAvailabilityOutput
 
 const getButtonColor = (
   disabled: boolean,
@@ -50,66 +37,41 @@ const getButtonColor = (
 }
 
 const getDisabledText = (
-  status: AttendanceStatus,
-  attendee: Attendee | null,
-  pool: boolean,
-  hasBeenCharged: boolean,
-  isPastDeregisterDeadline: boolean,
-  isLoggedIn: boolean,
-  hasMembership: boolean,
-  isSuspended: boolean,
-  registeredToParentEvent: boolean | null,
-  reservedToParentEvent: boolean | null,
-  hasTurnstileToken: boolean
-) => {
+  registrationAvailability: RegistrationAvailability | undefined,
+  hasTurnstileToken: boolean,
+  isLoggedIn: boolean
+): string | null => {
   if (!isLoggedIn) {
     return "Du må være innlogget for å melde deg på"
   }
 
-  const isAttending = attendee !== null
+  if (registrationAvailability === undefined) {
+    return null
+  }
 
-  if (isAttending) {
-    if (isPastDeregisterDeadline && attendee.reserved) {
-      return "Avmeldingsfristen har utløpt"
-    }
-
-    if (hasBeenCharged) {
-      return "Betaling er utført. Kontakt arrangør for avmelding og refusjon"
+  if (registrationAvailability.deregistration !== null) {
+    if (
+      !registrationAvailability.deregistration.canDeregister &&
+      registrationAvailability.deregistration.rejectionCause
+    ) {
+      return deregistrationRejectionMessages[registrationAvailability.deregistration.rejectionCause]
     }
 
     return null
   }
 
-  if (isSuspended) {
-    return "Du er suspendert fra Online"
-  }
+  const registration = registrationAvailability.registration
 
-  if (!hasMembership) {
-    return "Du må ha registrert medlemskap for å melde deg på"
-  }
-
-  if (status === "CLOSED") {
-    return "Påmeldingen er stengt"
-  }
-
-  if (!pool) {
-    return "Du har ingen påmeldingsgruppe"
-  }
-
-  if (status === "NOT_OPENED") {
-    return "Påmeldinger har ikke åpnet"
-  }
-
-  if (registeredToParentEvent === false) {
-    return "Du er ikke påmeldt foreldrearrangementet"
-  }
-
-  if (reservedToParentEvent === false && registeredToParentEvent === true) {
-    return "Du er i kø på foreldrearrangementet"
+  if (registration === null) {
+    return null
   }
 
   if (!hasTurnstileToken) {
-    return "Du må bekrefte at du ikke er en robot"
+    return registrationRejectionMessages.MISSING_TURNSTILE_TOKEN
+  }
+
+  if (!registration.canRegister && registration.rejectionCause) {
+    return registrationRejectionMessages[registration.rejectionCause]
   }
 
   return null
@@ -119,12 +81,11 @@ interface RegistrationButtonProps {
   registerForAttendance: () => void
   unregisterForAttendance: (deregisterReason: DeregisterReasonFormResult | null) => void
   attendance: Attendance
-  parentAttendance: Attendance | null
-  punishment: Punishment | null
+  registrationAvailability: RegistrationAvailability | undefined
   user: User | null
   event: Event
   isLoading: boolean
-  chargeScheduleDate: Date | null
+  turnstileHasLoaded: boolean
   hasTurnstileToken: boolean
 }
 
@@ -132,25 +93,19 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   registerForAttendance,
   unregisterForAttendance,
   attendance,
-  parentAttendance,
-  punishment,
+  registrationAvailability,
   user,
   event,
   isLoading,
-  chargeScheduleDate,
+  turnstileHasLoaded,
   hasTurnstileToken,
 }) => {
   const [deregisterModalOpen, setDeregisterModalOpen] = useState(false)
   const [confirmGracePeriodDeregister, setConfirmDeregister] = useState(false)
 
   const attendee = getAttendee(attendance, user)
-  const pool = getAttendablePool(attendance, user)
-  const attendanceStatus = getAttendanceStatus(attendance)
-  const hasMembership = user !== null && Boolean(findActiveMembership(user))
-
-  const deregisterGracePeriodEnd =
-    attendee !== null ? addMilliseconds(attendee.createdAt, DEREGISTER_GRACE_PERIOD_MS) : null
-  const isWithinDeregisterGracePeriod = deregisterGracePeriodEnd !== null && isFuture(deregisterGracePeriodEnd)
+  const deregistration = registrationAvailability?.deregistration ?? null
+  const isWithinDeregisterGracePeriod = deregistration?.isWithinGracePeriod ?? false
 
   useEffect(() => {
     if (attendee === null || !isWithinDeregisterGracePeriod) {
@@ -158,40 +113,17 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
     }
   }, [attendee, isWithinDeregisterGracePeriod])
 
-  // TODO: dont calculate this in frontend
-  const actualDeregisterDeadline = chargeScheduleDate
-    ? min([attendance.deregisterDeadline, chargeScheduleDate])
-    : attendance.deregisterDeadline
-
-  const isPastDeregisterDeadline = !isFuture(actualDeregisterDeadline)
-  const hasMergeDelay = pool?.mergeDelayHours ? pool.mergeDelayHours > 0 : false
-  const isSuspended = punishment?.suspended ?? false
-  const hasPunishment = punishment ? punishment.delay > 0 || isSuspended : false
-  const isPoolFull = pool
-    ? pool.capacity !== 0 && getReservedAttendeeCount(attendance, pool?.id) >= pool.capacity
-    : false
-
-  const parentAttendanceAttendee = parentAttendance && getAttendee(parentAttendance, user)
-  const registeredToParentEvent = parentAttendance ? Boolean(parentAttendanceAttendee) : null
-  const reservedToParentEvent = parentAttendance && parentAttendanceAttendee ? parentAttendanceAttendee.reserved : null
+  const isPoolFull = registrationAvailability?.pool?.isPoolFull ?? false
+  const punishment = registrationAvailability?.punishment ?? null
+  const hasPunishment = punishment !== null && (punishment.delay > 0 || punishment.suspended)
+  const hasMergeDelay = registrationAvailability?.registration?.hasMergeDelay ?? false
 
   const buttonText = attendee ? "Meld meg av" : "Meld meg på"
   const buttonIcon = null
 
-  const disabledText = getDisabledText(
-    attendanceStatus,
-    attendee,
-    Boolean(pool),
-    Boolean(attendee?.paymentChargedAt && !attendee.paymentRefundedAt),
-    isPastDeregisterDeadline,
-    Boolean(user),
-    hasMembership,
-    isSuspended,
-    registeredToParentEvent,
-    reservedToParentEvent,
-    hasTurnstileToken
-  )
-  const disabled = Boolean(disabledText)
+  const disabledText = getDisabledText(registrationAvailability, hasTurnstileToken, Boolean(user))
+  const isAvailabilityPending = Boolean(user) && registrationAvailability === undefined
+  const isButtonDisabled = Boolean(disabledText) || isLoading || isAvailabilityPending
 
   const handleClick = () => {
     if (!attendee) {
@@ -215,7 +147,9 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
     <IconLoader2 className="shrink-0 size-6 animate-spin" />
   ) : (
     <>
-      {disabled ? (
+      {!turnstileHasLoaded && registrationAvailability?.deregistration === null ? (
+        <IconLoader2 className="shrink-0 size-[1.25em] animate-spin" />
+      ) : isButtonDisabled ? (
         <IconLock className="shrink-0 size-[1.25em]" />
       ) : attendee ? (
         <IconUserMinus className="shrink-0 size-[1.25em]" />
@@ -232,12 +166,12 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   const registrationButton = (
     <Button
       onClick={handleClick}
-      disabled={disabled}
+      disabled={isButtonDisabled}
       icon={buttonIcon}
       className={cn(
         "text-base rounded-lg h-fit min-h-16 w-full",
-        disabled && "text-gray-800 dark:text-stone-300",
-        getButtonColor(disabled, Boolean(attendee), isPoolFull, hasPunishment, hasMergeDelay)
+        isButtonDisabled && "text-gray-800 dark:text-stone-300",
+        getButtonColor(isButtonDisabled, Boolean(attendee), isPoolFull, hasPunishment, hasMergeDelay)
       )}
     >
       {buttonContent}
@@ -271,11 +205,11 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   )
 
   const showDeregisterConfirm =
-    attendee !== null && isWithinDeregisterGracePeriod && confirmGracePeriodDeregister && !disabled
+    attendee !== null && isWithinDeregisterGracePeriod && confirmGracePeriodDeregister && !isButtonDisabled
 
   const actionButton = showDeregisterConfirm ? deregisterConfirmButton : registrationButton
 
-  if (disabled) {
+  if (disabledText) {
     return (
       <Tooltip delayDuration={100}>
         <TooltipTrigger asChild>
@@ -291,7 +225,7 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   return (
     <>
       {actionButton}
-      {attendee && !isWithinDeregisterGracePeriod && (
+      {attendee && deregistration?.requiresDeregisterReason && (
         <DeregisterModal
           open={deregisterModalOpen}
           setOpen={setDeregisterModalOpen}

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/deregistrationRejectionMessages.ts
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/deregistrationRejectionMessages.ts
@@ -1,0 +1,10 @@
+import type { AttendanceRouter } from "@dotkomonline/rpc"
+
+type DeregistrationRejectionCause = NonNullable<
+  NonNullable<AttendanceRouter.GetRegistrationAvailabilityOutput["deregistration"]>["rejectionCause"]
+>
+
+export const deregistrationRejectionMessages: Record<DeregistrationRejectionCause, string> = {
+  DEREGISTER_DEADLINE_PASSED: "Avmeldingsfristen har utløpt",
+  PAYMENT_COMPLETED: "Betaling er utført. Kontakt arrangør for avmelding og refusjon",
+}

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/registrationRejectionMessages.ts
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/registrationRejectionMessages.ts
@@ -1,0 +1,20 @@
+import type { AttendanceRouter } from "@dotkomonline/rpc"
+
+type RegistrationRejectionCause = NonNullable<
+  NonNullable<AttendanceRouter.GetRegistrationAvailabilityOutput["registration"]>["rejectionCause"]
+>
+
+export type RegistrationRejectionMessageKey = RegistrationRejectionCause | "MISSING_TURNSTILE_TOKEN"
+
+export const registrationRejectionMessages: Record<RegistrationRejectionMessageKey, string> = {
+  TOO_EARLY: "Påmeldinger har ikke åpnet",
+  TOO_LATE: "Påmeldingen er stengt",
+  SUSPENDED: "Du er suspendert fra Online",
+  MISSING_MEMBERSHIP: "Du har ikke Online-medlemskap",
+  NO_MATCHING_POOL: "Du har ingen påmeldingsgruppe",
+  MISSING_PARENT_REGISTRATION: "Du er ikke påmeldt foreldrearrangementet",
+  MISSING_PARENT_RESERVATION: "Du er i kø på foreldrearrangementet",
+  ALREADY_REGISTERED: "Du er allerede påmeldt",
+  INVALID_TURNSTILE_TOKEN: "Du er en robot", // litt userr men litt gøy
+  MISSING_TURNSTILE_TOKEN: "Du må bekrefte at du ikke er en robot",
+}

--- a/apps/web/src/app/arrangementer/components/mutations.ts
+++ b/apps/web/src/app/arrangementer/components/mutations.ts
@@ -4,7 +4,7 @@ import { useUser } from "@auth0/nextjs-auth0/client"
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
-export const useDeregisterMutation = () => {
+export const useDeregisterMutation = ({ onSuccess }: { onSuccess?: () => void } = {}) => {
   const trpc = useTRPC()
   const { trpcSSERegisterChangeConnectionState } = useTRPCSSERegisterChangeConnectionState()
   const queryClient = useQueryClient()
@@ -17,14 +17,13 @@ export const useDeregisterMutation = () => {
           return
         }
 
-        // Check if the connection is not open (connecting or idle)
         if (trpcSSERegisterChangeConnectionState !== "pending") {
-          await Promise.all([
-            await queryClient.invalidateQueries(
-              trpc.event.attendance.getAttendance.queryOptions({ id: input.attendanceId })
-            ),
-          ])
+          await queryClient.invalidateQueries(
+            trpc.event.attendance.getAttendance.queryOptions({ id: input.attendanceId })
+          )
         }
+
+        onSuccess?.()
       },
     })
   )

--- a/packages/types/src/attendance.ts
+++ b/packages/types/src/attendance.ts
@@ -1,8 +1,22 @@
 import { schemas } from "@dotkomonline/db/schemas"
-import { compareAsc } from "date-fns"
+import { compareAsc, hoursToMilliseconds, secondsToMilliseconds } from "date-fns"
 import { z } from "zod"
+import { PunishmentSchema } from "./mark"
 import { type User, type UserId, UserSchema, findActiveMembership } from "./user"
 import { getStudyGrade } from "@dotkomonline/utils"
+
+/**
+ * Grace period after registration during which deregistration requires no reason.
+ *
+ * This duration was chosen arbitrarily, though it seemed nice to not overlap with the 1 hour payment deadline.
+ * Frontends should account for a few seconds to account for clock skew to avoid errors near the grace period end.
+ */
+export const DEREGISTER_GRACE_PERIOD_MS = hoursToMilliseconds(2)
+
+/**
+ * Clock skew buffer subtracted from grace period end for UI eligibility display.
+ */
+export const DEREGISTER_GRACE_PERIOD_CLOCK_SKEW_MS = secondsToMilliseconds(15)
 
 export type AttendanceStatus = "NOT_OPENED" | "OPEN" | "CLOSED"
 
@@ -106,6 +120,62 @@ export const AttendanceSummarySchema = schemas.AttendanceSchema.extend({
   reservedAttendeeCount: z.number(),
 })
 export type AttendanceSummary = z.infer<typeof AttendanceSummarySchema>
+
+export const RegistrationRejectionCauseSchema = z.enum([
+  "SUSPENDED",
+  "TOO_EARLY",
+  "TOO_LATE",
+  "ALREADY_REGISTERED",
+  "MISSING_PARENT_REGISTRATION",
+  "MISSING_PARENT_RESERVATION",
+  "MISSING_MEMBERSHIP",
+  "NO_MATCHING_POOL",
+  "INVALID_TURNSTILE_TOKEN",
+])
+export type RegistrationRejectionCause = z.infer<typeof RegistrationRejectionCauseSchema>
+
+export const RegistrationAvailabilityPoolViewSchema = z.object({
+  id: AttendancePoolSchema.shape.id,
+  mergeDelayHours: z.number().nullable(),
+  isPoolFull: z.boolean(),
+})
+export type RegistrationAvailabilityPoolView = z.infer<typeof RegistrationAvailabilityPoolViewSchema>
+
+export const DeregistrationRejectionCauseSchema = z.enum(["DEREGISTER_DEADLINE_PASSED", "PAYMENT_COMPLETED"])
+export type DeregistrationRejectionCause = z.infer<typeof DeregistrationRejectionCauseSchema>
+
+export const RegistrationAvailabilityDeregistrationViewSchema = z.object({
+  attendeeId: AttendeeSchema.shape.id,
+  canDeregister: z.boolean(),
+  rejectionCause: DeregistrationRejectionCauseSchema.nullable(),
+  isWithinGracePeriod: z.boolean(),
+  requiresDeregisterReason: z.boolean(),
+  actualDeregisterDeadline: z.date(),
+  isPastDeregisterDeadline: z.boolean(),
+  hasBeenCharged: z.boolean(),
+  chargeScheduleDate: z.date().nullable(),
+})
+export type RegistrationAvailabilityDeregistrationView = z.infer<
+  typeof RegistrationAvailabilityDeregistrationViewSchema
+>
+
+export const RegistrationAvailabilityRegistrationViewSchema = z.object({
+  canRegister: z.boolean(),
+  rejectionCause: RegistrationRejectionCauseSchema.nullable(),
+  reservationActiveAt: z.date().nullable(),
+  willBeUnreserved: z.boolean(),
+  hasMergeDelay: z.boolean(),
+})
+export type RegistrationAvailabilityRegistrationView = z.infer<typeof RegistrationAvailabilityRegistrationViewSchema>
+
+export const RegistrationAvailabilityViewSchema = z.object({
+  userId: UserSchema.shape.id,
+  punishment: PunishmentSchema.nullable(),
+  pool: RegistrationAvailabilityPoolViewSchema.nullable(),
+  registration: RegistrationAvailabilityRegistrationViewSchema.nullable(),
+  deregistration: RegistrationAvailabilityDeregistrationViewSchema.nullable(),
+})
+export type RegistrationAvailabilityView = z.infer<typeof RegistrationAvailabilityViewSchema>
 
 export function getReservedAttendeeCount(attendance: Attendance, poolId?: AttendancePoolId): number {
   if (poolId) {


### PR DESCRIPTION
Moves a lot of frontend registration calculations into backend registration and deregistration availability views  
  
Upstack PR #3274 must be merged alongside this PR