### PR TITLE
Fix RegistrationButton updates when event opens

### DIFF
--- a/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
+++ b/apps/rpc/src/modules/event/attendance-availability-view.spec.ts
@@ -105,7 +105,11 @@ describe("buildRegistrationAvailabilityView", () => {
   it("returns rejection cause when registration is not allowed", () => {
     const attendance = createAttendance()
     const punishment: Punishment = { suspended: true, delay: 0 }
-    const result: RegistrationAvailabilityResult = { success: false, cause: "SUSPENDED" }
+    const result: RegistrationAvailabilityResult = {
+      success: false,
+      eventCause: null,
+      userCause: "SUSPENDED",
+    }
 
     const view = buildRegistrationAvailabilityView(userId, result, punishment, attendance)
 
@@ -115,7 +119,8 @@ describe("buildRegistrationAvailabilityView", () => {
       pool: null,
       registration: {
         canRegister: false,
-        rejectionCause: "SUSPENDED",
+        eventRejectionCause: null,
+        userRejectionCause: "SUSPENDED",
         reservationActiveAt: null,
         willBeUnreserved: false,
         hasMergeDelay: false,
@@ -133,13 +138,68 @@ describe("buildRegistrationAvailabilityView", () => {
     const view = buildRegistrationAvailabilityView(userId, result, punishment, attendance)
 
     expect(view.registration?.canRegister).toBe(true)
-    expect(view.registration?.rejectionCause).toBeNull()
+    expect(view.registration?.eventRejectionCause).toBeNull()
+    expect(view.registration?.userRejectionCause).toBeNull()
     expect(view.registration?.willBeUnreserved).toBe(true)
     expect(view.punishment).toEqual(punishment)
     expect(view.pool).toEqual({
       id: attendance.pools[0].id,
       mergeDelayHours: null,
       isPoolFull: false,
+    })
+  })
+
+  it("includes pool delay when registration is only blocked by the window", () => {
+    const attendance = createAttendance()
+    const pool = {
+      ...attendance.pools[0],
+      mergeDelayHours: 4,
+    }
+    const attendanceWithDelay = {
+      ...attendance,
+      pools: [pool],
+    }
+    const reservationActiveAt = addHours(getCurrentUTC(), 4)
+    const result: RegistrationAvailabilityResult = {
+      success: false,
+      eventCause: "TOO_EARLY",
+      userCause: null,
+      pool,
+      reservationActiveAt: new TZDate(reservationActiveAt),
+    }
+
+    const view = buildRegistrationAvailabilityView(userId, result, null, attendanceWithDelay)
+
+    expect(view.registration?.canRegister).toBe(false)
+    expect(view.registration?.eventRejectionCause).toBe("TOO_EARLY")
+    expect(view.registration?.userRejectionCause).toBeNull()
+    expect(view.registration?.hasMergeDelay).toBe(true)
+    expect(view.registration?.willBeUnreserved).toBe(true)
+    expect(view.pool).toEqual({
+      id: pool.id,
+      mergeDelayHours: 4,
+      isPoolFull: false,
+    })
+  })
+
+  it("returns both event and user rejection causes when registration is too early and the user is suspended", () => {
+    const attendance = createAttendance()
+    const punishment: Punishment = { suspended: true, delay: 0 }
+    const result: RegistrationAvailabilityResult = {
+      success: false,
+      eventCause: "TOO_EARLY",
+      userCause: "SUSPENDED",
+    }
+
+    const view = buildRegistrationAvailabilityView(userId, result, punishment, attendance)
+
+    expect(view.registration).toEqual({
+      canRegister: false,
+      eventRejectionCause: "TOO_EARLY",
+      userRejectionCause: "SUSPENDED",
+      reservationActiveAt: null,
+      willBeUnreserved: false,
+      hasMergeDelay: false,
     })
   })
 

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -23,7 +23,11 @@ import { isAdministrator, isCommitteeMember, isGroupMemberOfAny, isSameSubject, 
 import { FailedPreconditionError, InvalidArgumentError, NotFoundError } from "../../error"
 import { withAuditLogEntry, withAuthentication, withAuthorization, withDatabaseTransaction } from "../../middlewares"
 import { procedure, t } from "../../trpc"
-import { buildDeregistrationAvailabilityView, buildRegistrationAvailabilityView } from "./attendance-service"
+import {
+  buildDeregistrationAvailabilityView,
+  buildRegistrationAvailabilityView,
+  getRegistrationAvailabilityFailureCause,
+} from "./attendance-service"
 
 export type CreatePoolInput = inferProcedureInput<typeof createPoolProcedure>
 export type CreatePoolOutput = inferProcedureOutput<typeof createPoolProcedure>
@@ -110,7 +114,7 @@ const adminRegisterForEventProcedure = procedure
       }
     )
     if (!result.success) {
-      throw new FailedPreconditionError(`Failed to register: ${result.cause}`)
+      throw new FailedPreconditionError(`Failed to register: ${getRegistrationAvailabilityFailureCause(result)}`)
     }
     return await ctx.attendanceService.registerAttendee(ctx.handle, result)
   })
@@ -227,7 +231,7 @@ const registerForEventProcedure = procedure
       }
     )
     if (!result.success) {
-      throw new FailedPreconditionError(`Failed to register: ${result.cause}`)
+      throw new FailedPreconditionError(`Failed to register: ${getRegistrationAvailabilityFailureCause(result)}`)
     }
     return await ctx.attendanceService.registerAttendee(ctx.handle, result)
   })

