### PR TITLE
Improve navbar responsiveness for extra small screens

### DIFF
--- a/apps/web/src/components/Navbar/MobileMenuCard.tsx
+++ b/apps/web/src/components/Navbar/MobileMenuCard.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenuItem, cn } from "@dotkomonline/ui"
+import { DropdownMenuItem, Text, cn } from "@dotkomonline/ui"
 import type { MenuIcon } from "@/components/Navbar/Navbar"
 import { IconChevronRight } from "@tabler/icons-react"
 import Link from "next/link"
@@ -13,12 +13,12 @@ interface MobileMenuCardProps {
 
 export const MobileMenuCard: FC<MobileMenuCardProps> = ({ title, href, icon: IconComponent, onClick }) => {
   return (
-    <DropdownMenuItem asChild className="flex-1 cursor-pointer p-0">
+    <DropdownMenuItem asChild className="flex-[1_1_auto] cursor-pointer p-0">
       <Link
         href={href}
         onClick={onClick}
         className={cn(
-          "relative flex flex-col items-start justify-start w-full p-4 rounded-xl transition-colors",
+          "relative flex flex-col items-start justify-start p-4 rounded-xl transition-colors",
           "bg-blue-100 hover:bg-blue-200 dark:bg-stone-700 dark:hover:bg-stone-600",
           "border border-blue-200 dark:border-stone-600"
         )}
@@ -27,7 +27,9 @@ export const MobileMenuCard: FC<MobileMenuCardProps> = ({ title, href, icon: Ico
           <IconComponent className="shrink-0 size-6 text-gray-700 dark:text-stone-300" />
           <IconChevronRight className="shrink-0 size-6 opacity-70 text-gray-700 dark:text-stone-300" />
         </div>
-        <span className="text-base font-medium text-gray-800 dark:text-stone-100">{title}</span>
+        <Text element="span" className="text-base font-medium text-gray-800 dark:text-stone-100">
+          {title}
+        </Text>
       </Link>
     </DropdownMenuItem>
   )

--- a/apps/web/src/components/Navbar/MobileNavigation.tsx
+++ b/apps/web/src/components/Navbar/MobileNavigation.tsx
@@ -88,7 +88,7 @@ export const MobileNavigation: FC<{ links: MenuLink[] }> = ({ links }) => {
                 <div className="p-4">
                   <div className="flex flex-col gap-2">
                     {highlightedLinks.length > 0 && (
-                      <div className="flex gap-3 w-full pb-4">
+                      <div className="flex flex-wrap gap-x-3 gap-y-2 w-full pb-4">
                         {highlightedLinks.map((link) => {
                           const item = link as MenuItem
                           return (


### PR DESCRIPTION
This PR makes the mobile navbar collapse the cards into a column on tiny screens

![image.png](https://app.graphite.com/user-attachments/assets/cbf9da74-8cd5-49b6-af73-20c77b1ba230.png)



Still looks like this when there is space

![image.png](https://app.graphite.com/user-attachments/assets/c031f428-40d0-4bf4-a130-50bb3c5b838a.png)

