### PR TITLE
Replace `TimeBox` link with calendar subscription link

### DIFF
--- a/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
+++ b/apps/web/src/app/arrangementer/[slug]/[eventId]/page.tsx
@@ -17,7 +17,6 @@ import {
 } from "@dotkomonline/utils"
 import { isPast } from "date-fns"
 import type { Metadata } from "next"
-import Link from "next/link"
 import { RedirectType, notFound, permanentRedirect } from "next/navigation"
 import { AttendanceCard } from "../../components/AttendanceCard/AttendanceCard"
 import type { AttendanceRouter } from "@dotkomonline/rpc"
@@ -26,6 +25,7 @@ import { EventHeader } from "../../components/EventHeader"
 import { EventList } from "../../components/EventList"
 import { LocationBox } from "../../components/TimeLocationBox/LocationBox"
 import { TimeBox } from "../../components/TimeLocationBox/TimeBox"
+import Link from "next/link"
 
 const createOrganizerPageUrl = (item: Group | Company) => {
   if ("type" in item) {
@@ -172,14 +172,22 @@ const EventContent = ({
           </div>
         )}
 
-        <section>
+        <section className="flex flex-col gap-0.5">
           <Title element="h2" className="sr-only">
             Oppmøte
           </Title>
+
           <div className="grid min-w-0 grid-cols-1 gap-x-8 gap-y-3 min-[1150px]:grid-cols-2">
             <TimeBox event={event} />
             <LocationBox event={event} />
           </div>
+
+          <Link
+            href="/innstillinger/bruker#kalender"
+            className="w-fit text-sm sm:text-xs font-normal text-muted-foreground underline-offset-4 hover:underline"
+          >
+            Vil du ha arrangementer i kalenderen?
+          </Link>
         </section>
 
         {event.hostingGroups.length > 0 || event.companies.length > 0 ? (

--- a/apps/web/src/app/arrangementer/components/CalendarSubscriptionDialog.tsx
+++ b/apps/web/src/app/arrangementer/components/CalendarSubscriptionDialog.tsx
@@ -30,7 +30,7 @@ import {
   IconX,
 } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 import {
   createAllEventsCalendarUrl,
   createGoogleCalendarSubscribeUrl,
@@ -42,7 +42,13 @@ import Image from "next/image"
 
 type CalendarFeed = "personal" | "all"
 
-export function CalendarSubscriptionDialog({ triggerVariant = "ghost" }: { triggerVariant?: ButtonProps["variant"] }) {
+export function CalendarSubscriptionDialog({
+  triggerVariant = "ghost",
+  trigger,
+}: {
+  triggerVariant?: ButtonProps["variant"]
+  trigger?: ReactNode
+}) {
   const [open, setOpen] = useState(false)
   const { dbUser } = useAuthenticatedUser()
   const isLoggedIn = Boolean(dbUser)
@@ -67,6 +73,25 @@ export function CalendarSubscriptionDialog({ triggerVariant = "ghost" }: { trigg
       : "Logg inn for å abonnere på arrangementene du er påmeldt."
     : "Offentlige arrangementer fra Online."
 
+  let dialogTrigger = trigger
+  if (!dialogTrigger) {
+    dialogTrigger = (
+      <Button
+        variant={triggerVariant}
+        className="h-10 rounded-lg shrink-0"
+        icon={<IconCalendarPlus className="size-4" />}
+        onClick={() => setOpen(true)}
+      >
+        <Text element="span" className="max-sm:hidden">
+          Abonner på kalender
+        </Text>
+        <Text element="span" className="sm:hidden">
+          Abonner
+        </Text>
+      </Button>
+    )
+  }
+
   return (
     <AlertDialog
       open={open}
@@ -78,21 +103,7 @@ export function CalendarSubscriptionDialog({ triggerVariant = "ghost" }: { trigg
         }
       }}
     >
-      <AlertDialogTrigger asChild>
-        <Button
-          variant={triggerVariant}
-          className="h-10 rounded-lg shrink-0"
-          icon={<IconCalendarPlus className="size-4" />}
-          onClick={() => setOpen(true)}
-        >
-          <Text element="span" className="max-sm:hidden">
-            Abonner på kalender
-          </Text>
-          <Text element="span" className="sm:hidden">
-            Abonner
-          </Text>
-        </Button>
-      </AlertDialogTrigger>
+      <AlertDialogTrigger asChild>{dialogTrigger}</AlertDialogTrigger>
       <AlertDialogContent
         size="lg"
         className="max-h-[90dvh] min-w-0 overflow-x-hidden overflow-y-auto"

--- a/apps/web/src/app/arrangementer/components/TimeLocationBox/TimeBox.tsx
+++ b/apps/web/src/app/arrangementer/components/TimeLocationBox/TimeBox.tsx
@@ -1,30 +1,18 @@
-"use client"
-
 import type { Event } from "@dotkomonline/rpc/event"
-import { cn, Text } from "@dotkomonline/ui"
-import { IconArrowRight, IconArrowUpRight } from "@tabler/icons-react"
+import { Text } from "@dotkomonline/ui"
+import { IconArrowRight } from "@tabler/icons-react"
 import { format as formatDate, isSameDay, isSameYear, isThisYear } from "date-fns"
 import { nb } from "date-fns/locale"
 import type { FC } from "react"
-import { createGoogleCalendarLink } from "./utils"
 import { CalendarBox } from "@/components/atoms/CalendarBox"
 import { capitalizeFirstLetter } from "@dotkomonline/utils"
-import Link from "next/link"
 
 interface TimeBoxProps {
   event: Event
 }
 
 export const TimeBox: FC<TimeBoxProps> = ({ event }) => {
-  const { start, end, locationAddress, description, title: eventSummary } = event
-
-  const gcalLink = createGoogleCalendarLink({
-    title: eventSummary,
-    location: locationAddress ?? "",
-    description: description ?? "",
-    start,
-    end,
-  })
+  const { start, end } = event
 
   const sameDay = isSameDay(start, end)
   const showYear = !isSameYear(start, end) || !isThisYear(start) || !isThisYear(end)
@@ -34,21 +22,12 @@ export const TimeBox: FC<TimeBoxProps> = ({ event }) => {
     capitalizeFirstLetter(formatDate(date, showYear ? "dd.MM.yyyy" : "EEEE dd. MMMM", { locale: nb }))
 
   return (
-    <Link
-      className={cn(
-        "group/time-box flex w-full min-w-0 flex-row items-center gap-3 p-2 -mx-2 rounded-xl sm:gap-4",
-        "transition-colors hover:bg-gray-100 dark:hover:bg-stone-800"
-      )}
-      href={gcalLink}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <section className="flex w-full min-w-0 flex-row items-center gap-3 p-2 -mx-2 sm:gap-4">
       <CalendarBox
         start={start}
         end={end}
         className="shrink-0 bg-background dark:border-stone-700"
         containerClassName="shrink-0"
-        titleClassName="transition-colors"
       />
 
       {sameDay ? (
@@ -75,11 +54,6 @@ export const TimeBox: FC<TimeBoxProps> = ({ event }) => {
           </div>
         </div>
       )}
-
-      <IconArrowUpRight
-        aria-hidden
-        className="size-5 transition-[transform,color] group-hover/time-box:scale-120 shrink-0 text-muted-foreground group-hover/time-box:text-foreground"
-      />
-    </Link>
+    </section>
   )
 }


### PR DESCRIPTION
Replaces the link from `TimeBox` with a helper text under it that opens the calendar subscription dialog

![image.png](https://app.graphite.com/user-attachments/assets/bd6e61e0-3099-45d3-999f-6af1a7ab4f73.png)

![image.png](https://app.graphite.com/user-attachments/assets/93cf37f5-bee1-495e-b50a-def19250faf2.png)

