### PR TITLE
Add waitlist promotion to register change events

### DIFF
--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -811,6 +811,7 @@ export function getAttendanceService(
       data.reserved = true
 
       await attendanceRepository.updateAttendeeById(handle, attendeeId, data)
+      attendee.reserved = true
 
       const hasExistingPayment =
         attendee.paymentLink !== null ||
@@ -838,6 +839,7 @@ export function getAttendanceService(
       }
 
       sendEventRegistrationEmail(event, attendance, attendee)
+      emitRegisterChange(eventEmitter, attendance, attendee, "reserved")
     },
 
     async deregisterAttendee(handle, attendeeId, options) {
@@ -956,6 +958,13 @@ export function getAttendanceService(
       )
 
       sendEventRegistrationEmail(event, attendance, firstUnreservedAdjacentAttendee)
+
+      const promotedAttendee = {
+        ...firstUnreservedAdjacentAttendee,
+        reserved: true,
+      }
+
+      emitRegisterChange(eventEmitter, { ...attendance, attendees: remainingAttendees }, promotedAttendee, "reserved")
 
       for (const [index, waitlistAttendee] of sortedWaitlist.slice(1, 4).entries()) {
         sendWaitlistNotificationEmail(event, index + 1, waitlistAttendee)
@@ -1806,10 +1815,21 @@ function emitRegisterChange(
   attendee: Attendee,
   status: RegisterChangeEvent["status"]
 ) {
-  const attendees =
-    status === "registered"
-      ? [...attendance.attendees, attendee]
-      : attendance.attendees.filter((existingAttendee) => existingAttendee.id !== attendee.id)
+  let attendees: Attendee[]
+
+  if (status === "registered") {
+    attendees = [...attendance.attendees, attendee]
+  } else if (status === "deregistered") {
+    attendees = attendance.attendees.filter((existingAttendee) => existingAttendee.id !== attendee.id)
+  } else {
+    attendees = attendance.attendees.map((existingAttendee) => {
+      if (existingAttendee.id === attendee.id) {
+        return attendee
+      }
+
+      return existingAttendee
+    })
+  }
 
   eventEmitter.emit("attendance:register-change", {
     attendee,

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -130,6 +130,19 @@ export const AttendanceCard = ({
                 }
               }
 
+              if (status === "reserved") {
+                return {
+                  ...oldData,
+                  attendees: oldData.attendees.map((oldAttendee) => {
+                    if (oldAttendee.id === updatedAttendee.id) {
+                      return updatedAttendee
+                    }
+
+                    return oldAttendee
+                  }),
+                }
+              }
+
               if (oldData.attendees.some((oldAttendee) => oldAttendee.id === updatedAttendee.id)) {
                 console.warn("Attendee already exists in the list, not updating state.")
                 return oldData

--- a/packages/types/src/attendance.ts
+++ b/packages/types/src/attendance.ts
@@ -187,7 +187,7 @@ export type PoolOccupancy = z.infer<typeof PoolOccupancySchema>
 
 export const RegisterChangeEventSchema = z.object({
   attendee: AttendeeSchema,
-  status: z.enum(["registered", "deregistered"]),
+  status: z.enum(["registered", "deregistered", "reserved"]),
   poolOccupancies: z.array(PoolOccupancySchema),
 })
 export type RegisterChangeEvent = z.infer<typeof RegisterChangeEventSchema>


### PR DESCRIPTION
This is just missing from production.

Adds a new register change event status for `reserved`, which sets an existing attendee in cache from `reserved = false` to `reserved = true`

This is added for:

- When an attendee deregisters and another attendee is reserved from queue (`deregisterAttendee`)
- When `executeReserveAttendeeTask` runs