### PR TITLE
Show comparison grade bars for mixed periods

### DIFF
--- a/apps/grades-frontend/messages/en.json
+++ b/apps/grades-frontend/messages/en.json
@@ -144,7 +144,9 @@
       "hoverCompare": "{grade} · {percent} selected · {comparisonPercent} comparison",
       "grades": {
         "PASS": "Pass",
-        "FAIL": "Fail"
+        "FAIL": "Fail",
+        "PASSShort": "Pass",
+        "FAILShort": "Fail"
       }
     },
     "lineChart": {

--- a/apps/grades-frontend/messages/no.json
+++ b/apps/grades-frontend/messages/no.json
@@ -144,7 +144,9 @@
       "hoverCompare": "{grade} · {percent} valgt · {comparisonPercent} sammenligning",
       "grades": {
         "PASS": "Bestått",
-        "FAIL": "Ikke bestått"
+        "FAIL": "Ikke bestått",
+        "PASSShort": "Bst.",
+        "FAILShort": "IBst."
       }
     },
     "lineChart": {

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/CourseBarChartCard.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/CourseBarChartCard.tsx
@@ -35,10 +35,9 @@ export const CourseBarChartCard = ({ gradeDistributions, className }: Props) => 
   const primaryPeriodLabel = periodLabel(periodSelection)
   const comparisonPeriodLabel = formatComparePeriodLabel(comparisonPeriodSelection)
 
-  const { canGhostCompare: rawCanCompare } = getPeriodCompareFlags(selectedRows, comparisonRows)
-  const showGhostComparison = params.isGhost === true && rawCanCompare && comparison !== null
-
-  const canCompare = comparison !== null && rawCanCompare
+  const { canGhostCompare } = getPeriodCompareFlags(selectedRows, comparisonRows)
+  const canCompare = comparison !== null && canGhostCompare
+  const isComparisonEnabled = params.isGhost === true && canCompare
 
   const comparisonDisabledReason =
     comparison === null ? tBar("compareDisabledReason") : tBar("compareDisabledNotComparable")
@@ -54,7 +53,7 @@ export const CourseBarChartCard = ({ gradeDistributions, className }: Props) => 
               <Button
                 className={cn(
                   "cursor-pointer border-none text-sm font-normal transition-colors rounded-lg",
-                  showGhostComparison
+                  isComparisonEnabled
                     ? "bg-neutral-100 text-neutral-950 hover:bg-neutral-200/80 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600"
                     : "text-foreground hover:bg-neutral-100 dark:hover:bg-stone-700"
                 )}
@@ -79,7 +78,7 @@ export const CourseBarChartCard = ({ gradeDistributions, className }: Props) => 
       <GradeDistributionBarChart
         primary={primary}
         comparison={comparison}
-        ghostEnabled={showGhostComparison}
+        ghostEnabled={isComparisonEnabled}
         primaryPeriodLabel={primaryPeriodLabel}
         comparisonPeriodLabel={comparisonPeriodLabel}
       />

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/GradeDistributionBarChart.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/GradeDistributionBarChart.tsx
@@ -1,13 +1,27 @@
 "use client"
 
 import { cn } from "@dotkomonline/ui"
-import { useTranslations } from "next-intl"
+import { useSyncExternalStore } from "react"
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
 import type { AggregatedGradeDistribution } from "../../utils"
-import { GradeTick, SlotHoverCursor } from "./grade-bar-chart-primitives"
+import { CHART_SURFACE_CLASS, CHART_X_AXIS_HEIGHT, GradeTick, SlotHoverCursor } from "./grade-bar-chart-primitives"
 import { DistributionBarShape } from "./grade-bar-chart-shape"
 import { GradeBarChartHeader } from "./GradeBarChartHeader"
 import { useGradeChartData } from "./use-grade-chart-data"
+
+const COMPACT_AXIS_LABELS_QUERY = "(max-width: 599px), (min-width: 1024px) and (max-width: 1179px)"
+
+function useMediaQuery(query: string) {
+  return useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener("change", onChange)
+      return () => mql.removeEventListener("change", onChange)
+    },
+    () => window.matchMedia(query).matches,
+    () => false
+  )
+}
 
 type Props = {
   primary: AggregatedGradeDistribution
@@ -24,12 +38,12 @@ export function GradeDistributionBarChart({
   primaryPeriodLabel,
   comparisonPeriodLabel,
 }: Props) {
-  const t = useTranslations("CoursePage.barChart")
+  const compactViewport = useMediaQuery(COMPACT_AXIS_LABELS_QUERY)
   const { data, yMax, activeRow, setActiveField, showComparison, formatPercent } = useGradeChartData({
     primary,
     comparison,
     ghostEnabled,
-    t,
+    compactViewport,
   })
 
   const baseline = { x1: 0, x2: 0, y: 0 }
@@ -47,12 +61,7 @@ export function GradeDistributionBarChart({
 
       {/* biome-ignore lint/a11y/noStaticElementInteractions: block text/focus selection on Recharts SVG */}
       <div
-        className={cn(
-          "min-h-56 w-full flex-1 select-none text-muted-foreground outline-none lg:min-h-0",
-          "**:select-none **:outline-none",
-          "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none [&_svg]:outline-none",
-          "[&_.recharts-wrapper]:focus:outline-none [&_.recharts-surface]:focus:outline-none [&_svg]:focus:outline-none"
-        )}
+        className={cn("min-h-56 w-full flex-1 lg:min-h-0", CHART_SURFACE_CLASS)}
         onMouseDown={(event) => {
           event.preventDefault()
         }}
@@ -68,22 +77,22 @@ export function GradeDistributionBarChart({
             className="outline-none"
             style={{ userSelect: "none" }}
             onMouseMove={(state) => {
-              const label = state?.activeLabel
-              if (typeof label !== "string") {
+              const index = state?.activeTooltipIndex
+              if (typeof index !== "number" || index < 0 || index >= data.length) {
                 return
               }
 
-              const row = data.find((item) => item.label === label)
-              if (row) {
-                setActiveField(row.field)
-              }
+              setActiveField(data[index].field)
             }}
             onMouseLeave={() => setActiveField(null)}
           >
             <XAxis
-              dataKey="label"
+              dataKey="axisLabel"
               tickLine={false}
               axisLine={false}
+              interval={0}
+              height={CHART_X_AXIS_HEIGHT}
+              tickMargin={0}
               tick={<GradeTick />}
               className="text-muted-foreground"
             />

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/grade-bar-chart-primitives.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/grade-bar-chart-primitives.tsx
@@ -5,6 +5,19 @@ import { cn, Text } from "@dotkomonline/ui"
 const HOVER_INSET_PX = 2
 const HOVER_RADIUS = 6
 
+export const CHART_X_AXIS_HEIGHT = 17
+
+export const CHART_SURFACE_CLASS = cn(
+  "overflow-visible select-none text-muted-foreground outline-none",
+  "**:select-none **:outline-none",
+  "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none [&_svg]:outline-none",
+  "[&_.recharts-wrapper]:focus:outline-none [&_.recharts-surface]:focus:outline-none [&_svg]:focus:outline-none",
+  "[&_.recharts-wrapper]:overflow-visible [&_.recharts-surface]:overflow-visible [&_svg]:overflow-visible"
+)
+
+const TICK_FONT_SIZE = 12
+const TICK_DY = -2
+
 export type TickProps = {
   x?: number | string
   y?: number | string
@@ -30,10 +43,11 @@ export function GradeTick({ x, y, payload }: TickProps) {
     <text
       x={tickX}
       y={tickY}
-      dy={6}
+      dy={TICK_DY}
       textAnchor="middle"
+      dominantBaseline="hanging"
       fill="currentColor"
-      fontSize={12}
+      fontSize={TICK_FONT_SIZE}
       className="text-muted-foreground"
     >
       {payload.value}

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/grade-bar-chart-shape.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/grade-bar-chart-shape.tsx
@@ -26,17 +26,16 @@ export type ShapeProps = {
 }
 
 function barHeights(payload: ChartRow, slotTop: number, slotHeight: number) {
-  const baseline = slotTop + slotHeight
+  const chartBaseline = slotTop + slotHeight
   const scale = payload.plotValue > 0 ? payload.plotValue : 1
   const primaryHeight = (payload.value / scale) * slotHeight
   const ghostHeight = (payload.ghostValue / scale) * slotHeight
 
   return {
-    baseline,
     primaryHeight,
     ghostHeight,
-    primaryY: baseline - primaryHeight,
-    ghostY: baseline - ghostHeight,
+    primaryY: chartBaseline - primaryHeight,
+    ghostY: chartBaseline - ghostHeight,
   }
 }
 

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/use-grade-chart-data.ts
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseBarChart/use-grade-chart-data.ts
@@ -1,4 +1,10 @@
-import { getChartCountFields, type GradeDistributionCountFields } from "@dotkomonline/grades-backend/grade-distribution"
+import {
+  getChartCountFields,
+  letterGradeCountFieldKeys,
+  passFailCountFieldKeys,
+  type GradeDistributionCountFields,
+} from "@dotkomonline/grades-backend/grade-distribution"
+import { useTranslations } from "next-intl"
 import { useMemo, useState } from "react"
 import { chartFieldLabel, type AggregatedGradeDistribution } from "../../utils"
 
@@ -7,21 +13,21 @@ const Y_MAX_HEADROOM = 1.1
 export type ChartRow = {
   field: keyof GradeDistributionCountFields
   label: string
+  axisLabel: string
   value: number
   count: number
   ghostValue: number
-  ghostCount: number
   plotValue: number
 }
-
-type TranslateFn = (key: "percent" | "grades.PASS" | "grades.FAIL", values?: { value: number }) => string
 
 type Options = {
   primary: AggregatedGradeDistribution
   comparison: AggregatedGradeDistribution | null
   ghostEnabled: boolean
-  t: TranslateFn
+  compactViewport: boolean
 }
+
+type BarChartTranslate = ReturnType<typeof useTranslations<"CoursePage.barChart">>
 
 function toPercent(count: number, total: number) {
   if (total <= 0) {
@@ -31,54 +37,51 @@ function toPercent(count: number, total: number) {
   return (count / total) * 100
 }
 
-function chartRowLabel(field: keyof GradeDistributionCountFields, t: TranslateFn) {
-  const label = chartFieldLabel(field)
+function chartRowLabels(field: keyof GradeDistributionCountFields, t: BarChartTranslate, compactAxisLabels: boolean) {
+  const grade = chartFieldLabel(field)
 
-  if (label === "PASS" || label === "FAIL") {
-    return t(`grades.${label}`)
+  if (grade === "PASS" || grade === "FAIL") {
+    return {
+      label: t(`grades.${grade}`),
+      axisLabel: compactAxisLabels ? t(`grades.${grade}Short`) : t(`grades.${grade}`),
+    }
   }
 
-  return label
+  return { label: grade, axisLabel: grade }
 }
 
-/**
- * Letter-only rows store A–F and leave passed/failed at 0. When the chart is
- * PASS/FAIL-only, fold letter grades into pass/fail so letter comparisons ghost correctly.
- * Skip folding when letter bars are also shown, or totals would double-count.
- */
-function getChartFieldCount(
-  grades: GradeDistributionCountFields,
-  field: keyof GradeDistributionCountFields,
-  fields: readonly (keyof GradeDistributionCountFields)[]
+// When ghost compare is on, show the union of primary and comparison columns.
+function getChartFieldsForView(
+  primary: GradeDistributionCountFields,
+  comparison: GradeDistributionCountFields | null,
+  showComparison: boolean
 ) {
-  const chartIsPassFailOnly = fields.every((key) => key === "passedCount" || key === "failedCount")
-
-  if (chartIsPassFailOnly && field === "passedCount") {
-    return (
-      grades.passedCount +
-      grades.gradeACount +
-      grades.gradeBCount +
-      grades.gradeCCount +
-      grades.gradeDCount +
-      grades.gradeECount
-    )
+  const primaryFields = getChartCountFields(primary)
+  if (!showComparison || !comparison) {
+    return primaryFields
   }
 
-  if (chartIsPassFailOnly && field === "failedCount") {
-    return grades.failedCount + grades.gradeFCount
-  }
+  const comparisonFields = getChartCountFields(comparison)
+  const orderedKeys = [...letterGradeCountFieldKeys, ...passFailCountFieldKeys]
 
-  return grades[field]
+  return orderedKeys.filter((key) => primaryFields.includes(key) || comparisonFields.includes(key))
+}
+
+function chartFieldsAreMixedLetterAndPassFail(fields: readonly (keyof GradeDistributionCountFields)[]) {
+  const hasLetter = fields.some((field) => field.startsWith("grade"))
+  const hasPassFail = fields.some((field) => field === "passedCount" || field === "failedCount")
+  return hasLetter && hasPassFail
 }
 
 function sumChartFieldCounts(
   grades: GradeDistributionCountFields,
   fields: readonly (keyof GradeDistributionCountFields)[]
 ) {
-  return fields.reduce((sum, field) => sum + getChartFieldCount(grades, field, fields), 0)
+  return fields.reduce((sum, field) => sum + grades[field], 0)
 }
 
-export function useGradeChartData({ primary, comparison, ghostEnabled, t }: Options) {
+export function useGradeChartData({ primary, comparison, ghostEnabled, compactViewport }: Options) {
+  const t = useTranslations("CoursePage.barChart")
   const [activeField, setActiveField] = useState<keyof GradeDistributionCountFields | null>(null)
 
   const showComparison = ghostEnabled && comparison !== null
@@ -86,27 +89,29 @@ export function useGradeChartData({ primary, comparison, ghostEnabled, t }: Opti
   const formatPercent = (value: number) => t("percent", { value: Math.round(value) })
 
   const data = useMemo(() => {
-    const fields = getChartCountFields(primary.grades)
+    const fields = getChartFieldsForView(primary.grades, comparison?.grades ?? null, showComparison)
+    const compactAxisLabels = compactViewport && chartFieldsAreMixedLetterAndPassFail(fields)
     const primaryTotal = sumChartFieldCounts(primary.grades, fields)
     const comparisonTotal = comparison ? sumChartFieldCounts(comparison.grades, fields) : 0
 
     return fields.map((field): ChartRow => {
-      const count = getChartFieldCount(primary.grades, field, fields)
-      const ghostCount = comparison ? getChartFieldCount(comparison.grades, field, fields) : 0
+      const count = primary.grades[field]
+      const ghostCount = comparison ? comparison.grades[field] : 0
       const value = toPercent(count, primaryTotal)
       const ghostValue = showComparison ? toPercent(ghostCount, comparisonTotal) : 0
+      const { label, axisLabel } = chartRowLabels(field, t, compactAxisLabels)
 
       return {
         field,
-        label: chartRowLabel(field, t),
+        label,
+        axisLabel,
         value,
         count,
         ghostValue,
-        ghostCount,
         plotValue: showComparison ? Math.max(value, ghostValue) : value,
       }
     })
-  }, [primary.grades, comparison, showComparison, t])
+  }, [primary.grades, comparison, showComparison, compactViewport, t])
 
   const yMax = useMemo(() => {
     const peak = data.reduce((max, row) => Math.max(max, row.plotValue), 0)

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseLineChart/CourseLineChart.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseLineChart/CourseLineChart.tsx
@@ -14,6 +14,7 @@ import {
   YAxis,
   type MouseHandlerDataParam,
 } from "recharts"
+import { CHART_SURFACE_CLASS, CHART_X_AXIS_HEIGHT, GradeTick } from "../CourseBarChart/grade-bar-chart-primitives"
 import { SelectionDot, NullFloorDot } from "./line-chart-selection-dot"
 
 export type CourseLineChartMode = "LETTER" | "PASS_FAIL"
@@ -28,7 +29,7 @@ type Props = {
   mode: CourseLineChartMode
   points: CourseLineChartPoint[]
   selectedIds: string[]
-  onPointClick?: (pointId: string) => void
+  onPointClick: (pointId: string) => void
   className?: string
 }
 
@@ -51,8 +52,7 @@ const LINE_STROKE_WIDTH = 1.8
 const MAX_X_TICKS = 8
 const HOVER_DOT_RADIUS = 4.5
 const GRID_STROKE_OPACITY = 0.07
-const AXIS_TICK_MARGIN = 8
-const X_AXIS_HEIGHT = AXIS_TICK_MARGIN + 14
+const Y_AXIS_TICK_MARGIN = 8
 
 function getFocusPoint(points: CourseLineChartPoint[], selectedIds: string[]): CourseLineChartPoint | null {
   if (selectedIds.length !== 1) {
@@ -92,24 +92,24 @@ function getSelectionIndexRange(points: CourseLineChartPoint[], selectedIds: str
 function getPeriodStrokeStops(
   pointCount: number,
   selection: { start: number; end: number }
-): Array<{ offset: number; color: string; role: string }> {
+): { id: string; offset: number; color: string }[] {
   const lastIndex = pointCount - 1
   const toPct = (index: number) => (index / lastIndex) * 100
   const startPct = toPct(selection.start)
   const endPct = selection.end >= lastIndex ? 100 : toPct(selection.end)
-  const stops: Array<{ offset: number; color: string; role: string }> = []
+  const stops: { id: string; offset: number; color: string }[] = []
 
   if (selection.start > 0) {
-    stops.push({ offset: 0, color: HISTORY_STROKE, role: "before-start" })
-    stops.push({ offset: startPct, color: HISTORY_STROKE, role: "before-end" })
+    stops.push({ id: "before-start", offset: 0, color: HISTORY_STROKE })
+    stops.push({ id: "before-end", offset: startPct, color: HISTORY_STROKE })
   }
 
-  stops.push({ offset: startPct, color: PRIMARY_STROKE, role: "primary-start" })
-  stops.push({ offset: endPct, color: PRIMARY_STROKE, role: "primary-end" })
+  stops.push({ id: "primary-start", offset: startPct, color: PRIMARY_STROKE })
+  stops.push({ id: "primary-end", offset: endPct, color: PRIMARY_STROKE })
 
   if (endPct < 100) {
-    stops.push({ offset: endPct, color: HISTORY_STROKE, role: "after-start" })
-    stops.push({ offset: 100, color: HISTORY_STROKE, role: "after-end" })
+    stops.push({ id: "after-start", offset: endPct, color: HISTORY_STROKE })
+    stops.push({ id: "after-end", offset: 100, color: HISTORY_STROKE })
   }
 
   return stops
@@ -141,7 +141,7 @@ function getEvenXTickLabels(points: CourseLineChartPoint[], maxTicks: number) {
 }
 
 function estimateYAxisWidth(mode: CourseLineChartMode) {
-  return mode === "PASS_FAIL" ? AXIS_TICK_MARGIN + 36 : AXIS_TICK_MARGIN + 12
+  return mode === "PASS_FAIL" ? Y_AXIS_TICK_MARGIN + 36 : Y_AXIS_TICK_MARGIN + 12
 }
 
 function formatMetricValue(format: ReturnType<typeof useFormatter>, mode: CourseLineChartMode, value: number) {
@@ -198,9 +198,8 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
   }, [])
 
   const isSingleSelection = selectedIds.length === 1
-  const isPeriodSelection = selectedIds.length > 1
   const selectionCoversAll = selectedIds.length > 0 && points.every((point) => selectedIds.includes(point.id))
-  const highlightPeriod = isPeriodSelection && !selectionCoversAll
+  const highlightPeriod = selectedIds.length > 1 && !selectionCoversAll
 
   const focusPoint = useMemo(() => getFocusPoint(points, selectedIds), [points, selectedIds])
   const selectionRange = useMemo(() => getSelectionIndexRange(points, selectedIds), [points, selectedIds])
@@ -239,16 +238,13 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
     <div
       ref={containerRef}
       className={cn(
-        "min-h-40 w-full flex-1 overflow-visible select-none text-muted-foreground outline-none",
-        "**:select-none **:outline-none",
-        "[&_.recharts-wrapper]:overflow-visible! [&_.recharts-surface]:overflow-visible!",
-        "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none [&_svg]:outline-none [&_svg]:overflow-visible!",
-        "[&_.recharts-wrapper]:focus:outline-none [&_.recharts-surface]:focus:outline-none [&_svg]:focus:outline-none",
-        onPointClick &&
-          "cursor-pointer! [&_.recharts-wrapper]:cursor-pointer! [&_svg]:cursor-pointer! **:cursor-pointer!",
+        "min-h-40 w-full flex-1 cursor-pointer!",
+        "[&_.recharts-wrapper]:cursor-pointer! [&_svg]:cursor-pointer! **:cursor-pointer!",
+        "[&_.recharts-wrapper]:overflow-visible! [&_.recharts-surface]:overflow-visible! [&_svg]:overflow-visible!",
+        CHART_SURFACE_CLASS,
         className
       )}
-      style={onPointClick ? { cursor: "pointer" } : undefined}
+      style={{ cursor: "pointer" }}
       onMouseDown={(event) => {
         event.preventDefault()
       }}
@@ -264,12 +260,12 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
           margin={{ top: 4, right: 0, left: 0, bottom: 0 }}
           accessibilityLayer={false}
           tabIndex={-1}
-          className={onPointClick ? "cursor-pointer! outline-none" : "outline-none"}
-          style={{ userSelect: "none", cursor: onPointClick ? "pointer" : undefined }}
+          className="cursor-pointer! outline-none"
+          style={{ userSelect: "none", cursor: "pointer" }}
           onClick={(state) => {
             const id = resolvePointIdFromChartEvent(state, points)
             if (id) {
-              onPointClick?.(id)
+              onPointClick(id)
             }
           }}
         >
@@ -277,11 +273,7 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
             <defs>
               <linearGradient id={strokeGradientId} x1="0" y1="0" x2="1" y2="0">
                 {periodStrokeStops.map((stop) => (
-                  <stop
-                    key={`${stop.offset}-${stop.color}-${stop.role}`}
-                    offset={`${stop.offset}%`}
-                    stopColor={stop.color}
-                  />
+                  <stop key={stop.id} offset={`${stop.offset}%`} stopColor={stop.color} />
                 ))}
               </linearGradient>
             </defs>
@@ -301,9 +293,9 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
             ticks={xTickLabels}
             tickLine={false}
             axisLine={false}
-            height={X_AXIS_HEIGHT}
-            tickMargin={AXIS_TICK_MARGIN}
-            tick={{ fontSize: 12 }}
+            height={CHART_X_AXIS_HEIGHT}
+            tickMargin={0}
+            tick={<GradeTick />}
             interval={0}
             padding={{ left: 0, right: 0 }}
           />
@@ -315,7 +307,7 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
             tickLine={false}
             axisLine={false}
             width={yAxisWidth}
-            tickMargin={AXIS_TICK_MARGIN}
+            tickMargin={Y_AXIS_TICK_MARGIN}
             tick={{ fontSize: 12 }}
             tickFormatter={formatYTick}
             interval={0}
@@ -331,7 +323,7 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
             strokeWidth={LINE_STROKE_WIDTH}
             strokeLinecap="round"
             strokeLinejoin="round"
-            style={onPointClick ? { cursor: "pointer" } : undefined}
+            style={{ cursor: "pointer" }}
             dot={(dotProps) => {
               const payload = dotProps.payload as CourseLineChartPoint | undefined
               if (payload?.value == null) {
@@ -367,7 +359,7 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
                   cy={dotProps.cy}
                   r={HOVER_DOT_RADIUS}
                   fill={PRIMARY_STROKE}
-                  style={onPointClick ? { cursor: "pointer" } : undefined}
+                  style={{ cursor: "pointer" }}
                 />
               )
             }}
@@ -386,7 +378,7 @@ export function CourseLineChart({ mode, points, selectedIds, onPointClick, class
                   cy={shapeProps.cy}
                   focused={isSingleSelection && point.id === focusId}
                   inSelectedPeriod={highlightPeriod && selectedIdSet.has(point.id)}
-                  onSelect={() => onPointClick?.(point.id)}
+                  onSelect={() => onPointClick(point.id)}
                 />
               )}
             />

--- a/apps/grades-frontend/src/app/emner/[id]/components/CourseLineChart/line-chart-selection-dot.tsx
+++ b/apps/grades-frontend/src/app/emner/[id]/components/CourseLineChart/line-chart-selection-dot.tsx
@@ -65,7 +65,7 @@ export function SelectionDot({
 
     return (
       <ZIndexLayer zIndex={DefaultZIndexes.label}>
-        <g onPointerDown={(event) => event.stopPropagation()}>
+        <g>
           <circle cx={cx} cy={cy} r={SELECTION_DOT_RADIUS} fill={PRIMARY_FILL} />
           {label && (
             <g>
@@ -124,9 +124,6 @@ export function NullFloorDot({ cx, cy, focused = false, inSelectedPeriod = false
         onClick={(event) => {
           event.stopPropagation()
           onSelect?.()
-        }}
-        onPointerDown={(event) => {
-          event.stopPropagation()
         }}
       >
         <circle cx={cx} cy={markCy} r={NULL_FLOOR_HIT_RADIUS} fill="transparent" />

--- a/apps/grades-frontend/src/app/emner/[id]/utils.ts
+++ b/apps/grades-frontend/src/app/emner/[id]/utils.ts
@@ -1,28 +1,31 @@
-import type { Semester, SemesterKey } from "@dotkomonline/grades-backend/course"
+import type { Semester } from "@dotkomonline/grades-backend/course"
 import {
   aggregateGradeDistributions,
   calculateCourseStatistics,
   getLetterGradeCandidateCount,
+  getPassFailCandidateCount,
   sortGradeDistributionsByYearAndSemester,
   type GradeDistribution,
   type GradeDistributionCountFields,
 } from "@dotkomonline/grades-backend/grade-distribution"
 import type { PeriodPreset, PeriodSelection } from "./course-page-params"
 
+const CHART_FIELD_LABELS: Record<keyof GradeDistributionCountFields, string> = {
+  gradeACount: "A",
+  gradeBCount: "B",
+  gradeCCount: "C",
+  gradeDCount: "D",
+  gradeECount: "E",
+  gradeFCount: "F",
+  passedCount: "PASS",
+  failedCount: "FAIL",
+}
+
 export function chartFieldLabel(field: keyof GradeDistributionCountFields): string {
-  if (field === "passedCount") {
-    return "PASS"
-  }
-
-  if (field === "failedCount") {
-    return "FAIL"
-  }
-
-  return field.replace(/^grade/, "").replace(/Count$/, "")
+  return CHART_FIELD_LABELS[field]
 }
 
 export type AggregatedGradeDistribution = {
-  semesters: SemesterKey[]
   candidateCount: number
   averageGrade: number | null
   passRate: number
@@ -66,7 +69,6 @@ export function toAggregatedGradeDistribution(gradeDistributions: GradeDistribut
   const letterCount = getLetterGradeCandidateCount(grades)
 
   return {
-    semesters: gradeDistributions.map((gd) => ({ year: gd.year, semester: gd.semester })),
     candidateCount,
     averageGrade: letterCount === 0 ? null : averageGrade,
     passRate,
@@ -161,8 +163,6 @@ export function getFallbackComparisonPeriodSelection(primary: PeriodSelection): 
 }
 
 export type PeriodCompareFlags = {
-  selectedHasLetterGrades: boolean
-  comparisonHasLetterGrades: boolean
   showLetterKpi: boolean
   showLetterDelta: boolean
   canGhostCompare: boolean
@@ -174,12 +174,11 @@ export function getPeriodCompareFlags(
 ): PeriodCompareFlags {
   const selectedHasLetterGrades = selectedRows.some((row) => getLetterGradeCandidateCount(row) > 0)
   const comparisonHasLetterGrades = comparisonRows.some((row) => getLetterGradeCandidateCount(row) > 0)
+  const comparisonHasPassFailGrades = comparisonRows.some((row) => getPassFailCandidateCount(row) > 0)
 
   return {
-    selectedHasLetterGrades,
-    comparisonHasLetterGrades,
     showLetterKpi: selectedHasLetterGrades,
     showLetterDelta: selectedHasLetterGrades && comparisonHasLetterGrades,
-    canGhostCompare: !selectedHasLetterGrades || comparisonHasLetterGrades,
+    canGhostCompare: !selectedHasLetterGrades || comparisonHasLetterGrades || comparisonHasPassFailGrades,
   }
 }


### PR DESCRIPTION
When comparison is enabled in the barchart and comparing a letter period with pass/fail period, show A-F and Pass/Fail bars

![image.png](https://app.graphite.com/user-attachments/assets/a5ef800d-4163-4f26-bafb-2e8cbb077b16.png)