--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -20,6 +20,8 @@ import {
   DEREGISTER_GRACE_PERIOD_MS,
   type RegistrationAvailabilityView,
   type RegistrationRejectionCause,
+  type RegistrationUserCause,
+  type RegistrationWindowCause,
   type RegisterChangeEvent,
   buildPoolOccupancies,
   getReservedAttendeeCount,
@@ -116,7 +118,7 @@ type EventDeregistrationOptions = {
   ignoreDeregistrationWindow: boolean
 }
 
-export type { RegistrationRejectionCause } from "./attendance"
+export type { RegistrationRejectionCause, RegistrationUserCause, RegistrationWindowCause } from "./attendance"
 
 export type RegistrationBypassCause = keyof typeof RegistrationBypassCause
 export const RegistrationBypassCause = {
@@ -156,9 +158,37 @@ export type RegistrationAvailabilitySuccess = {
   options: EventRegistrationOptions
   success: true
 }
-export type RegistrationAvailabilityFailure = {
-  cause: RegistrationRejectionCause
-  success: false
+export type RegistrationAvailabilityFailure =
+  | {
+      success: false
+      eventCause: RegistrationWindowCause
+      userCause: null
+      pool: AttendancePool
+      reservationActiveAt: TZDate
+    }
+  | {
+      success: false
+      eventCause: RegistrationWindowCause | null
+      userCause: RegistrationUserCause
+    }
+
+export function getRegistrationAvailabilityFailureCause(
+  result: RegistrationAvailabilityFailure
+): RegistrationRejectionCause {
+  if (result.eventCause !== null) {
+    return result.eventCause
+  }
+  return result.userCause
+}
+
+function registrationAvailabilityFailure(
+  eventCause: RegistrationWindowCause | null,
+  userCause: RegistrationUserCause
+): RegistrationAvailabilityFailure {
+  if (eventCause === null) {
+    return { success: false, eventCause: null, userCause }
+  }
+  return { success: false, eventCause, userCause }
 }
 
 /**
@@ -500,6 +530,8 @@ export function getAttendanceService(
       // For example, we do not need to query the parent event if the `options` tell to ignore any constraints on the
       // parent event.
 
+      let eventCause: RegistrationWindowCause | null = null
+
       const turnstileCheckRunner = async (): Promise<boolean> => {
         if (!turnstileToken) {
           return false
@@ -538,28 +570,30 @@ export function getAttendanceService(
 
       if (!turnstileCheckResult) {
         if (!options.overrideTurnstileCheck) {
-          return { cause: "INVALID_TURNSTILE_TOKEN", success: false }
+          return registrationAvailabilityFailure(eventCause, "INVALID_TURNSTILE_TOKEN")
         }
         bypassedChecks.push("OVERRIDDEN_TURNSTILE_CHECK")
       }
 
       const isPreviouslyRegistered = attendance.attendees.some((a) => a.userId === userId)
       if (isPreviouslyRegistered) {
-        return { cause: "ALREADY_REGISTERED", success: false }
+        return registrationAvailabilityFailure(eventCause, "ALREADY_REGISTERED")
       }
 
       if (isFuture(attendance.registerStart)) {
         if (!options.ignoreRegistrationWindow) {
-          return { cause: "TOO_EARLY", success: false }
+          eventCause = "TOO_EARLY"
+        } else {
+          bypassedChecks.push("IGNORE_REGISTRATION_START")
         }
-        bypassedChecks.push("IGNORE_REGISTRATION_START")
       }
 
       if (isPast(attendance.registerEnd)) {
         if (!options.ignoreRegistrationWindow) {
-          return { cause: "TOO_LATE", success: false }
+          eventCause = "TOO_LATE"
+        } else {
+          bypassedChecks.push("IGNORE_REGISTRATION_END")
         }
-        bypassedChecks.push("IGNORE_REGISTRATION_END")
       }
 
       // PERF: We only query and check parent relationship when bypassing is not required.
@@ -575,11 +609,11 @@ export function getAttendanceService(
             const attendee = parentAttendance.attendees.find((a) => a.userId === userId)
 
             if (attendee === undefined) {
-              return { cause: "MISSING_PARENT_REGISTRATION", success: false }
+              return registrationAvailabilityFailure(eventCause, "MISSING_PARENT_REGISTRATION")
             }
 
             if (!attendee.reserved) {
-              return { cause: "MISSING_PARENT_RESERVATION", success: false }
+              return registrationAvailabilityFailure(eventCause, "MISSING_PARENT_RESERVATION")
             }
           }
         }
@@ -588,7 +622,7 @@ export function getAttendanceService(
       const membership = findActiveMembership(user)
 
       if (membership === null) {
-        return { cause: "MISSING_MEMBERSHIP", success: false }
+        return registrationAvailabilityFailure(eventCause, "MISSING_MEMBERSHIP")
       }
 
       // This is a "free" check that does zero roundtrips against the database, despite having a rather large piece of
@@ -609,7 +643,7 @@ export function getAttendanceService(
           )
 
           // TODO: Maybe this should just be an invariant?
-          return { cause: "NO_MATCHING_POOL", success: false }
+          return registrationAvailabilityFailure(eventCause, "NO_MATCHING_POOL")
         }
 
         applicablePool = pool
@@ -619,7 +653,7 @@ export function getAttendanceService(
       }
 
       if (applicablePool === null) {
-        return { cause: "NO_MATCHING_POOL", success: false }
+        return registrationAvailabilityFailure(eventCause, "NO_MATCHING_POOL")
       }
 
       // PERF: This always has to be queried at this point, so for this reason, this query comes relatively late in
@@ -628,7 +662,7 @@ export function getAttendanceService(
       const punishment = await personalMarkService.findPunishmentByUserId(handle, userId)
 
       if (punishment?.suspended === true) {
-        return { cause: "SUSPENDED", success: false }
+        return registrationAvailabilityFailure(eventCause, "SUSPENDED")
       }
 
       let reservationActiveAt = getCurrentUTC()
@@ -637,6 +671,16 @@ export function getAttendanceService(
       }
       if (punishment !== null) {
         reservationActiveAt = addHours(reservationActiveAt, punishment.delay)
+      }
+
+      if (eventCause !== null) {
+        return {
+          success: false,
+          eventCause,
+          userCause: null,
+          pool: applicablePool,
+          reservationActiveAt,
+        }
       }
 
       return {
@@ -1843,14 +1887,15 @@ export function buildRegistrationAvailabilityView(
   punishment: Punishment | null,
   attendance: Attendance
 ): RegistrationAvailabilityView {
-  if (!result.success) {
+  if (!result.success && result.userCause !== null) {
     return {
       userId,
       punishment,
       pool: null,
       registration: {
         canRegister: false,
-        rejectionCause: result.cause,
+        eventRejectionCause: result.eventCause,
+        userRejectionCause: result.userCause,
         reservationActiveAt: null,
         willBeUnreserved: false,
         hasMergeDelay: false,
@@ -1874,8 +1919,9 @@ export function buildRegistrationAvailabilityView(
       isPoolFull,
     },
     registration: {
-      canRegister: true,
-      rejectionCause: null,
+      canRegister: result.success,
+      eventRejectionCause: result.success ? null : result.eventCause,
+      userRejectionCause: null,
       reservationActiveAt,
       willBeUnreserved,
       hasMergeDelay,

--- a/apps/rpc/src/modules/event/attendance.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/attendance.e2e-spec.ts
@@ -193,7 +193,7 @@ describe("attendance integration tests", async () => {
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
       })
-    ).toEqual({ success: false, cause: "NO_MATCHING_POOL" })
+    ).toEqual({ success: false, eventCause: null, userCause: "NO_MATCHING_POOL" })
   })
 
   it("should throw an error if the user has no active membership", async () => {
@@ -214,7 +214,7 @@ describe("attendance integration tests", async () => {
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
       })
-    ).toEqual({ success: false, cause: "MISSING_MEMBERSHIP" })
+    ).toEqual({ success: false, eventCause: null, userCause: "MISSING_MEMBERSHIP" })
   })
 
   it("should throw an error if the user is suspended", async () => {
@@ -261,7 +261,7 @@ describe("attendance integration tests", async () => {
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
       })
-    ).toEqual({ success: false, cause: "SUSPENDED" })
+    ).toEqual({ success: false, eventCause: null, userCause: "SUSPENDED" })
   })
 
   it("should not allow registration outside of the registration window", async () => {
@@ -290,16 +290,23 @@ describe("attendance integration tests", async () => {
     expect(findActiveMembership(user)).not.toBeNull()
 
     // Attempt to registrer before the registration window opens
-    expect(
-      await core.attendanceService.getRegistrationAvailability(dbClient, attendance.id, null, user.id, {
+    const availability = await core.attendanceService.getRegistrationAvailability(
+      dbClient,
+      attendance.id,
+      null,
+      user.id,
+      {
         immediateReservation: false,
         immediatePayment: false,
         ignoreRegistrationWindow: false,
         overriddenAttendancePoolId: null,
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
-      })
-    ).toEqual({ success: false, cause: "TOO_EARLY" })
+      }
+    )
+    expect(availability).toMatchObject({ success: false, eventCause: "TOO_EARLY", userCause: null })
+    invariant(!availability.success && availability.userCause === null)
+    expect(availability.pool).toBeDefined()
     // But bypassing the registration window, it should succeed
     const registration = await core.attendanceService.getRegistrationAvailability(
       dbClient,
@@ -359,7 +366,7 @@ describe("attendance integration tests", async () => {
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
       })
-    ).toEqual({ success: false, cause: "ALREADY_REGISTERED" })
+    ).toEqual({ success: false, eventCause: null, userCause: "ALREADY_REGISTERED" })
   })
 
   it("should add a reservation time if the user has a punishment", async () => {
@@ -592,7 +599,7 @@ describe("attendance integration tests", async () => {
         ignoreRegisteredToParent: false,
         overrideTurnstileCheck: true,
       })
-    ).toEqual({ success: false, cause: "NO_MATCHING_POOL" })
+    ).toEqual({ success: false, eventCause: null, userCause: "NO_MATCHING_POOL" })
     // But if an admin registers the user with an forceAttendancePoolId, it should succeed
     const result = await core.attendanceService.getRegistrationAvailability(dbClient, attendance.id, null, user.id, {
       immediateReservation: true,
@@ -835,7 +842,8 @@ describe("attendance integration tests", async () => {
 
     expect(view.registration?.canRegister).toBe(true)
     expect(view.deregistration).toBeNull()
-    expect(view.registration?.rejectionCause).toBeNull()
+    expect(view.registration?.eventRejectionCause).toBeNull()
+    expect(view.registration?.userRejectionCause).toBeNull()
   })
 
   it("should build deregistration availability view for registered attendee", async () => {

--- a/apps/rpc/src/modules/event/attendance.ts
+++ b/apps/rpc/src/modules/event/attendance.ts
@@ -166,10 +166,11 @@ export const AttendanceSummarySchema = AttendanceBaseSchema.extend({
 })
 export type AttendanceSummary = z.infer<typeof AttendanceSummarySchema>
 
-export const RegistrationRejectionCauseSchema = z.enum([
+export const RegistrationWindowCauseSchema = z.enum(["TOO_EARLY", "TOO_LATE"])
+export type RegistrationWindowCause = z.infer<typeof RegistrationWindowCauseSchema>
+
+export const RegistrationUserCauseSchema = z.enum([
   "SUSPENDED",
-  "TOO_EARLY",
-  "TOO_LATE",
   "ALREADY_REGISTERED",
   "MISSING_PARENT_REGISTRATION",
   "MISSING_PARENT_RESERVATION",
@@ -177,6 +178,9 @@ export const RegistrationRejectionCauseSchema = z.enum([
   "NO_MATCHING_POOL",
   "INVALID_TURNSTILE_TOKEN",
 ])
+export type RegistrationUserCause = z.infer<typeof RegistrationUserCauseSchema>
+
+export const RegistrationRejectionCauseSchema = z.union([RegistrationWindowCauseSchema, RegistrationUserCauseSchema])
 export type RegistrationRejectionCause = z.infer<typeof RegistrationRejectionCauseSchema>
 
 export const RegistrationAvailabilityPoolViewSchema = z.object({
@@ -206,7 +210,8 @@ export type RegistrationAvailabilityDeregistrationView = z.infer<
 
 export const RegistrationAvailabilityRegistrationViewSchema = z.object({
   canRegister: z.boolean(),
-  rejectionCause: RegistrationRejectionCauseSchema.nullable(),
+  eventRejectionCause: RegistrationWindowCauseSchema.nullable(),
+  userRejectionCause: RegistrationUserCauseSchema.nullable(),
   reservationActiveAt: z.date().nullable(),
   willBeUnreserved: z.boolean(),
   hasMergeDelay: z.boolean(),

--- a/apps/web/.ladle/fixtures/attendance.ts
+++ b/apps/web/.ladle/fixtures/attendance.ts
@@ -205,7 +205,8 @@ export const createMockRegistrationAvailability = (
   },
   registration: {
     canRegister: true,
-    rejectionCause: null,
+    eventRejectionCause: null,
+    userRejectionCause: null,
     reservationActiveAt: null,
     willBeUnreserved: false,
     hasMergeDelay: false,

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/AttendanceCard.tsx
@@ -13,7 +13,7 @@ import { createAuthorizeUrl, getCurrentUTC } from "@dotkomonline/utils"
 import { IconEdit } from "@tabler/icons-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSubscription } from "@trpc/tanstack-react-query"
-import { differenceInSeconds, isBefore, isPast, secondsToMilliseconds } from "date-fns"
+import { differenceInMilliseconds, differenceInSeconds, isBefore, isPast, secondsToMilliseconds } from "date-fns"
 import Link from "next/link"
 import Turnstile from "react-turnstile"
 import { useEffect, useState } from "react"
@@ -91,8 +91,21 @@ export const AttendanceCard = ({
   )
 
   useEffect(() => {
-    if (attendance) {
-      setAttendanceStatus(getAttendanceStatus(attendance))
+    setAttendanceStatus(getAttendanceStatus(attendance))
+
+    if (!isBefore(getCurrentUTC(), attendance.registerStart)) {
+      return
+    }
+
+    const timeoutId = setTimeout(
+      () => {
+        setAttendanceStatus(getAttendanceStatus(attendance))
+      },
+      differenceInMilliseconds(attendance.registerStart, getCurrentUTC())
+    )
+
+    return () => {
+      clearTimeout(timeoutId)
     }
   }, [attendance])
 
@@ -298,12 +311,6 @@ export const AttendanceCard = ({
   const isRegisterActionPending = registerMutation.isPending || deregisterMutation.isPending
 
   const hasPunishment = punishment !== null && (punishment.delay > 0 || punishment.suspended)
-
-  if (isBefore(getCurrentUTC(), attendance.registerStart)) {
-    setTimeout(() => {
-      setAttendanceStatus("OPEN")
-    }, attendance.registerStart.getTime() - Date.now())
-  }
 
   return (
     <section className="flex flex-col gap-4 min-h-[6rem] sm:p-4 sm:rounded-xl sm:border sm:border-gray-200 sm:dark:border-stone-800 sm:dark:bg-stone-800">

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.stories.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.stories.tsx
@@ -63,7 +63,8 @@ export const AllStates = () => {
             },
             registration: {
               canRegister: true,
-              rejectionCause: null,
+              eventRejectionCause: null,
+              userRejectionCause: null,
               reservationActiveAt: null,
               willBeUnreserved: true,
               hasMergeDelay: false,
@@ -98,7 +99,8 @@ export const AllStates = () => {
             },
             registration: {
               canRegister: true,
-              rejectionCause: null,
+              eventRejectionCause: null,
+              userRejectionCause: null,
               reservationActiveAt: null,
               willBeUnreserved: false,
               hasMergeDelay: true,
@@ -170,7 +172,8 @@ export const AllStates = () => {
           registrationAvailability={createMockRegistrationAvailability({
             registration: {
               canRegister: false,
-              rejectionCause: "TOO_EARLY",
+              eventRejectionCause: "TOO_EARLY",
+              userRejectionCause: null,
               reservationActiveAt: null,
               willBeUnreserved: false,
               hasMergeDelay: false,
@@ -188,7 +191,8 @@ export const AllStates = () => {
           registrationAvailability={createMockRegistrationAvailability({
             registration: {
               canRegister: false,
-              rejectionCause: "TOO_LATE",
+              eventRejectionCause: "TOO_LATE",
+              userRejectionCause: null,
               reservationActiveAt: null,
               willBeUnreserved: false,
               hasMergeDelay: false,
@@ -207,7 +211,8 @@ export const AllStates = () => {
             punishment: createMockPunishment({ suspended: true, delay: 0 }),
             registration: {
               canRegister: false,
-              rejectionCause: "SUSPENDED",
+              eventRejectionCause: null,
+              userRejectionCause: "SUSPENDED",
               reservationActiveAt: null,
               willBeUnreserved: false,
               hasMergeDelay: false,
@@ -226,7 +231,8 @@ export const AllStates = () => {
             pool: null,
             registration: {
               canRegister: false,
-              rejectionCause: "NO_MATCHING_POOL",
+              eventRejectionCause: null,
+              userRejectionCause: "NO_MATCHING_POOL",
               reservationActiveAt: null,
               willBeUnreserved: false,
               hasMergeDelay: false,

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/RegistrationButton.tsx
@@ -7,6 +7,7 @@ import { Button, Text, Tooltip, TooltipContent, TooltipTrigger, cn } from "@dotk
 import { IconLoader2, IconLock, IconUserMinus, IconUserPlus, IconX } from "@tabler/icons-react"
 import { type FC, useEffect, useState } from "react"
 import type { DeregisterReasonFormResult } from "../DeregisterModal"
+import { getAttendanceStatus } from "../attendanceStatus"
 import { deregistrationRejectionMessages } from "./deregistrationRejectionMessages"
 import { registrationRejectionMessages } from "./registrationRejectionMessages"
 
@@ -71,7 +72,8 @@ const getButtonColor = (
 const getDisabledText = (
   registrationAvailability: RegistrationAvailability | undefined,
   turnstileStatus: TurnstileStatus,
-  isLoggedIn: boolean
+  isLoggedIn: boolean,
+  attendance: Attendance
 ): string | null => {
   if (!isLoggedIn) {
     return "Du må være innlogget for å melde deg på"
@@ -98,6 +100,12 @@ const getDisabledText = (
     return null
   }
 
+  const attendanceStatus = getAttendanceStatus(attendance)
+
+  if (attendanceStatus === "NOT_OPENED") {
+    return registrationRejectionMessages.TOO_EARLY
+  }
+
   if (turnstileStatus === "loading") {
     return registrationRejectionMessages.TURNSTILE_LOADING
   }
@@ -110,8 +118,12 @@ const getDisabledText = (
     return registrationRejectionMessages.MISSING_TURNSTILE_TOKEN
   }
 
-  if (!registration.canRegister && registration.rejectionCause) {
-    return registrationRejectionMessages[registration.rejectionCause]
+  if (attendanceStatus === "CLOSED" || registration.eventRejectionCause === "TOO_LATE") {
+    return registrationRejectionMessages.TOO_LATE
+  }
+
+  if (registration.userRejectionCause !== null) {
+    return registrationRejectionMessages[registration.userRejectionCause]
   }
 
   return null
@@ -158,7 +170,7 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({
   const buttonText = attendee ? "Meld meg av" : "Meld meg på"
   const buttonIcon = null
 
-  const disabledText = getDisabledText(registrationAvailability, turnstileStatus, Boolean(user))
+  const disabledText = getDisabledText(registrationAvailability, turnstileStatus, Boolean(user), attendance)
   const isAvailabilityPending = Boolean(user) && registrationAvailability === undefined
   const isButtonDisabled = Boolean(disabledText) || isLoading || isAvailabilityPending
 

--- a/apps/web/src/app/arrangementer/components/AttendanceCard/registrationRejectionMessages.ts
+++ b/apps/web/src/app/arrangementer/components/AttendanceCard/registrationRejectionMessages.ts
@@ -1,8 +1,9 @@
 import type { AttendanceRouter } from "@dotkomonline/rpc"
 
-type RegistrationRejectionCause = NonNullable<
-  NonNullable<AttendanceRouter.GetRegistrationAvailabilityOutput["registration"]>["rejectionCause"]
->
+type RegistrationView = NonNullable<AttendanceRouter.GetRegistrationAvailabilityOutput["registration"]>
+type RegistrationRejectionCause =
+  | NonNullable<RegistrationView["eventRejectionCause"]>
+  | NonNullable<RegistrationView["userRejectionCause"]>
 
 export type RegistrationRejectionMessageKey =
   | RegistrationRejectionCause


### PR DESCRIPTION
This isn't as simple as it seems because the frontend needs to know if the only reason the button is disabled is `TOO_EARLY`, or if there's multiple reasons. Without that, we can't enable the button without being sure the user is applicable for registration unless we trigger a refetch of `getRegistrationAvailability`which would cause all connected clients to fetch it at the same time