### PR TITLE
Add radius to Tilt component to match children

### DIFF
--- a/apps/web/src/app/arrangementer/components/EventHeader.tsx
+++ b/apps/web/src/app/arrangementer/components/EventHeader.tsx
@@ -27,6 +27,7 @@ export const EventHeader: FC<Props> = ({ event, showDashboardLink }) => {
         tiltMaxAngleX={0.25}
         tiltMaxAngleY={0.25}
         glareMaxOpacity={0.1}
+        glareBorderRadius="var(--radius-xl)"
         className="rounded-xl bg-gray-100 dark:bg-stone-800/50"
       >
         <div className="group relative w-full aspect-video md:aspect-24/9 overflow-hidden rounded-xl">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -78,7 +78,13 @@ export default async function App() {
                 <EventCard key={event.id} event={event} attendance={attendance} userId={user?.id} />
               ))}
 
-              <Tilt tiltMaxAngleX={0.25} tiltMaxAngleY={0.25} scale={1.005} className="h-full">
+              <Tilt
+                tiltMaxAngleX={0.25}
+                tiltMaxAngleY={0.25}
+                scale={1.005}
+                glareBorderRadius="var(--radius-xl)"
+                className="h-full"
+              >
                 <Button
                   variant="unstyled"
                   element={Link}
@@ -104,7 +110,13 @@ export default async function App() {
                 ))}
 
                 <div className="snap-center pr-4">
-                  <Tilt tiltMaxAngleX={0.25} tiltMaxAngleY={0.25} scale={1.005} className="h-full">
+                  <Tilt
+                    tiltMaxAngleX={0.25}
+                    tiltMaxAngleY={0.25}
+                    scale={1.005}
+                    glareBorderRadius="var(--radius-xl)"
+                    className="h-full"
+                  >
                     <Button
                       element={Link}
                       href="/arrangementer"
@@ -143,7 +155,13 @@ export default async function App() {
                 <EventCard key={event.id} event={event} attendance={attendance} userId={user.id} />
               ))}
 
-              <Tilt tiltMaxAngleX={0.25} tiltMaxAngleY={0.25} scale={1.005} className="h-full">
+              <Tilt
+                tiltMaxAngleX={0.25}
+                tiltMaxAngleY={0.25}
+                scale={1.005}
+                glareBorderRadius="var(--radius-xl)"
+                className="h-full"
+              >
                 <Button
                   variant="unstyled"
                   element={Link}
@@ -169,7 +187,13 @@ export default async function App() {
                 ))}
 
                 <div className="snap-center pr-4">
-                  <Tilt tiltMaxAngleX={0.25} tiltMaxAngleY={0.25} scale={1.005} className="h-full">
+                  <Tilt
+                    tiltMaxAngleX={0.25}
+                    tiltMaxAngleY={0.25}
+                    scale={1.005}
+                    glareBorderRadius="var(--radius-xl)"
+                    className="h-full"
+                  >
                     <Button
                       element={Link}
                       href="/arrangementer"

--- a/apps/web/src/components/molecules/EventListItem/EventImage.tsx
+++ b/apps/web/src/components/molecules/EventListItem/EventImage.tsx
@@ -37,7 +37,7 @@ export const EventImage: FC<EventImageProps> = ({
   const eventHasEnded = isPast(end)
 
   return (
-    <Tilt>
+    <Tilt glareBorderRadius="var(--radius-lg)">
       <div className={cn("relative", className)}>
         <div className={cn("relative bg-gray-100 dark:bg-stone-800/50 rounded-lg overflow-hidden", imageClassName)}>
           {imageUrl ? (


### PR DESCRIPTION
Fixes that Tilt is square while the content is rounded:

![image.png](https://app.graphite.com/user-attachments/assets/b6d255f1-8566-4b9a-a6d0-6eb4d8b17d24.png)

