### PR TITLE
Update dashboard event list page

### DIFF
--- a/apps/dashboard/src/app/(internal)/arrangementer/components/event-hosting-group-list.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/event-hosting-group-list.tsx
@@ -1,42 +1,58 @@
-import type { Company } from "@dotkomonline/rpc/company"
-import type { Group } from "@dotkomonline/rpc/group"
-import { Anchor, Group as MantineGroup, Text } from "@mantine/core"
+import { Company } from "@dotkomonline/rpc/company"
+import { GroupTypeSchema, type Group } from "@dotkomonline/rpc/group"
+import { Anchor, Group as MantineGroup, Text, Tooltip } from "@mantine/core"
 import Link from "next/link"
 import type { FC } from "react"
+
+const MAX_GROUPS_TO_DISPLAY = 4 as const
+const LEEWAY = 1 as const
 
 export type EventHostingGroupListProps = {
   groups: Group[]
   companies: Company[]
 }
 
-/**
- * Component for displaying a list of groups that are hosting an event
- *
- * This list is strictly ordered based on the highest interest priority. The
- * order is companies then groups.
- */
+const getName = (group: Group | Company) => {
+  return "abbreviation" in group ? group.abbreviation : group.name
+}
+
 export const EventHostingGroupList: FC<EventHostingGroupListProps> = ({ groups, companies }) => {
-  // Nobody is set as organizer yet
-  if (groups.length === 0 && companies.length === 0) {
+  const organizers = groups.filter((group) => group.type !== GroupTypeSchema.enum.INTEREST_GROUP)
+  const otherGroups = [...groups.filter((group) => group.type === GroupTypeSchema.enum.INTEREST_GROUP), ...companies]
+
+  if (organizers.length === 0) {
     return (
-      <Text c="dark" size="sm">
-        Ingen arrangører
+      <Text c="red" size="sm">
+        Ingen arrangører. Kontakt HS.
       </Text>
     )
   }
 
+  const maxSize =
+    organizers.length + otherGroups.length > MAX_GROUPS_TO_DISPLAY + LEEWAY
+      ? MAX_GROUPS_TO_DISPLAY
+      : MAX_GROUPS_TO_DISPLAY + LEEWAY
+
+  const groupsToDisplay = [...organizers, ...otherGroups].slice(0, maxSize)
+  const remainingGroups = [...organizers, ...otherGroups].slice(maxSize)
+
   return (
-    <MantineGroup gap="xs">
-      {companies.map((company) => (
-        <Anchor key={company.id} component={Link} size="sm" href={`/bedrifter/${company.slug}`}>
-          {company.name}
-        </Anchor>
-      ))}
-      {groups.map((group) => (
-        <Anchor key={group.slug} component={Link} size="sm" href={`/grupper/${group.slug}`}>
-          {group.abbreviation}
-        </Anchor>
-      ))}
+    <MantineGroup gap="sm">
+      {groupsToDisplay.map((group) => {
+        return (
+          <Anchor key={group.slug} component={Link} size="sm" href={`/grupper/${group.slug}`}>
+            {getName(group)}
+          </Anchor>
+        )
+      })}
+
+      {organizers.length > MAX_GROUPS_TO_DISPLAY + LEEWAY && (
+        <Tooltip label={remainingGroups.map((group) => getName(group)).join(", ")}>
+          <Text c="dimmed" size="sm">
+            +{remainingGroups.length}
+          </Text>
+        </Tooltip>
+      )}
     </MantineGroup>
   )
 }

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/events-table.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/events-table.tsx
@@ -1,58 +1,181 @@
 import { DateTooltip } from "@/components/DateTooltip"
 import { GenericTable } from "@/components/GenericTable"
-import { type EventWithAttendance, mapEventStatusToLabel, mapEventTypeToLabel } from "@dotkomonline/rpc/event"
-import { Anchor } from "@mantine/core"
+import { TableCellLink } from "@/components/TableCellLink"
+import { useCanEditByGroups } from "@/hooks/use-can-edit-by-groups"
+import {
+  EventStatusSchema,
+  type EventWithAttendance,
+  mapEventStatusToLabel,
+  mapEventTypeToLabel,
+} from "@dotkomonline/rpc/event"
 import { createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table"
-import Link from "next/link"
 import { useMemo } from "react"
 import { EventHostingGroupList } from "./event-hosting-group-list"
+import { Box, Center, Group, Pill, Tooltip } from "@mantine/core"
+import { IconEye, IconEyeDotted } from "@tabler/icons-react"
+import { PermissionTooltip } from "@/components/PermissionTooltip"
+import { useAuthorization } from "@/auth/authorization-context"
+
+export type EventTableRow = EventWithAttendance & {
+  canEdit: boolean
+}
 
 interface Props {
   events: EventWithAttendance[]
   onLoadMore?(): void
+  dimReadOnlyRows?: boolean
 }
 
-export const EventTable = ({ events, onLoadMore }: Props) => {
-  const columnHelper = createColumnHelper<EventWithAttendance>()
+export const EventTable = ({ events, onLoadMore, dimReadOnlyRows = false }: Props) => {
+  const authorization = useAuthorization()
+  const { isAdministrator } = authorization
+  const canEditByGroups = useCanEditByGroups()
+
+  const rows = useMemo(
+    (): EventTableRow[] =>
+      events.map((eventWithAttendance) => ({
+        ...eventWithAttendance,
+        canEdit: canEditByGroups(eventWithAttendance.event.hostingGroups.map((group) => group.slug)),
+      })),
+    [canEditByGroups, events]
+  )
+
+  const columnHelper = createColumnHelper<EventTableRow>()
   const columns = useMemo(
-    () => [
-      columnHelper.accessor(({ event }) => event, {
-        id: "title",
-        header: () => "Arrangementnavn",
-        cell: (info) => (
-          <Anchor component={Link} size="sm" href={`/arrangementer/${info.getValue().id}`}>
-            {info.getValue().title}
-          </Anchor>
-        ),
-      }),
-      columnHelper.accessor("event.start", {
-        header: () => "Startdato",
-        cell: (info) => <DateTooltip date={info.getValue()} />,
-      }),
-      columnHelper.accessor(({ event }) => event, {
-        id: "organizers",
-        header: () => "Arrangører",
-        cell: (info) => (
-          <EventHostingGroupList groups={info.getValue().hostingGroups} companies={info.getValue().companies} />
-        ),
-      }),
-      columnHelper.accessor("event.type", {
-        header: () => "Type",
-        cell: (info) => mapEventTypeToLabel(info.getValue()),
-      }),
-      columnHelper.accessor("event.status", {
-        header: () => "Status",
-        cell: (info) => mapEventStatusToLabel(info.getValue()),
-      }),
-    ],
-    [columnHelper]
+    () =>
+      [
+        isAdministrator === false
+          ? columnHelper.accessor("canEdit", {
+              header: () => null,
+              meta: {
+                fit: true,
+                noPadding: true,
+              },
+              cell: (info) => {
+                const canEdit = info.getValue()
+
+                return <EditableRowIndicator canEdit={canEdit} />
+              },
+            })
+          : null,
+        columnHelper.accessor(({ event }) => event, {
+          id: "title",
+          // The margin matches the padding of <TableCellLink>
+          header: () => <span style={{ marginLeft: "var(--mantine-spacing-xs)" }}>Arrangement</span>,
+          meta: {
+            smallPadding: true,
+          },
+          cell: (info) => {
+            const status = info.getValue().status
+            const isDraft = status === EventStatusSchema.enum.DRAFT
+
+            return (
+              <TableCellLink href={`/arrangementer/${info.getValue().id}`} size="sm">
+                <Group>
+                  {info.getValue().title}
+                  {isDraft && (
+                    <Pill
+                      size="xs"
+                      bg="var(--mantine-color-orange-light)"
+                      c="var(--mantine-color-orange-light-color)"
+                      styles={{
+                        label: {
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "4px",
+                          paddingRight: "1px",
+                          letterSpacing: "0.025em",
+                        },
+                      }}
+                    >
+                      <IconEyeDotted size={14} />
+                      {mapEventStatusToLabel(status)}
+                    </Pill>
+                  )}
+                </Group>
+              </TableCellLink>
+            )
+          },
+        }),
+        columnHelper.accessor("event.start", {
+          header: () => "Startdato",
+          cell: (info) => <DateTooltip date={info.getValue()} />,
+        }),
+        columnHelper.accessor(({ event }) => event, {
+          id: "organizers",
+          header: () => "Arrangører",
+          cell: (info) => (
+            <EventHostingGroupList groups={info.getValue().hostingGroups} companies={info.getValue().companies} />
+          ),
+        }),
+        columnHelper.accessor("event.type", {
+          header: () => "Type",
+          cell: (info) => mapEventTypeToLabel(info.getValue()),
+        }),
+      ].filter((column): column is NonNullable<typeof column> => Boolean(column)),
+    [columnHelper, isAdministrator]
   )
 
   const table = useReactTable({
-    data: events,
+    data: rows,
     getCoreRowModel: getCoreRowModel(),
     columns,
   })
 
-  return <GenericTable table={table} onLoadMore={onLoadMore} />
+  return (
+    <GenericTable
+      table={table}
+      onLoadMore={onLoadMore}
+      getRowStyle={(row) => ({
+        opacity: dimReadOnlyRows && !row.original.canEdit ? 0.65 : 1,
+      })}
+      getCellStyle={(_row, columnIndex) => {
+        if (columnIndex === 0) {
+          return {
+            paddingRight: 0,
+            paddingLeft: "10px",
+          }
+        }
+
+        return undefined
+      }}
+    />
+  )
+}
+
+interface EditableRowIndicatorProps {
+  canEdit: boolean
+  readOnlyLabel?: string
+  editableLabel?: string
+}
+
+function EditableRowIndicator({
+  canEdit,
+  readOnlyLabel = "Du kan se dette arrangementet, men ikke redigere det",
+  editableLabel = "Du kan redigere dette arrangementet",
+}: EditableRowIndicatorProps) {
+  if (canEdit) {
+    return (
+      <Tooltip label={editableLabel}>
+        <Center w="14px">
+          <Box
+            w="4px"
+            h="20px"
+            style={{
+              borderRadius: "var(--mantine-radius-xl)",
+              backgroundColor: "var(--mantine-color-blue-4)",
+            }}
+          />
+        </Center>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <PermissionTooltip allowed={false} label={readOnlyLabel}>
+      <Center>
+        <IconEye size={14} color="var(--mantine-color-dimmed)" />
+      </Center>
+    </PermissionTooltip>
+  )
 }

--- a/apps/dashboard/src/app/(internal)/arrangementer/page.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/page.tsx
@@ -1,28 +1,144 @@
 "use client"
 
-import type { EventFilterQuery } from "@dotkomonline/rpc/event"
+import type { EventFilterQuery, EventWithAttendance } from "@dotkomonline/rpc/event"
 import { useAuthorization } from "@/auth/authorization-context"
 import { PermissionTooltip } from "@/components/PermissionTooltip"
-import { Button, Group, Skeleton, Stack, Title } from "@mantine/core"
+import { Button, Group, SegmentedControl, Skeleton, Stack, Text, Title } from "@mantine/core"
+import { getCurrentUTC } from "@dotkomonline/utils"
 import { IconPencil } from "@tabler/icons-react"
 import Link from "next/link"
-import { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useMemo, useState } from "react"
 import { EventFilters } from "./components/event-filters"
 import { EventTable } from "./components/events-table"
 import { useEventAllInfiniteQuery } from "./queries"
+import { interval, isWithinInterval, compareAsc } from "date-fns"
+
+type TimeTab = "kommende" | "tidligere"
+type ScopeFilter = "alle" | "mine"
+
+function parseTimeTab(value: string | null): TimeTab {
+  if (value === "tidligere") {
+    return "tidligere"
+  }
+
+  return "kommende"
+}
+
+function parseScopeFilter(value: string | null): ScopeFilter {
+  if (value === "mine") {
+    return "mine"
+  }
+
+  return "alle"
+}
 
 export default function EventPage() {
-  const [filter, setFilter] = useState<EventFilterQuery>({})
-  const { events, isLoading: isEventsLoading, fetchNextPage } = useEventAllInfiniteQuery({ filter })
-  const { canCreateEvents } = useAuthorization()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [searchFilter, setSearchFilter] = useState<EventFilterQuery>({})
+
+  const timeTab = parseTimeTab(searchParams.get("tab"))
+  const scopeFilterFromQuery = parseScopeFilter(searchParams.get("scope"))
+
+  const authorization = useAuthorization()
+  const { canCreateEvents, isAdministrator, affiliations } = authorization
   const canCreate = canCreateEvents()
+
+  const affiliationSlugs = useMemo(() => [...affiliations.keys()], [affiliations])
+  const canUseMineFilter = !isAdministrator && affiliationSlugs.length > 0
+  const scopeFilter = canUseMineFilter ? scopeFilterFromQuery : "alle"
+
+  const handleTimeTabChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("tab", value)
+
+    router.replace(`/arrangementer?${params.toString()}`)
+  }
+
+  const handleScopeFilterChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("scope", value)
+
+    router.replace(`/arrangementer?${params.toString()}`)
+  }
+
+  const filter = useMemo((): EventFilterQuery => {
+    const now = getCurrentUTC()
+    const timeFilter: EventFilterQuery =
+      timeTab === "kommende"
+        ? { byEndDate: { min: now, max: null }, orderBy: "asc" }
+        : { byEndDate: { min: null, max: now }, orderBy: "desc" }
+
+    const mineFilter: EventFilterQuery =
+      scopeFilter === "mine" && !isAdministrator && affiliationSlugs.length > 0
+        ? { byOrganizingGroup: affiliationSlugs }
+        : {}
+
+    return {
+      ...searchFilter,
+      ...timeFilter,
+      ...mineFilter,
+    }
+  }, [affiliationSlugs, isAdministrator, scopeFilter, searchFilter, timeTab])
+
+  const { events, isLoading: isEventsLoading, fetchNextPage } = useEventAllInfiniteQuery({ filter })
+
+  const displayEvents = useMemo(() => {
+    if (timeTab === "kommende") {
+      return sortUpcomingEvents(events)
+    }
+
+    return events
+  }, [events, timeTab])
 
   return (
     <Stack>
       <Title order={1}>Arrangementer</Title>
 
-      <Group justify="space-between">
-        <EventFilters onChange={setFilter} />
+      <Group justify="space-between" align="flex-end" wrap="wrap">
+        <Stack gap="sm">
+          <SegmentedControl
+            value={timeTab}
+            onChange={handleTimeTabChange}
+            data={[
+              { label: "Kommende", value: "kommende" },
+              { label: "Tidligere", value: "tidligere" },
+            ]}
+          />
+
+          <Group wrap="wrap">
+            <EventFilters onChange={setSearchFilter} />
+
+            {canUseMineFilter && (
+              <SegmentedControl
+                value={scopeFilter}
+                onChange={handleScopeFilterChange}
+                disabled={!canUseMineFilter}
+                data={[
+                  { label: "Alle", value: "alle" },
+                  { label: "Mine", value: "mine" },
+                ]}
+              />
+            )}
+
+            <Text component="span" size="sm" c="dimmed">
+              Viser{" "}
+              {isEventsLoading ? (
+                <Skeleton
+                  component="span"
+                  display="inline-block"
+                  width="2ch"
+                  height="1.25em"
+                  style={{ verticalAlign: "middle" }}
+                />
+              ) : (
+                displayEvents.length
+              )}{" "}
+              arrangementer
+            </Text>
+          </Group>
+        </Stack>
 
         <Group>
           <PermissionTooltip allowed={canCreate}>
@@ -39,8 +155,26 @@ export default function EventPage() {
       </Group>
 
       <Skeleton visible={isEventsLoading}>
-        <EventTable events={events} onLoadMore={fetchNextPage} />
+        <EventTable events={displayEvents} onLoadMore={fetchNextPage} dimReadOnlyRows={scopeFilter === "alle"} />
       </Skeleton>
     </Stack>
   )
+}
+
+function sortUpcomingEvents(events: EventWithAttendance[]): EventWithAttendance[] {
+  const now = getCurrentUTC()
+
+  return events.toSorted((left, right) => {
+    const leftInterval = interval(left.event.start, left.event.end)
+    const rightInterval = interval(right.event.start, right.event.end)
+
+    const leftOngoing = isWithinInterval(now, leftInterval)
+    const rightOngoing = isWithinInterval(now, rightInterval)
+
+    if (leftOngoing !== rightOngoing) {
+      return leftOngoing ? -1 : 1
+    }
+
+    return compareAsc(left.event.start, right.event.start)
+  })
 }

--- a/apps/dashboard/src/hooks/use-can-edit-by-groups.ts
+++ b/apps/dashboard/src/hooks/use-can-edit-by-groups.ts
@@ -1,0 +1,9 @@
+import { useAuthorization } from "@/auth/authorization-context"
+import type { GroupId } from "@dotkomonline/rpc/group"
+import { useCallback } from "react"
+
+export function useCanEditByGroups() {
+  const { canEditEvent } = useAuthorization()
+
+  return useCallback((groupIds: readonly GroupId[]) => canEditEvent(groupIds), [canEditEvent])
+}


### PR DESCRIPTION
This PR adds tabs for future and past events to the dashboard event list page. It also adds filters to only show "your events", which are events you are able to edit.

Events that are read-only to the user are dimmed and has an eye next to its row, and editable events have a blue pill so they're easier to spot while scrolling.

The past events tab is sorted descending, so the newest event is the first one. The future events are sorted ascending, so the event closest to now is the first one.

![image.png](https://app.graphite.com/user-attachments/assets/3531ecc6-7eca-4c08-a9d3-d119858dad9b.png)

