### PR TITLE
Update create pool modal and update input validation

### DIFF
--- a/apps/dashboard/src/app/(internal)/arrangementer/[id]/attendees-page.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/[id]/attendees-page.tsx
@@ -77,6 +77,7 @@ const Page: FC<Props> = ({ event, attendance, feedbackAnswers }) => {
           onSubmit={(values) => {
             openManualCreateUserAttendModal({
               attendanceId: attendance.id,
+              eventId: event.id,
               userId: values.id,
             })
           }}

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/create-pool-modal.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/create-pool-modal.tsx
@@ -3,7 +3,7 @@ import { type ContextModalProps, modals } from "@mantine/modals"
 import type { FC } from "react"
 import { useCreatePoolMutation } from "../mutations"
 import { useAttendanceGetQuery } from "../queries"
-import { PoolForm } from "./pool-form"
+import { getAvailablePoolYears, PoolForm } from "./pool-form"
 
 interface CreatePoolModalProps {
   attendanceId: AttendanceId
@@ -37,7 +37,7 @@ export const CreatePoolModal: FC<ContextModalProps<CreatePoolModalProps>> = ({
   return pools ? (
     <PoolForm
       defaultValues={{
-        yearCriteria: [],
+        yearCriteria: getAvailablePoolYears(disabledYears),
         capacity: 0,
         title: "",
         mergeDelayHours: null,

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/manual-create-user-attend-modal.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/manual-create-user-attend-modal.tsx
@@ -1,60 +1,93 @@
+import { createCheckboxInput } from "@/components/forms/CheckboxInput"
 import { useFormBuilder } from "@/components/forms/Form"
-import { createSelectInput } from "@/components/forms/SelectInput"
+import { createSegmentedControlInput } from "@/components/forms/SegmentedControlInput"
+import type { InputProducerResult } from "@/components/forms/types"
+import { useIsMobile } from "@/hooks/use-is-mobile"
 import { notifyFail } from "@/lib/notifications"
+import {
+  type Attendance,
+  type AttendancePool,
+  type Attendee,
+  getAttendablePool,
+  getReservedAttendeeCount,
+  getUnreservedAttendeeCount,
+} from "@dotkomonline/rpc/attendance"
+import type { Event, EventId, EventWithAttendance } from "@dotkomonline/rpc/event"
+import type { User, UserId } from "@dotkomonline/rpc/user"
+import { Group, Loader, Stack, Text } from "@mantine/core"
 import { type ContextModalProps, modals } from "@mantine/modals"
-import type { FC } from "react"
+import { IconAlertTriangle } from "@tabler/icons-react"
+import { type FC, useEffect } from "react"
+import { type Control, type UseFormGetValues, type UseFormSetValue, useWatch } from "react-hook-form"
 import { z } from "zod"
+import { useUserQuery } from "../../brukere/queries"
 import { useAdminForEventMutation as useAdminRegisterForEventMutation } from "../mutations"
-import { useAttendanceGetQuery } from "../queries"
+import { useAttendanceGetQuery, useFindParentEventQuery } from "../queries"
+import { UserBox } from "./user-box"
 
 interface ModalProps {
   userId: string
   attendanceId: string
+  eventId: EventId
 }
 
 const FormSchema = z.object({
   poolId: z.string(),
+  ignoreRegisteredToParent: z.boolean().default(true),
+  immediateReservation: z.boolean().default(false),
+  paymentDeadlineHours: z.enum(["1", "24"]).default("24"),
 })
+
+type FormInput = z.input<typeof FormSchema>
+type FormResult = z.output<typeof FormSchema>
 
 export const ManualCreateUserAttendModal: FC<ContextModalProps<ModalProps>> = ({
   context,
   id,
-  innerProps: { attendanceId, userId },
+  innerProps: { attendanceId, eventId, userId },
 }) => {
+  const isMobile = useIsMobile() ?? false
   const { mutate: createAttendee } = useAdminRegisterForEventMutation()
 
   const { data: attendance } = useAttendanceGetQuery(attendanceId)
+  const { data: user, isLoading: isUserLoading } = useUserQuery(userId)
+  const { data: parentEventWithAttendance } = useFindParentEventQuery(eventId)
 
-  const onSubmit = (userId: string, attendancePoolId: string) => {
-    createAttendee({
-      attendanceId,
-      userId,
-      attendancePoolId,
-    })
-
-    context.closeModal(id)
-  }
-
-  const defaultValue = attendance?.pools[0]?.id ?? ""
+  const defaultPoolId = getDefaultPoolId(attendance, user)
 
   const Form = useFormBuilder({
     schema: FormSchema,
     defaultValues: {
-      poolId: defaultValue,
+      poolId: defaultPoolId,
+      ignoreRegisteredToParent: true,
+      immediateReservation: false,
+      paymentDeadlineHours: "24",
     },
     fields: {
-      poolId: createSelectInput({
-        label: "Påmeldingsgruppe",
-        data: attendance?.pools.map((pool) => ({
-          label: pool.title,
-          value: pool.id,
-        })),
+      poolId: createPoolIdField(attendance, user, isMobile),
+      ignoreRegisteredToParent: createIgnoreRegisteredToParentField(parentEventWithAttendance, userId),
+      immediateReservation: createCheckboxInput({
+        label: "Tving påmeldtstatus",
+        description:
+          "Gir reservert plass med en gang. Uten dette kan brukeren havne i kø hvis gruppen er full, har utsettelse, eller brukeren har prikker.",
       }),
+      paymentDeadlineHours: createPaymentDeadlineField(attendance),
     },
     label: "Meld på bruker",
     onSubmit: (values) => {
       try {
-        onSubmit(userId, values.poolId)
+        createAttendee({
+          attendanceId,
+          userId,
+          attendancePoolId: values.poolId,
+          options: {
+            ignoreRegisteredToParent: values.ignoreRegisteredToParent,
+            immediateReservation: values.immediateReservation,
+            immediatePayment: isImmediatePayment(values.paymentDeadlineHours),
+          },
+        })
+
+        context.closeModal(id)
       } catch (e) {
         notifyFail({
           title: "Oops!",
@@ -64,12 +97,266 @@ export const ManualCreateUserAttendModal: FC<ContextModalProps<ModalProps>> = ({
     },
   })
 
-  return <Form />
+  return (
+    <Stack w="100%" style={{ overflowX: "auto" }}>
+      <UserSection user={user} isLoading={isUserLoading} isMobile={isMobile} />
+      <Form />
+    </Stack>
+  )
 }
 
-export const openManualCreateUserAttendModal = ({ userId, attendanceId }: ModalProps) =>
+function UserSection({ user, isLoading, isMobile }: { user: User | undefined; isLoading: boolean; isMobile: boolean }) {
+  if (isLoading) {
+    return <Loader />
+  }
+
+  if (user === undefined) {
+    return null
+  }
+
+  return <UserBox user={user} isMobile={isMobile} />
+}
+
+function createPoolIdField(
+  attendance: Attendance | undefined,
+  user: User | undefined,
+  isMobile: boolean
+): InputProducerResult<FormInput, FormResult> {
+  const PoolInput = createSegmentedControlInput<FormInput, FormResult>({
+    label: "Påmeldingsgruppe",
+    orientation: isMobile ? "vertical" : "horizontal",
+    data:
+      attendance?.pools.map((pool) => ({
+        label: pool.title,
+        value: pool.id,
+      })) ?? [],
+  })
+
+  return function PoolIdField(context) {
+    useRecommendedPoolSelection({
+      attendance,
+      user,
+      getValues: context.getValues,
+      setValue: context.setValue,
+      isPoolSelectionDirty: context.state.dirtyFields.poolId === true,
+    })
+
+    return (
+      <Stack gap="xs">
+        <PoolInput {...context} />
+        <SelectedPoolOccupancy control={context.control} attendance={attendance} />
+      </Stack>
+    )
+  }
+}
+
+function useRecommendedPoolSelection({
+  attendance,
+  user,
+  getValues,
+  setValue,
+  isPoolSelectionDirty,
+}: {
+  attendance: Attendance | undefined
+  user: User | undefined
+  getValues: UseFormGetValues<FormInput>
+  setValue: UseFormSetValue<FormInput>
+  isPoolSelectionDirty: boolean
+}) {
+  const recommendedPoolId = getDefaultPoolId(attendance, user)
+
+  useEffect(() => {
+    if (recommendedPoolId === "") {
+      return
+    }
+
+    if (isPoolSelectionDirty) {
+      return
+    }
+
+    if (getValues("poolId") === recommendedPoolId) {
+      return
+    }
+
+    setValue("poolId", recommendedPoolId)
+  }, [getValues, isPoolSelectionDirty, recommendedPoolId, setValue])
+}
+
+function createIgnoreRegisteredToParentField(
+  parentEventWithAttendance: EventWithAttendance | null | undefined,
+  userId: UserId
+): InputProducerResult<FormInput, FormResult> {
+  const IgnoreParentInput = createCheckboxInput<FormInput, FormResult>({
+    label: "Ignorer påmelding til forelderarrangement",
+    description: "Tillat påmelding selv om brukeren ikke er påmeldt forelderarrangementet.",
+  })
+
+  return function IgnoreRegisteredToParentField(context) {
+    if (parentEventWithAttendance == null) {
+      return null
+    }
+
+    return (
+      <Stack gap="xs">
+        <ParentEventRegistrationStatus
+          parentEvent={parentEventWithAttendance.event}
+          parentAttendance={parentEventWithAttendance.attendance}
+          userId={userId}
+        />
+        <IgnoreParentInput {...context} />
+      </Stack>
+    )
+  }
+}
+
+function ParentEventRegistrationStatus({
+  parentEvent,
+  parentAttendance,
+  userId,
+}: {
+  parentEvent: Event
+  parentAttendance: Attendance | null
+  userId: UserId
+}) {
+  const parentAttendee = parentAttendance?.attendees.find((attendee) => attendee.userId === userId) ?? null
+  const isMissingReservedSpot = parentAttendee === null || !parentAttendee.reserved
+
+  return (
+    <Group gap={6} mb="xs">
+      <ParentRegistrationWarning showWarning={isMissingReservedSpot} />
+      <Text size="sm">{getParentRegistrationStatusText(parentEvent.title, parentAttendee)}</Text>
+    </Group>
+  )
+}
+
+function ParentRegistrationWarning({ showWarning }: { showWarning: boolean }) {
+  if (!showWarning) {
+    return null
+  }
+
+  return <IconAlertTriangle color="var(--mantine-color-red-6)" size={20} />
+}
+
+function getParentRegistrationStatusText(parentEventTitle: string, parentAttendee: Attendee | null): string {
+  if (parentAttendee === null) {
+    return `Ikke påmeldt forelderarrangementet ${parentEventTitle}`
+  }
+
+  if (!parentAttendee.reserved) {
+    return `På venteliste på forelderarrangementet ${parentEventTitle}`
+  }
+
+  return `Påmeldt forelderarrangementet ${parentEventTitle}`
+}
+
+function createPaymentDeadlineField(attendance: Attendance | undefined): InputProducerResult<FormInput, FormResult> {
+  const PaymentDeadlineInput = createSegmentedControlInput<FormInput, FormResult>({
+    label: "Betalingsfrist",
+    data: [
+      { value: "1", label: "1 time" },
+      { value: "24", label: "24 timer" },
+    ],
+  })
+
+  return function PaymentDeadlineField(context) {
+    if (attendance === undefined || attendance.attendancePrice === null || attendance.attendancePrice === 0) {
+      return null
+    }
+
+    return <PaymentDeadlineInput {...context} />
+  }
+}
+
+function isImmediatePayment(paymentDeadlineHours: FormResult["paymentDeadlineHours"]): boolean {
+  return paymentDeadlineHours === "1"
+}
+
+function getDefaultPoolId(attendance: Attendance | undefined, user: User | undefined): string {
+  if (attendance === undefined) {
+    return ""
+  }
+
+  if (user !== undefined) {
+    const attendablePool = getAttendablePool(attendance, user)
+
+    if (attendablePool !== null) {
+      return attendablePool.id
+    }
+  }
+
+  return attendance.pools[0]?.id ?? ""
+}
+
+function SelectedPoolOccupancy({
+  control,
+  attendance,
+}: {
+  control: Control<FormInput>
+  attendance: Attendance | undefined
+}) {
+  const selectedPoolId = useWatch({ control, name: "poolId" })
+
+  if (attendance === undefined) {
+    return null
+  }
+
+  const selectedPool = attendance.pools.find((pool) => pool.id === selectedPoolId)
+
+  if (selectedPool === undefined) {
+    return null
+  }
+
+  return <PoolOccupancyStatus pool={selectedPool} attendance={attendance} />
+}
+
+function PoolOccupancyStatus({ pool, attendance }: { pool: AttendancePool; attendance: Attendance }) {
+  const reservedAttendeeCount = getReservedAttendeeCount(attendance, pool.id)
+  const unreservedAttendeeCount = getUnreservedAttendeeCount(attendance, pool.id)
+  const poolIsFull = pool.capacity > 0 && reservedAttendeeCount >= pool.capacity
+
+  return (
+    <Stack gap={4}>
+      <Group gap={6}>
+        <FullPoolWarning poolIsFull={poolIsFull} />
+        <Text size="sm">{getPoolOccupancyText(pool, reservedAttendeeCount)}</Text>
+      </Group>
+      <WaitlistCount count={unreservedAttendeeCount} poolTitle={pool.title} />
+    </Stack>
+  )
+}
+
+function FullPoolWarning({ poolIsFull }: { poolIsFull: boolean }) {
+  if (!poolIsFull) {
+    return null
+  }
+
+  return <IconAlertTriangle color="var(--mantine-color-red-6)" size={20} />
+}
+
+function WaitlistCount({ count, poolTitle }: { count: number; poolTitle: string }) {
+  if (count === 0) {
+    return null
+  }
+
+  return (
+    <Text size="sm">
+      {count} i kø i {poolTitle}
+    </Text>
+  )
+}
+
+function getPoolOccupancyText(pool: AttendancePool, reservedAttendeeCount: number): string {
+  if (pool.capacity > 0) {
+    return `${reservedAttendeeCount}/${pool.capacity} påmeldte i ${pool.title}`
+  }
+
+  return `${reservedAttendeeCount} påmeldte i ${pool.title} (ledige plasser)`
+}
+
+export const openManualCreateUserAttendModal = ({ userId, attendanceId, eventId }: ModalProps) =>
   modals.openContextModal({
     modal: "event/attendance/attendee/create",
-    title: "Meld på bruker",
-    innerProps: { userId, attendanceId },
+    title: "Admin-påmeld bruker",
+    size: "lg",
+    innerProps: { userId, attendanceId, eventId },
   })

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/pool-form.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/pool-form.tsx
@@ -1,13 +1,15 @@
 import { createLabelledCheckboxGroupInput } from "@/components/forms/CheckboxGroup"
 import { createNumberInput } from "@/components/forms/NumberInput"
 import { createTextInput } from "@/components/forms/TextInput"
+import { getErrorMessage, type InputFieldContext } from "@/components/forms/types"
 import { notifyFail } from "@/lib/notifications"
+import { MAX_MERGE_DELAY_HOURS } from "@dotkomonline/rpc/attendance"
 import { createPoolName } from "@dotkomonline/utils"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { ActionIcon, Box, Button, Flex, Stack } from "@mantine/core"
+import { ActionIcon, Box, Button, Flex, NumberInput } from "@mantine/core"
 import { IconX } from "@tabler/icons-react"
-import { type FC, useEffect, useMemo } from "react"
-import { useForm } from "react-hook-form"
+import { type FC, useEffect, useMemo, useState } from "react"
+import { Controller, useForm, useWatch } from "react-hook-form"
 import { z } from "zod"
 
 const yearEntries = [
@@ -18,6 +20,18 @@ const yearEntries = [
   { label: "5. klasse", key: 5 },
 ]
 
+export function getAvailablePoolYears(disabledYears: number[]) {
+  return yearEntries.map((entry) => entry.key).filter((year) => !disabledYears.includes(year))
+}
+
+function getCapacityMax(hasMergeDelay: boolean) {
+  if (hasMergeDelay) {
+    return 0
+  }
+
+  return undefined
+}
+
 export interface PoolFormProps {
   onSubmit(values: PoolForm): void
   disabledYears: number[]
@@ -27,27 +41,114 @@ export interface PoolFormProps {
   minCapacity?: number
 }
 
-export const PoolFormSchema = z.object({
-  yearCriteria: z.array(z.number()).min(1, "Du må velge minst ett klassetrinn."),
-  capacity: z.number().min(0),
-  title: z.string().min(1),
-  mergeDelayHours: z.preprocess((val) => {
-    if (typeof val === "number") {
-      const num = Number(val)
-      if (num === 0) {
-        return null
+export const PoolFormSchema = z
+  .object({
+    yearCriteria: z.array(z.number()).min(1, "Du må velge minst ett klassetrinn."),
+    capacity: z.int().min(0),
+    title: z.string().min(1),
+    mergeDelayHours: z.preprocess((val) => {
+      if (typeof val === "number") {
+        const num = Number(val)
+
+        if (num === 0) {
+          return null
+        }
+
+        return num
       }
-      return num
+
+      return null
+    }, z
+      .int()
+      .min(0, `Utsettelse må være mellom 0 og ${MAX_MERGE_DELAY_HOURS} timer.`)
+      .max(MAX_MERGE_DELAY_HOURS, `Utsettelse må være mellom 0 og ${MAX_MERGE_DELAY_HOURS} timer.`)
+      .nullable()),
+  })
+  .superRefine((values, context) => {
+    if (values.mergeDelayHours === null || values.mergeDelayHours === 0) {
+      return
     }
-    return null
-  }, z
-    .int()
-    .min(0, "Utsettelse må være mellom 0 og 96 timer (4 dager).")
-    .max(96, "Utsettelse må være mellom 0 og 96 timer (4 dager).")
-    .nullable()),
-})
+
+    if (values.capacity === 0) {
+      return
+    }
+
+    context.addIssue({
+      code: "custom",
+      message: "Kapasitet må være ubegrenset når gruppen har utsettelse",
+      path: ["capacity"],
+    })
+  })
 export type PoolForm = z.infer<typeof PoolFormSchema>
 type PoolFormInput = z.input<typeof PoolFormSchema>
+
+function getCapacityDisplayValue(capacity: number, isFocused: boolean): string | number {
+  if (capacity === 0 && !isFocused) {
+    return ""
+  }
+
+  return capacity
+}
+
+function CapacityInput({
+  name,
+  state,
+  control,
+  setValue,
+  disabled,
+  min,
+}: InputFieldContext<PoolFormInput, PoolForm> & { min: number }) {
+  const [isFocused, setIsFocused] = useState(false)
+  const mergeDelayHours = useWatch({ control, name: "mergeDelayHours" })
+  const hasMergeDelay = typeof mergeDelayHours === "number" && mergeDelayHours > 0
+
+  useEffect(() => {
+    if (!hasMergeDelay) {
+      return
+    }
+
+    setValue("capacity", 0, { shouldValidate: true, shouldDirty: true })
+  }, [hasMergeDelay, setValue])
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => {
+        const capacity = typeof field.value === "number" ? field.value : 0
+
+        return (
+          <NumberInput
+            label="Kapasitet"
+            description={
+              <>
+                Antall som kan melde seg på før de automatisk settes i kø. Du kan ha flere påmeldte enn kapasitet dersom
+                du admin-påmelder dem.
+                <br />
+                Kapasitet må være ubegrenset når gruppen har utsettelse.
+              </>
+            }
+            min={min}
+            max={getCapacityMax(hasMergeDelay)}
+            withAsterisk
+            value={getCapacityDisplayValue(capacity, isFocused)}
+            placeholder="Ubegrenset"
+            onChange={(value) => field.onChange({ target: { value: value === "" ? 0 : value } })}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            disabled={disabled || hasMergeDelay}
+            error={getErrorMessage(state, name)}
+            styles={{
+              input: {
+                "--input-placeholder-color": "var(--mantine-color-text)",
+              },
+            }}
+          />
+        )
+      }}
+    />
+  )
+}
 
 export const usePoolForm = (props: PoolFormProps) => {
   const form = useForm<PoolFormInput, unknown, PoolForm>({
@@ -100,36 +201,29 @@ export const usePoolForm = (props: PoolFormProps) => {
         },
         {
           name: "capacity",
-          component: createNumberInput<PoolFormInput, PoolForm>({
-            label: "Kapasitet",
-            description: (
-              <Stack gap="xs">
-                <span>
-                  Antall som kan melde seg på før de automatisk settes i kø. Du kan ha flere påmeldte enn kapasitet.
-                </span>
-                <span>Sett til 0 for ubegrenset kapasitet.</span>
-              </Stack>
-            ),
-            min: props.minCapacity ?? 0,
-            required: true,
-          }),
+          component: (fieldContext: InputFieldContext<PoolFormInput, PoolForm>) => (
+            <CapacityInput {...fieldContext} min={props.minCapacity ?? 0} />
+          ),
         },
         {
           name: "mergeDelayHours",
           component: createNumberInput<PoolFormInput, PoolForm>({
             label: "Utsettelse i timer",
             description: (
-              <Stack gap="xs">
-                <span>Hvor mange timer brukere i gruppen skal stå i kø før de blir påmeldt.</span>
-                <span>
-                  Påmeldingsgruppen vil slå seg sammen med andre påmeldingsgrupper etter utsettelsestiden har gått ut.
-                  Dette gir andre muligheten til å melde seg på før den som meldte seg på får en plass.
-                </span>
-                <span>Kapasiteten bør være 0 dersom gruppen har utsettelse.</span>
-              </Stack>
+              <>
+                Hvor mange timer brukere i gruppen skal stå i kø før de blir påmeldt.
+                <br />
+                Påmeldingsgruppen vil slå seg sammen med andre påmeldingsgrupper etter utsettelsestiden har gått ut.
+                Dette gir andre muligheten til å melde seg på før den som meldte seg på får en plass.
+                <br />
+                Kapasiteten må være ubegrenset dersom gruppen har utsettelse.
+              </>
             ),
             placeholder: "Ingen utsettelse",
             min: 0,
+            max: MAX_MERGE_DELAY_HOURS,
+            suffix: " timer",
+            startValue: 1,
           }),
         },
       ] as const,

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/pools-box.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/pools-box.tsx
@@ -32,7 +32,7 @@ const AttendancePoolCard: FC<NormalPoolBoxProps> = ({ pool, attendance, deleteGr
           <Text>
             {reservedAttendeeCount} {pool.capacity > 0 ? `/ ${pool.capacity} påmeldte` : "påmeldte (ledige plasser)"}
           </Text>
-          {unreservedAttendeeCount > 0 && <Text>{unreservedAttendeeCount} på venteliste</Text>}
+          {unreservedAttendeeCount > 0 && <Text>{unreservedAttendeeCount} i kø</Text>}
           <Space h="xs" />
           <Text size="sm">Årstrinn: {formatPoolYearCriterias(pool.yearCriteria)}</Text>
           <Text size="sm">

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/qr-code-scanned-modal.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/qr-code-scanned-modal.tsx
@@ -5,9 +5,8 @@ import {
   getAttendeeQueuePosition,
   getUnreservedAttendeeCount,
 } from "@dotkomonline/rpc/attendance"
-import { type User, findActiveMembership, getMembershipTypeName, getGenderName } from "@dotkomonline/rpc/user"
-import { getCurrentUTC, getStudyGrade } from "@dotkomonline/utils"
-import { Button, Flex, Group, Image, Stack, Text, Title, useComputedColorScheme } from "@mantine/core"
+import { getCurrentUTC } from "@dotkomonline/utils"
+import { Button, Group, Stack, Text, Title } from "@mantine/core"
 import { useMediaQuery } from "@mantine/hooks"
 import { type ContextModalProps, modals } from "@mantine/modals"
 import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react"
@@ -15,6 +14,7 @@ import { formatDate, formatDistanceToNow } from "date-fns"
 import { nb } from "date-fns/locale"
 import type { FC } from "react"
 import { useUpdateEventAttendanceMutation } from "../mutations"
+import { UserBox } from "./user-box"
 
 interface ModalProps {
   attendance: Attendance
@@ -152,42 +152,6 @@ export const QRCodeScannedModal: FC<ContextModalProps<ModalProps>> = ({
           </Button>
         </Group>
       </Stack>
-    </Stack>
-  )
-}
-
-interface UserBoxProps {
-  user: User
-  isMobile: boolean
-}
-
-const UserBox = ({ user, isMobile }: UserBoxProps) => {
-  const isLightMode = useComputedColorScheme() === "light"
-
-  const membership = findActiveMembership(user)
-  const grade = membership?.semester != null ? getStudyGrade(membership.semester) : null
-  const membershipType = membership && getMembershipTypeName(membership.type)
-
-  return (
-    <Stack>
-      <Flex
-        direction={isMobile ? "column" : "row"}
-        gap="md"
-        p="sm"
-        bg={isLightMode ? "gray.1" : "dark.5"}
-        style={{ borderRadius: 16 }}
-        align="flex-start"
-        wrap="nowrap"
-      >
-        <Image src={user.imageUrl} alt={user.name ?? user.username} radius="md" w={100} h={100} />
-        <Stack gap={2}>
-          <Title order={4}>{user.name}</Title>
-          <Text size="sm">{membership ? `Medlemskap: ${membershipType}` : "Ingen aktivt medlemskap"}</Text>
-          <Text size="sm">{membership ? (grade ? `Klasse: ${grade}` : "Ingen klassetrinn") : "-"}</Text>
-          <Text size="sm">Kjønn: {getGenderName(user.gender)}</Text>
-          <Text size="sm">Kostholdsrestriksjoner: {user.dietaryRestrictions || "Ingen"}</Text>
-        </Stack>
-      </Flex>
     </Stack>
   )
 }

--- a/apps/dashboard/src/app/(internal)/arrangementer/components/user-box.tsx
+++ b/apps/dashboard/src/app/(internal)/arrangementer/components/user-box.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { type User, findActiveMembership, getMembershipTypeName, getGenderName } from "@dotkomonline/rpc/user"
+import { getStudyGrade } from "@dotkomonline/utils"
+import { Avatar, Flex, Stack, Text, Title } from "@mantine/core"
+import { IconUser } from "@tabler/icons-react"
+
+interface UserBoxProps {
+  user: User
+  isMobile: boolean
+}
+
+export function UserBox({ user, isMobile }: UserBoxProps) {
+  return (
+    <Stack>
+      <Flex
+        direction={isMobile ? "column" : "row"}
+        gap="md"
+        p="xs"
+        bg="var(--mantine-color-gray-light)"
+        style={{ borderRadius: "var(--mantine-radius-md)" }}
+        align="flex-start"
+        wrap="nowrap"
+      >
+        <Avatar src={user.imageUrl ?? undefined} alt={user.name ?? user.username} radius="sm" size={100}>
+          <IconUser size={48} />
+        </Avatar>
+        <Stack gap={2}>
+          <Title order={4}>{user.name}</Title>
+          <Text size="sm">{getMembershipDisplayText(user)}</Text>
+          <Text size="sm">Kjønn: {getGenderName(user.gender)}</Text>
+          <Text size="sm">Kostholdsrestriksjoner: {user.dietaryRestrictions || "Ingen"}</Text>
+        </Stack>
+      </Flex>
+    </Stack>
+  )
+}
+
+function getMembershipDisplayText(user: User): string {
+  const membership = findActiveMembership(user)
+
+  if (membership === null) {
+    return "Ingen klasseinformasjon"
+  }
+
+  const membershipType = getMembershipTypeName(membership.type)
+  const grade = membership.semester != null ? getStudyGrade(membership.semester) : null
+
+  if (grade === null) {
+    return membershipType
+  }
+
+  return `${grade}. klasse (${membershipType})`
+}

--- a/apps/dashboard/src/app/(internal)/arrangementer/queries.ts
+++ b/apps/dashboard/src/app/(internal)/arrangementer/queries.ts
@@ -52,6 +52,12 @@ export const useEventWithAttendancesGetQuery = (id: EventId, enabled?: boolean) 
   return useQuery(trpc.event.get.queryOptions(id, { enabled }))
 }
 
+export const useFindParentEventQuery = (eventId: EventId) => {
+  const trpc = useTRPC()
+
+  return useQuery(trpc.event.findParentEvent.queryOptions({ eventId }))
+}
+
 export const useEventAllByAttendingUserInfiniteQuery = (id: UserId, page?: Pageable) => {
   const trpc = useTRPC()
   const { data, ...query } = useInfiniteQuery({

--- a/apps/dashboard/src/components/forms/Form.tsx
+++ b/apps/dashboard/src/components/forms/Form.tsx
@@ -105,7 +105,7 @@ export function useFormBuilder<T extends z.ZodRawShape>({
             })(e)
           }}
         >
-          <Flex direction="column" gap="md">
+          <Flex direction="column" gap="lg">
             {configuration.components}
             <div>
               <Button type="submit" disabled={configuration.disabled}>

--- a/apps/dashboard/src/components/forms/SegmentedControlInput.tsx
+++ b/apps/dashboard/src/components/forms/SegmentedControlInput.tsx
@@ -1,4 +1,4 @@
-import { Input, SegmentedControl, type SegmentedControlProps } from "@mantine/core"
+import { Input, SegmentedControl, Stack, type SegmentedControlProps } from "@mantine/core"
 import type { ReactNode } from "react"
 import { Controller, type FieldValues } from "react-hook-form"
 import { getErrorMessage, type InputProducerResult } from "./types"
@@ -30,20 +30,21 @@ export function createSegmentedControlInput<
         required={required}
         error={getErrorMessage(state, name)}
       >
-        <Controller
-          control={control}
-          name={name}
-          render={({ field }) => (
-            <SegmentedControl
-              {...props}
-              fullWidth={fullWidth}
-              mt={label || description ? "xs" : undefined}
-              value={field.value}
-              onChange={field.onChange}
-              disabled={disabled ?? props.disabled}
-            />
-          )}
-        />
+        <Stack gap={0} mt={label || description ? "xs" : undefined} w={fullWidth ? "100%" : "fit-content"}>
+          <Controller
+            control={control}
+            name={name}
+            render={({ field }) => (
+              <SegmentedControl
+                {...props}
+                fullWidth={fullWidth}
+                value={field.value}
+                onChange={field.onChange}
+                disabled={disabled ?? props.disabled}
+              />
+            )}
+          />
+        </Stack>
       </Input.Wrapper>
     )
   }

--- a/apps/rpc/src/modules/event/attendance-router.ts
+++ b/apps/rpc/src/modules/event/attendance-router.ts
@@ -115,6 +115,13 @@ const deleteAttendanceProcedure = procedure
     return ctx.attendanceService.deleteAttendance(ctx.handle, input.id)
   })
 
+const ADMIN_REGISTER_DEFAULT_OPTIONS = {
+  ignoreRegisteredToParent: true,
+  immediateReservation: false,
+  immediatePayment: false,
+  overrideTurnstileCheck: true,
+} as const
+
 export type AdminRegisterForEventInput = inferProcedureInput<typeof adminRegisterForEventProcedure>
 export type AdminRegisterForEventOutput = inferProcedureOutput<typeof adminRegisterForEventProcedure>
 const adminRegisterForEventProcedure = procedure
@@ -123,6 +130,14 @@ const adminRegisterForEventProcedure = procedure
       attendanceId: AttendanceSchema.shape.id,
       attendancePoolId: AttendancePoolSchema.shape.id,
       userId: UserSchema.shape.id,
+      options: z
+        .object({
+          ignoreRegisteredToParent: z.boolean().default(ADMIN_REGISTER_DEFAULT_OPTIONS.ignoreRegisteredToParent),
+          immediateReservation: z.boolean().default(ADMIN_REGISTER_DEFAULT_OPTIONS.immediateReservation),
+          immediatePayment: z.boolean().default(ADMIN_REGISTER_DEFAULT_OPTIONS.immediatePayment),
+          overrideTurnstileCheck: z.boolean().default(ADMIN_REGISTER_DEFAULT_OPTIONS.overrideTurnstileCheck),
+        })
+        .default(ADMIN_REGISTER_DEFAULT_OPTIONS),
     })
   )
   .use(withAuthentication())
@@ -137,11 +152,11 @@ const adminRegisterForEventProcedure = procedure
       input.userId,
       {
         ignoreRegistrationWindow: true,
-        immediateReservation: true,
-        immediatePayment: false,
+        ignoreRegisteredToParent: input.options.ignoreRegisteredToParent,
+        immediateReservation: input.options.immediateReservation,
+        immediatePayment: input.options.immediatePayment,
         overriddenAttendancePoolId: input.attendancePoolId,
-        ignoreRegisteredToParent: true,
-        overrideTurnstileCheck: true,
+        overrideTurnstileCheck: input.options.overrideTurnstileCheck,
       }
     )
     if (!result.success) {

--- a/apps/rpc/src/modules/event/attendance-service.ts
+++ b/apps/rpc/src/modules/event/attendance-service.ts
@@ -27,6 +27,7 @@ import {
   getReservedAttendeeCount,
   isAttendable,
   isAttendeeChargedAndUnrefunded,
+  MAX_MERGE_DELAY_HOURS,
 } from "./attendance"
 import { type Event, findFirstHostingGroupEmail } from "./event"
 import { DEFAULT_MARK_DURATION, type Punishment } from "../mark/mark"
@@ -1774,15 +1775,21 @@ function validateAttendanceWrite(data: AttendanceWrite) {
 }
 
 function validateAttendancePoolWrite(data: AttendancePoolWrite) {
-  if (data.mergeDelayHours !== null && (data.mergeDelayHours < 0 || data.mergeDelayHours > 48)) {
-    throw new InvalidArgumentError("Merge delay for pool must be between 0 and 48 hours")
-  }
-
   if (data.capacity < 0) {
     throw new InvalidArgumentError("Capacity for pool must be zero or positive")
   }
 
-  if (data.yearCriteria.some((v) => v < 1 || v > 5)) {
+  if (data.mergeDelayHours !== null && (data.mergeDelayHours < 0 || data.mergeDelayHours > MAX_MERGE_DELAY_HOURS)) {
+    throw new InvalidArgumentError(`Merge delay for pool must be between 0 and ${MAX_MERGE_DELAY_HOURS} hours`)
+  }
+
+  const hasMergeDelay = data.mergeDelayHours !== null && data.mergeDelayHours > 0
+
+  if (hasMergeDelay && data.capacity !== 0) {
+    throw new InvalidArgumentError("Capacity for pool must be unlimited (0) when the pool has a merge delay")
+  }
+
+  if (data.yearCriteria.some((year) => year < 1 || year > 5)) {
     throw new InvalidArgumentError("Year criteria must be between 1 and 5")
   }
 }

--- a/apps/rpc/src/modules/event/attendance.e2e-spec.ts
+++ b/apps/rpc/src/modules/event/attendance.e2e-spec.ts
@@ -153,6 +153,57 @@ describe("attendance integration tests", async () => {
     ).rejects.toThrow(InvalidArgumentError)
   })
 
+  it("should require unlimited capacity when pool has a merge delay", async () => {
+    const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+
+    await expect(
+      core.attendanceService.createAttendancePool(
+        dbClient,
+        attendance.id,
+        getMockAttendancePool({
+          mergeDelayHours: 24,
+          capacity: 10,
+        })
+      )
+    ).rejects.toThrow(InvalidArgumentError)
+
+    await expect(
+      core.attendanceService.createAttendancePool(
+        dbClient,
+        attendance.id,
+        getMockAttendancePool({
+          mergeDelayHours: 24,
+          capacity: 0,
+          yearCriteria: [1],
+        })
+      )
+    ).resolves.toBeDefined()
+  })
+
+  it("should require unlimited capacity when updating a pool with a merge delay", async () => {
+    const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
+    const pool = await core.attendanceService.createAttendancePool(
+      dbClient,
+      attendance.id,
+      getMockAttendancePool({
+        capacity: 10,
+        yearCriteria: [1],
+      })
+    )
+
+    await expect(
+      core.attendanceService.updateAttendancePool(
+        dbClient,
+        pool.id,
+        getMockAttendancePool({
+          mergeDelayHours: 24,
+          capacity: 10,
+          yearCriteria: [1],
+        })
+      )
+    ).rejects.toThrow(InvalidArgumentError)
+  })
+
   it("should allow temporary overlap when updating", async () => {
     const attendance = await core.attendanceService.createAttendance(dbClient, getMockAttendance())
     const pool = await core.attendanceService.createAttendancePool(
@@ -433,6 +484,7 @@ describe("attendance integration tests", async () => {
       attendance.id,
       getMockAttendancePool({
         mergeDelayHours: 24,
+        capacity: 0,
         yearCriteria: [1],
       })
     )
@@ -582,6 +634,7 @@ describe("attendance integration tests", async () => {
       attendance.id,
       getMockAttendancePool({
         mergeDelayHours: 24,
+        capacity: 0,
         yearCriteria: [5],
       })
     )

--- a/apps/rpc/src/modules/event/attendance.ts
+++ b/apps/rpc/src/modules/event/attendance.ts
@@ -100,6 +100,9 @@ export const AttendeePaymentWriteSchema = AttendeeSchema.pick({
   paymentCheckoutUrl: true,
 })
 
+// The 96-hour limit is arbitrary
+export const MAX_MERGE_DELAY_HOURS = 96
+
 const AttendancePoolBaseSchema = z.object({
   id: z.string(),
   title: z.string(),


### PR DESCRIPTION
This probably should have been multiple PRs but whatever

This PR:

- Makes merge pool delay require capacity of zero.
- Makes us have one source of truth regarding max merge pool delay, and fixes a mismatch between UI and service
- Defaults new pools to all remaining year criterias
- Adds options to admin registration

![image.png](https://app.graphite.com/user-attachments/assets/050cfe7e-fac0-4623-a918-c7744d62e9a3.png)