### PR TITLE
Update event page navigation

### DIFF
--- a/apps/web/src/app/arrangementer/EventListPage.tsx
+++ b/apps/web/src/app/arrangementer/EventListPage.tsx
@@ -21,8 +21,8 @@ import { getCurrentUTC } from "@dotkomonline/utils"
 import {
   IconCalendarMonth,
   IconFilter2,
-  IconLayout2,
   IconLayoutColumns,
+  IconLayoutGrid,
   IconLayoutList,
   IconSearch,
   IconX,
@@ -242,28 +242,43 @@ export const EventListPage = ({ initialListViewMode }: Props) => {
           >
             <ToggleGroupItem
               value="cards"
-              className="flex flex-row items-center gap-2 h-full border-field-border max-[390px]:justify-center"
+              className={cn(
+                "flex flex-row items-center gap-2 h-full border-field-border",
+                isCalendar
+                  ? "max-[450px]:justify-center max-[450px]:w-12"
+                  : "max-[390px]:justify-center max-[390px]:w-12"
+              )}
             >
-              <IconLayout2 className="size-4.5" />
-              <Text element="span" className="max-[390px]:hidden">
+              <IconLayoutGrid className="size-4.5" />
+              <Text element="span" className={cn(isCalendar ? "max-[450px]:hidden" : "max-[390px]:hidden")}>
                 Kort
               </Text>
             </ToggleGroupItem>
             <ToggleGroupItem
               value="list"
-              className="flex flex-row items-center gap-2 h-full border-field-border max-[390px]:justify-center"
+              className={cn(
+                "flex flex-row items-center gap-2 h-full border-field-border",
+                isCalendar
+                  ? "max-[450px]:justify-center max-[450px]:w-12"
+                  : "max-[390px]:justify-center max-[390px]:w-12"
+              )}
             >
               <IconLayoutList className="size-4.5" />
-              <Text element="span" className="max-[390px]:hidden">
+              <Text element="span" className={cn(isCalendar ? "max-[450px]:hidden" : "max-[390px]:hidden")}>
                 Liste
               </Text>
             </ToggleGroupItem>
             <ToggleGroupItem
               value="calendar"
-              className="flex flex-row items-center gap-2 h-full border-field-border max-[390px]:justify-center"
+              className={cn(
+                "flex flex-row items-center gap-2 h-full border-field-border",
+                isCalendar
+                  ? "max-[450px]:justify-center max-[450px]:w-12"
+                  : "max-[390px]:justify-center max-[390px]:w-12"
+              )}
             >
               <IconCalendarMonth className="size-4.5" />
-              <Text element="span" className="max-[390px]:hidden">
+              <Text element="span" className={cn(isCalendar ? "max-[450px]:hidden" : "max-[390px]:hidden")}>
                 Kalender
               </Text>
             </ToggleGroupItem>


### PR DESCRIPTION
This PR makes the icon buttons wider for small screens making them easier to press. It collapses into "icon-only" sooner on calendar view, to avoid wrapping. Also replaced the card layout icon with a more symmetrical one.

Before:

<img width="321" height="286" alt="image" src="https://github.com/user-attachments/assets/0e6e4cf2-6f7a-4fb3-82be-984692045d4c" />

<img width="305" height="286" alt="image" src="https://github.com/user-attachments/assets/aab21c68-3a58-4c48-90c7-b4558ad93c4e" />


After:

<img width="321" height="286" alt="image" src="https://github.com/user-attachments/assets/62d0e1a8-f7b4-43c4-bb29-cd27ceb3eeab" />

<img width="305" height="286" alt="image" src="https://github.com/user-attachments/assets/00775737-79de-466f-aaf1-67fd2ae8cb99" />


