### PR TITLE
Hide blank lines in GroupListItem description

### DIFF
--- a/apps/web/src/components/molecules/GroupListItem/index.tsx
+++ b/apps/web/src/components/molecules/GroupListItem/index.tsx
@@ -46,7 +46,11 @@ export const GroupListItem: FC<GroupListItemProps> = ({ group }: GroupListItemPr
         <Title element="h3" className="text-xl">
           {displayName}
         </Title>
-        <RichText content={group.description} hideToggleButton className="sm:line-clamp-4 line-clamp-2" />
+        <RichText
+          content={group.description}
+          hideToggleButton
+          className="[&_p:empty]:hidden [&_p]:my-0 sm:line-clamp-4 line-clamp-2"
+        />
       </div>
     </Link>
   )


### PR DESCRIPTION
Faxe-ordenen thought they could get away with it.

Before:

![image.png](https://app.graphite.com/user-attachments/assets/fbc442fc-cf1f-4852-be57-0ad7b94a8412.png)

After:

![image.png](https://app.graphite.com/user-attachments/assets/b8dbf10a-1bbf-4895-b119-8fbad4246699.png)

