### PR TITLE
Stop creating Sentry issues for browser extension errors

### DIFF
--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -59,5 +59,8 @@ export default withSentryConfig(config, {
     treeshake: {
       removeDebugLogging: true,
     },
+    unstable_sentryWebpackPluginOptions: {
+      applicationKey: "monoweb-dashboard",
+    },
   },
 })

--- a/apps/dashboard/src/instrumentation-client.ts
+++ b/apps/dashboard/src/instrumentation-client.ts
@@ -11,6 +11,12 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN !== undefined) {
     sendDefaultPii: false,
     debug: false,
     skipOpenTelemetrySetup: true,
+    integrations: [
+      Sentry.thirdPartyErrorFilterIntegration({
+        filterKeys: ["monoweb-dashboard"],
+        behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+      }),
+    ],
   })
 }
 

--- a/apps/grades-frontend/next.config.mjs
+++ b/apps/grades-frontend/next.config.mjs
@@ -64,5 +64,8 @@ export default withSentryConfig(withNextIntl(nextConfig), {
   webpack: {
     reactComponentAnnotation: true,
     treeshake: { removeDebugLogging: true },
+    unstable_sentryWebpackPluginOptions: {
+      applicationKey: "grades-frontend",
+    },
   },
 })

--- a/apps/grades-frontend/src/instrumentation-client.ts
+++ b/apps/grades-frontend/src/instrumentation-client.ts
@@ -12,6 +12,12 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN !== undefined) {
     sendDefaultPii: false,
     debug: false,
     skipOpenTelemetrySetup: true,
+    integrations: [
+      Sentry.thirdPartyErrorFilterIntegration({
+        filterKeys: ["grades-frontend"],
+        behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+      }),
+    ],
   })
 }
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -63,5 +63,8 @@ export default withSentryConfig(config, {
     treeshake: {
       removeDebugLogging: true,
     },
+    unstable_sentryWebpackPluginOptions: {
+      applicationKey: "monoweb-web",
+    },
   },
 })

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -12,6 +12,12 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN !== undefined) {
     sendDefaultPii: false,
     debug: false,
     skipOpenTelemetrySetup: true,
+    integrations: [
+      Sentry.thirdPartyErrorFilterIntegration({
+        filterKeys: ["monoweb-web"],
+        behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+      }),
+    ],
   })
 }
 


### PR DESCRIPTION
https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/filtering/#using-thirdpartyerrorfilterintegration

This should stop browser extension exceptions like `Failed to connect to MetaMask` from polluting Sentry 