### PR TITLE
Fix group logo display in dark mode

### DIFF
--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "@/auth"
+import { GroupLogo } from "@/components/atoms/GroupLogo"
 import { EventListItem } from "@/components/molecules/EventListItem/EventListItem"
 import { env } from "@/env"
 import { server } from "@/utils/trpc/server"
@@ -7,14 +8,13 @@ import {
   type Company,
   type Event,
   type Group,
-  type GroupType,
   type Punishment,
   type User,
   createGroupPageUrl,
   getAttendanceCapacity,
   getReservedAttendeeCount,
 } from "@dotkomonline/types"
-import { cn, Tabs, TabsContent, TabsList, TabsTrigger, Text, Title } from "@dotkomonline/ui"
+import { Tabs, TabsContent, TabsList, TabsTrigger, Text, Title } from "@dotkomonline/ui"
 import {
   createAbsoluteEventPageUrl,
   createEventPageUrl,
@@ -23,7 +23,6 @@ import {
 } from "@dotkomonline/utils"
 import { isPast } from "date-fns"
 import type { Metadata } from "next"
-import Image from "next/image"
 import Link from "next/link"
 import { RedirectType, notFound, permanentRedirect } from "next/navigation"
 import { AttendanceCard } from "../../components/AttendanceCard/AttendanceCard"
@@ -33,8 +32,6 @@ import { EventList } from "../../components/EventList"
 import { SixtySevenShake } from "../../components/SixtySevenShake"
 import { TimeLocationBox } from "../../components/TimeLocationBox/TimeLocationBox"
 
-type OrganizerType = GroupType | "COMPANY"
-
 const createOrganizerPageUrl = (item: Group | Company) => {
   if ("type" in item) {
     return createGroupPageUrl(item)
@@ -43,20 +40,19 @@ const createOrganizerPageUrl = (item: Group | Company) => {
   return `/bedrifter/${item.slug}`
 }
 
-const mapToImageAndName = (item: Group | Company, type: OrganizerType) => (
+const mapToImageAndName = (item: Group | Company) => (
   <Link
     href={createOrganizerPageUrl(item)}
     key={item.name}
     className="flex flex-row gap-2 items-center px-3 py-2 rounded-lg border border-gray-200 hover:bg-gray-100 dark:border-stone-700 dark:hover:bg-stone-800"
   >
     {item.imageUrl && (
-      <Image
+      <GroupLogo
         src={item.imageUrl}
-        // TODO: Reconsider life once more
         alt={"abbreviation" in item ? item.abbreviation : item.name}
         width={22}
         height={22}
-        className={cn((type === "COMMITTEE" || type === "NODE_COMMITTEE") && "dark:invert")}
+        containerClassName="rounded-sm p-0.5 size-5.5"
       />
     )}
     <Text>{"abbreviation" in item ? item.abbreviation : item.name}</Text>
@@ -181,8 +177,8 @@ interface EventContentProps {
 }
 
 const EventContent = ({ event, attendance, parentEvent, parentAttendance, punishment, user }: EventContentProps) => {
-  const hostingGroups = event.hostingGroups.map((group) => mapToImageAndName(group, group.type))
-  const companyList = event.companies.map((company) => mapToImageAndName(company, "COMPANY"))
+  const hostingGroups = event.hostingGroups.map((group) => mapToImageAndName(group))
+  const companyList = event.companies.map((company) => mapToImageAndName(company))
   const organizers = [...companyList, ...hostingGroups]
 
   return (

--- a/apps/web/src/app/arrangementer/components/filters/GroupFilter.tsx
+++ b/apps/web/src/app/arrangementer/components/filters/GroupFilter.tsx
@@ -1,10 +1,9 @@
 "use client"
 
+import { GroupLogoAvatar } from "@/components/atoms/GroupLogo"
 import type { Group, GroupId } from "@dotkomonline/types"
 import {
-  Avatar,
   AvatarFallback,
-  AvatarImage,
   Button,
   Collapsible,
   CollapsibleContent,
@@ -98,16 +97,18 @@ export const GroupFilter = ({ value, onChange, groups }: GroupFilterProps) => {
                     )}
                   >
                     <div className="flex items-center gap-3 min-w-0">
-                      <Avatar size="sm" className="bg-white p-0.5 -m-0.5">
-                        <AvatarImage
-                          src={group.imageUrl ?? undefined}
-                          alt={group.name ?? group.slug}
-                          className="saturate-50 opacity-75 group-hover/group-item:saturate-100 group-hover/group-item:opacity-100 transition-all"
-                        />
-                        <AvatarFallback className="bg-gray-200 dark:bg-stone-700">
-                          <IconQuestionMark className="size-4 text-muted-foreground" />
-                        </AvatarFallback>
-                      </Avatar>
+                      <GroupLogoAvatar
+                        size="sm"
+                        src={group.imageUrl}
+                        alt={group.name ?? group.slug}
+                        className="p-0.5 -m-0.5"
+                        imageClassName="saturate-50 opacity-75 group-hover/group-item:saturate-100 group-hover/group-item:opacity-100 transition-all"
+                        fallback={
+                          <AvatarFallback className="bg-gray-200 dark:bg-stone-700">
+                            <IconQuestionMark className="size-4 text-muted-foreground" />
+                          </AvatarFallback>
+                        }
+                      />
                       <Text element="span" className="truncate max-md:text-base">
                         {group.abbreviation}
                       </Text>

--- a/apps/web/src/app/grupper/components/GroupPage.tsx
+++ b/apps/web/src/app/grupper/components/GroupPage.tsx
@@ -1,10 +1,17 @@
 import { EventList } from "@/app/arrangementer/components/EventList"
+import { GroupLogoAvatar } from "@/components/atoms/GroupLogo"
 import { getServerSession } from "@/auth"
 import { server } from "@/utils/trpc/server"
 import { type GroupMember, type GroupRole, GroupRoleTypeEnum, type UserId, getGroupTypeName } from "@dotkomonline/types"
 import { Avatar, AvatarFallback, AvatarImage, Badge, Button, RichText, Text, Title, cn } from "@dotkomonline/ui"
 import { getCurrentUTC } from "@dotkomonline/utils"
-import { IconArrowUpRight, IconRosetteDiscountCheckFilled, IconUser, IconUsers, IconWorld } from "@tabler/icons-react"
+import {
+  IconArrowUpRight,
+  IconQuestionMark,
+  IconRosetteDiscountCheckFilled,
+  IconUser,
+  IconWorld,
+} from "@tabler/icons-react"
 import { compareDesc } from "date-fns"
 import Link from "next/link"
 import { WanderingMascot } from "./WanderingMascot"
@@ -117,12 +124,16 @@ export const GroupPage = async ({ params }: CommitteePageProps) => {
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col gap-2 sm:flex-row sm:gap-8 rounded-lg">
-        <Avatar className={cn("w-24 h-24 md:w-32 md:h-32", easterEgg?.avatarClassName)}>
-          <AvatarImage src={group.imageUrl ?? undefined} alt={name} />
-          <AvatarFallback className="bg-gray-200 dark:bg-stone-600">
-            <IconUsers width={48} height={48} />
-          </AvatarFallback>
-        </Avatar>
+        <GroupLogoAvatar
+          src={group.imageUrl}
+          alt={name}
+          className={cn("p-1 w-24 h-24 md:w-32 md:h-32", easterEgg?.avatarClassName)}
+          fallback={
+            <AvatarFallback className="bg-gray-200 dark:bg-stone-600">
+              <IconQuestionMark className="size-12 text-muted-foreground" />
+            </AvatarFallback>
+          }
+        />
 
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-0.5">

--- a/apps/web/src/app/om-linjeforeningen/page.tsx
+++ b/apps/web/src/app/om-linjeforeningen/page.tsx
@@ -1,3 +1,4 @@
+import { GroupLogo } from "@/components/atoms/GroupLogo"
 import { OnlineIcon } from "@/components/atoms/OnlineIcon"
 import { server } from "@/utils/trpc/server"
 import type { Group } from "@dotkomonline/types"
@@ -109,23 +110,17 @@ type CardProps = {
 
 const Card: FC<CardProps> = ({ imageUrl, title, description }: CardProps) => {
   return (
-    <li className="flex items-center text-left">
-      <div className="w-[150px] mr-4 shrink-0">
+    <li className="flex gap-3 text-left">
+      <div className="shrink-0">
         {imageUrl ? (
-          <Image
-            src={imageUrl}
-            alt={title}
-            className="object-contain h-auto rounded-full dark:invert"
-            width={150}
-            height={150}
-          />
+          <GroupLogo src={imageUrl} alt={title} width={112} height={112} containerClassName="rounded-full size-29.5" />
         ) : (
-          <OnlineIcon width={150} height={150} />
+          <OnlineIcon width={112} height={112} />
         )}
       </div>
       <div className="grow min-w-0">
         <Title>{title}</Title>
-        <RichText maxLines={5} className="line-clamp-4" content={description} hideToggleButton={true} />
+        <RichText maxLines={3} content={description} hideToggleButton={true} />
       </div>
     </li>
   )

--- a/apps/web/src/app/profil/[username]/ProfilePage.tsx
+++ b/apps/web/src/app/profil/[username]/ProfilePage.tsx
@@ -2,6 +2,7 @@
 
 import { EventList } from "@/app/arrangementer/components/EventList"
 import { useEventAllSummariesByAttendingUserIdInfiniteQuery } from "@/app/arrangementer/components/queries"
+import { GroupLogoAvatar } from "@/components/atoms/GroupLogo"
 import { OnlineIcon } from "@/components/atoms/OnlineIcon"
 import { EventListItemSkeleton } from "@/components/molecules/EventListItem/EventListItem"
 import { MembershipDisplay } from "@/components/molecules/MembershipDisplay/MembershipDisplay"
@@ -39,8 +40,8 @@ import {
   IconLock,
   IconMail,
   IconPhone,
-  IconPhoto,
   IconPointFilled,
+  IconQuestionMark,
   IconUser,
 } from "@tabler/icons-react"
 import { useQueries } from "@tanstack/react-query"
@@ -386,15 +387,24 @@ export function ProfilePage() {
                 href={group.pageUrl}
                 className="flex flex-row items-center gap-3 p-3 rounded-md bg-gray-50 hover:bg-gray-100 dark:bg-stone-800 dark:hover:bg-stone-700 transition-colors"
               >
-                <Avatar className="w-14 h-14">
-                  <AvatarImage src={group.imageUrl ?? undefined} />
-                  <AvatarFallback className="bg-gray-200 dark:bg-stone-500">
-                    <IconPhoto width={32} height={32} />
-                  </AvatarFallback>
-                </Avatar>
+                <GroupLogoAvatar
+                  src={group.imageUrl}
+                  alt={group.name ?? group.abbreviation}
+                  className="w-14 h-14 p-0.75"
+                  fallback={
+                    <AvatarFallback className="bg-gray-200 dark:bg-stone-500">
+                      <IconQuestionMark className="size-8 text-muted-foreground" />
+                    </AvatarFallback>
+                  }
+                />
                 <div className="flex flex-col gap-0.5 grow min-w-0">
                   <Text className="text-lg">{group.name}</Text>
-                  <RichText maxLines={3} className="line-clamp-2" hideToggleButton={true} content={group.description} />
+                  <RichText
+                    maxLines={3}
+                    className="line-clamp-2 text-muted-foreground"
+                    hideToggleButton={true}
+                    content={group.description}
+                  />
                 </div>
               </Link>
             ))}

--- a/apps/web/src/components/atoms/GroupLogo.tsx
+++ b/apps/web/src/components/atoms/GroupLogo.tsx
@@ -1,0 +1,38 @@
+import { Avatar, AvatarImage, cn } from "@dotkomonline/ui"
+import Image from "next/image"
+import type { ComponentProps, ReactNode } from "react"
+
+type GroupLogoAvatarProps = {
+  src?: string | null
+  alt: string
+  className?: string
+  imageClassName?: string
+  size?: ComponentProps<typeof Avatar>["size"]
+  fallback?: ReactNode
+}
+
+export function GroupLogoAvatar({ src, alt, className, imageClassName, size, fallback }: GroupLogoAvatarProps) {
+  return (
+    <Avatar size={size} className={cn("bg-white", className)}>
+      <AvatarImage src={src ?? undefined} alt={alt} className={cn("object-contain", imageClassName)} />
+      {fallback}
+    </Avatar>
+  )
+}
+
+type GroupLogoProps = {
+  src: string
+  alt: string
+  width: number
+  height: number
+  className?: string
+  containerClassName?: string
+}
+
+export function GroupLogo({ src, alt, width, height, className, containerClassName }: GroupLogoProps) {
+  return (
+    <div className={cn("flex shrink-0 items-center justify-center overflow-hidden bg-white", containerClassName)}>
+      <Image src={src} alt={alt} width={width} height={height} className={cn("object-contain", className)} />
+    </div>
+  )
+}

--- a/apps/web/src/components/molecules/GroupListItem/index.tsx
+++ b/apps/web/src/components/molecules/GroupListItem/index.tsx
@@ -1,8 +1,8 @@
+import { GroupLogo } from "@/components/atoms/GroupLogo"
 import { OnlineIcon } from "@/components/atoms/OnlineIcon"
 import { type Group, createGroupPageUrl, getGroupTypeName } from "@dotkomonline/types"
 import { Badge, RichText, Text, Title, cn } from "@dotkomonline/ui"
 import { IconMoonFilled } from "@tabler/icons-react"
-import Image from "next/image"
 import Link from "next/link"
 import type { FC } from "react"
 
@@ -41,25 +41,22 @@ export const GroupListItem: FC<GroupListItemProps> = ({ group }: GroupListItemPr
       <div className="flex flex-col items-center gap-4">
         <div
           className={cn(
-            "relative bg-gray-50 group-hover:bg-white transition-all p-3 rounded-full w-36 h-36",
+            "relative transition-all rounded-full w-36 h-36",
             inactive && "opacity-50 group-hover:opacity-100"
           )}
         >
           {group.imageUrl ? (
-            <Image
+            <GroupLogo
               src={group.imageUrl}
               alt={group.abbreviation}
               height={120}
               width={120}
-              className="object-contain rounded-full"
+              containerClassName="rounded-full size-36 p-3"
             />
           ) : (
-            <OnlineIcon
-              variant="light"
-              width={100}
-              height={100}
-              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
-            />
+            <div className="flex items-center justify-center bg-gray-50 dark:bg-stone-700 rounded-full size-36">
+              <OnlineIcon variant="light" width={100} height={100} />
+            </div>
           )}
         </div>
 
@@ -80,12 +77,12 @@ export const GroupListItem: FC<GroupListItemProps> = ({ group }: GroupListItemPr
       )}
     >
       {group.imageUrl ? (
-        <Image
+        <GroupLogo
           src={group.imageUrl}
           alt={group.abbreviation}
           height={82}
           width={82}
-          className="object-contain rounded-full"
+          containerClassName="rounded-full size-[82px]"
         />
       ) : (
         <OnlineIcon width={82} height={82} />


### PR DESCRIPTION
Adds a white background to group logos and removes any color inversion.

Examples of before:  
![image.png](https://app.graphite.com/user-attachments/assets/db802c98-88d9-4be8-abc4-1b052998c853.png)

![image.png](https://app.graphite.com/user-attachments/assets/f735b048-be64-42bb-bf76-9021f4277090.png)

Examples of after:

![image.png](https://app.graphite.com/user-attachments/assets/2067422d-c5b9-43bd-bcd7-d948f56e11e7.png)

![image.png](https://app.graphite.com/user-attachments/assets/4ab957ab-427e-47a5-8da4-4ae622d95e86.png)