### PR TITLE
Add pool occupancy to register change events

### DIFF
--- a/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
+++ b/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
@@ -1,5 +1,6 @@
 import { TZDate } from "@date-fns/tz"
 import type { Attendance, Attendee, Punishment } from "@dotkomonline/types"
+import { buildPoolOccupancies } from "@dotkomonline/types"
 import { getCurrentUTC } from "@dotkomonline/utils"
 import { addDays, addHours, subHours } from "date-fns"
 import { describe, expect, it } from "vitest"
@@ -228,5 +229,41 @@ describe("buildDeregistrationAvailabilityView", () => {
 
     expect(view.deregistration?.actualDeregisterDeadline).toEqual(chargeScheduleDate)
     expect(view.deregistration?.chargeScheduleDate).toEqual(chargeScheduleDate)
+  })
+})
+
+describe("buildPoolOccupancies", () => {
+  it("marks a pool as full when reserved count reaches capacity", () => {
+    const attendance = createAttendance({
+      attendees: [
+        createAttendee({ id: "00000000-0000-4000-8000-000000000031", reserved: true }),
+        createAttendee({ id: "00000000-0000-4000-8000-000000000032", reserved: true }),
+      ],
+    })
+
+    const poolOccupancies = buildPoolOccupancies(attendance)
+
+    expect(poolOccupancies).toEqual([
+      {
+        poolId: attendance.pools[0].id,
+        reservedCount: 2,
+        capacity: 2,
+        isPoolFull: true,
+      },
+    ])
+  })
+
+  it("ignores unreserved attendees when computing pool fullness", () => {
+    const attendance = createAttendance({
+      attendees: [
+        createAttendee({ id: "00000000-0000-4000-8000-000000000031", reserved: true }),
+        createAttendee({ id: "00000000-0000-4000-8000-000000000032", reserved: false }),
+      ],
+    })
+
+    const poolOccupancies = buildPoolOccupancies(attendance)
+
+    expect(poolOccupancies[0]?.isPoolFull).toBe(false)
+    expect(poolOccupancies[0]?.reservedCount).toBe(1)
   })
 })

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -5,7 +5,6 @@ import {
   AttendancePoolWriteSchema,
   AttendanceSchema,
   AttendanceWriteSchema,
-  type Attendee,
   AttendeeSchema,
   AttendeeSelectionResponseSchema,
   DeregisterReasonTypeSchema,
@@ -13,6 +12,7 @@ import {
   EventSchema,
   type GroupId,
   RegistrationAvailabilityViewSchema,
+  RegisterChangeEventSchema,
   UserSchema,
 } from "@dotkomonline/types"
 import { getCurrentUTC } from "@dotkomonline/utils"
@@ -240,13 +240,13 @@ const onRegisterChangeProcedure = procedure
   .use(withDatabaseTransaction())
   .subscription(async function* ({ input, ctx, signal }) {
     for await (const [data] of on(ctx.eventEmitter, "attendance:register-change", { signal })) {
-      const attendeeUpdateData = data as { attendee: Attendee; status: "registered" | "deregistered" }
+      const registerChangeEvent = RegisterChangeEventSchema.parse(data)
 
-      if (attendeeUpdateData.attendee.attendanceId !== input.attendanceId) {
+      if (registerChangeEvent.attendee.attendanceId !== input.attendanceId) {
         continue
       }
 
-      yield attendeeUpdateData
+      yield registerChangeEvent
     }
   })
 

--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -24,10 +24,12 @@ import {
   type Punishment,
   type RegistrationAvailabilityView,
   type RegistrationRejectionCause,
+  type RegisterChangeEvent,
   type TaskId,
   type User,
   type UserId,
   findActiveMembership,
+  buildPoolOccupancies,
   getReservedAttendeeCount,
   isAttendable,
   isAttendeeChargedAndUnrefunded,
@@ -731,10 +733,7 @@ export function getAttendanceService(
         )
       }
 
-      eventEmitter.emit("attendance:register-change", {
-        attendee,
-        status: "registered",
-      })
+      emitRegisterChange(eventEmitter, attendance, attendee, "registered")
       logger.info(
         "Attendee(ID=%s,UserID=%s) named %s has registered (effective %s) for Event(ID=%s) named %s with options: %o",
         attendee.id,
@@ -869,10 +868,7 @@ export function getAttendanceService(
       await attendanceRepository.deleteAttendeeById(handle, attendeeId)
       const event = await eventService.getByAttendanceId(handle, attendance.id)
 
-      eventEmitter.emit("attendance:register-change", {
-        attendee,
-        status: "deregistered",
-      })
+      emitRegisterChange(eventEmitter, attendance, attendee, "deregistered")
       logger.info(
         "Attendee(ID=%s,UserID=%s) named %s has deregistered from Event(ID=%s) named %s with options: %o",
         attendee.id,
@@ -1802,6 +1798,27 @@ function emitRegistrationAvailabilityDiagnostics(
         continue diag
     }
   }
+}
+
+function emitRegisterChange(
+  eventEmitter: EventEmitter,
+  attendance: Attendance,
+  attendee: Attendee,
+  status: RegisterChangeEvent["status"]
+) {
+  const attendees =
+    status === "registered"
+      ? [...attendance.attendees, attendee]
+      : attendance.attendees.filter((existingAttendee) => existingAttendee.id !== attendee.id)
+
+  eventEmitter.emit("attendance:register-change", {
+    attendee,
+    status,
+    poolOccupancies: buildPoolOccupancies({
+      ...attendance,
+      attendees,
+    }),
+  } satisfies RegisterChangeEvent)
 }
 
 export function buildRegistrationAvailabilityView(

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -31,6 +31,7 @@ import { NonAttendablePoolsBox } from "./NonAttendablePoolsBox"
 import { PaymentExplanationDialog } from "./PaymentExplanationDialog"
 import { PunishmentBox } from "./PunishmentBox"
 import { RegistrationButton } from "./RegistrationButton"
+import { patchRegistrationAvailabilityFromPoolOccupancies } from "./patchRegistrationAvailabilityFromPoolOccupancies"
 import { SelectionsForm } from "./SelectionsForm"
 import { TicketButton } from "./TicketButton"
 import { ViewAttendeesButton } from "./ViewAttendeesButton"
@@ -114,7 +115,7 @@ export const AttendanceCard = ({
         onConnectionStateChange: (state) => {
           setTRPCSSERegisterChangeConnectionState(state.state)
         },
-        onData: ({ status, attendee: updatedAttendee }) => {
+        onData: ({ status, attendee: updatedAttendee, poolOccupancies }) => {
           queryClient.setQueryData(
             trpc.event.attendance.getAttendance.queryOptions({ id: attendance?.id }).queryKey,
             (oldData) => {
@@ -147,7 +148,21 @@ export const AttendanceCard = ({
                 attendanceId: attendance?.id ?? "",
               })
             )
+
+            return
           }
+
+          if (!user) {
+            return
+          }
+
+          const queryOptions = trpc.event.attendance.getRegistrationAvailability.queryOptions({
+            attendanceId: attendance?.id ?? "",
+          })
+
+          queryClient.setQueryData(queryOptions.queryKey, (oldData) =>
+            patchRegistrationAvailabilityFromPoolOccupancies(oldData, poolOccupancies)
+          )
         },
       }
     )

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/patchRegistrationAvailabilityFromPoolOccupancies.ts
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/patchRegistrationAvailabilityFromPoolOccupancies.ts
@@ -1,0 +1,46 @@
+import type { AttendanceRouter } from "@dotkomonline/rpc"
+import type { PoolOccupancy } from "@dotkomonline/types"
+import { isFuture } from "date-fns"
+
+type RegistrationAvailability = AttendanceRouter.GetRegistrationAvailabilityOutput
+
+export function patchRegistrationAvailabilityFromPoolOccupancies(
+  registrationAvailability: RegistrationAvailability | undefined,
+  poolOccupancies: PoolOccupancy[]
+): RegistrationAvailability | undefined {
+  if (registrationAvailability === undefined) {
+    return registrationAvailability
+  }
+
+  if (
+    registrationAvailability.deregistration !== null ||
+    registrationAvailability.pool === null ||
+    registrationAvailability.registration === null
+  ) {
+    return registrationAvailability
+  }
+
+  const pool = registrationAvailability.pool
+  const registration = registrationAvailability.registration
+  const poolOccupancy = poolOccupancies.find((occupancy) => occupancy.poolId === pool.id)
+
+  if (poolOccupancy === undefined) {
+    return registrationAvailability
+  }
+
+  const willBeUnreserved =
+    (registration.reservationActiveAt !== null && isFuture(registration.reservationActiveAt)) ||
+    poolOccupancy.isPoolFull
+
+  return {
+    ...registrationAvailability,
+    pool: {
+      ...pool,
+      isPoolFull: poolOccupancy.isPoolFull,
+    },
+    registration: {
+      ...registration,
+      willBeUnreserved,
+    },
+  }
+}

--- a/packages/types/src/attendance.ts
+++ b/packages/types/src/attendance.ts
@@ -177,6 +177,35 @@ export const RegistrationAvailabilityViewSchema = z.object({
 })
 export type RegistrationAvailabilityView = z.infer<typeof RegistrationAvailabilityViewSchema>
 
+export const PoolOccupancySchema = z.object({
+  poolId: AttendancePoolSchema.shape.id,
+  reservedCount: z.number(),
+  capacity: z.number(),
+  isPoolFull: z.boolean(),
+})
+export type PoolOccupancy = z.infer<typeof PoolOccupancySchema>
+
+export const RegisterChangeEventSchema = z.object({
+  attendee: AttendeeSchema,
+  status: z.enum(["registered", "deregistered"]),
+  poolOccupancies: z.array(PoolOccupancySchema),
+})
+export type RegisterChangeEvent = z.infer<typeof RegisterChangeEventSchema>
+
+export function buildPoolOccupancies(attendance: Attendance): PoolOccupancy[] {
+  return attendance.pools.map((pool) => {
+    const reservedCount = getReservedAttendeeCount(attendance, pool.id)
+    const isPoolFull = pool.capacity !== 0 && reservedCount >= pool.capacity
+
+    return {
+      poolId: pool.id,
+      reservedCount,
+      capacity: pool.capacity,
+      isPoolFull,
+    }
+  })
+}
+
 export function getReservedAttendeeCount(attendance: Attendance, poolId?: AttendancePoolId): number {
   if (poolId) {
     return attendance.attendees.filter((attendee) => attendee.attendancePoolId === poolId && attendee.reserved).length


### PR DESCRIPTION
Adds pool occupancy data to register change SSE updates. This means that we do not have to invalidate the registration availability views query, and can update cache in-place instead

Downstack #3273 needs this PR, otherwise the registration info will go out of sync whenever someone registers, which obviously is problematic. This PR is split because I thought it was easier to review this way